### PR TITLE
Enable attribute lists in Hugo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,6 +29,10 @@ disableKinds = ["RSS"] # page home section taxonomy taxonomyTerm RSS sitemap rob
 #   languageName = "Nynorsk"
 #   weight = 3
 
+[markup.goldmark.parser.attribute]
+block = true
+title = true
+
 [markup.goldmark.renderer]
 unsafe = true
 


### PR DESCRIPTION
To be able to handle different presentations of list, tables, etc. in markdown using CSS, I've enabled [attribute lists](https://gohugo.io/getting-started/configuration-markup/#goldmark) in Goldmark, the markdown parser used by Hugo.

![image](https://user-images.githubusercontent.com/6088624/134294817-d860198c-4b62-43f4-ad57-632e24edc207.png)

## Example

This markdown list...
```markdown
- list item 1
- list item 2
{.connected-bullets}
```

...will be renedered as this html
```html
<ul class="connected-bullets">
  <li>list item 1</li>
  <li>list item 2</li>
</ul>
