### PR TITLE
Remove PresentationField from docs

### DIFF
--- a/content/teknologi/altinnstudio/altinn-api/clients/_index.md
+++ b/content/teknologi/altinnstudio/altinn-api/clients/_index.md
@@ -65,10 +65,6 @@ The next code block show the content of a newly created JSON file (**01036800298
   "org": "tdd",
   "createdDateTime": "2019-09-03T11:52:49.9684927Z",
   "lastChangedDateTime": "2019-09-03T11:52:49.9684927Z",
-  "presentationField": {
-    "nb": "Testapplikasjon",
-    "en": "Test Application"
-  },
   "process": {
     "currentTask": "FormFilling_1",
     "isComplete": false

--- a/static/swagger/altinn-platform-storage-v1.json
+++ b/static/swagger/altinn-platform-storage-v1.json
@@ -2172,31 +2172,6 @@
         },
         "additionalProperties": false
       },
-      "PresentationField": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "nullable": true
-          },
-          "textResource": {
-            "type": "string",
-            "nullable": true
-          },
-          "value": {
-            "type": "string",
-            "nullable": true
-          },
-          "taskIds": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
       "Application": {
         "type": "object",
         "properties": {
@@ -2242,13 +2217,6 @@
           },
           "partyTypesAllowed": {
             "$ref": "#/components/schemas/PartyTypesAllowed"
-          },
-          "presentationFields": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PresentationField"
-            },
-            "nullable": true
           },
           "created": {
             "type": "string",


### PR DESCRIPTION
A small fix removing mention about Application.PresentationField and Instance.PresentationField as they have been removed.
Related to issue 4135 for altinn-studio repo.