### PR TITLE
Added better defaults for markdown in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
 {
     "[markdown]": {
         "editor.wordWrap": "off",
-	"files.trimTrailingWhitespace": false
+        "editor.renderWhitespace": "trailing",
+        "editor.rulers": [ 120 ],
+	    "files.trimTrailingWhitespace": false
     }
 }


### PR DESCRIPTION
Added the following default settings for editing markdown in vscode.

- `"editor.wordWrap": "off"` - **Don't wrap lines of text automatically** since that hides long lines. Long lines are hard to read, causes horizontal scrolling and makes diffing changes harder in git, and should thus be avoided. Markdown should be readable as markdown.
- `"editor.renderWhitespace": "trailing"` - In markdown, two trailing spaces at the end of a line will render as newline when converted to HTML. **Now trailing spaces are visible in vscode.**
- `"files.trimTrailingWhitespace": false` - **Avoid automatically trimming trailing spaces** when saving, ref. the issue above.
- `"editor.rulers": [ 120 ]` - A ruler to help remembering adding too long lines, 120 seems like an ok value for this.

![image](https://user-images.githubusercontent.com/6088624/134876965-2f383b43-dfdb-4a39-847e-c113c6e059d4.png)
