### PR TITLE
Newer versions notice in migration guide

### DIFF
--- a/content/community/changelog/deployment/migration/_index.en.md
+++ b/content/community/changelog/deployment/migration/_index.en.md
@@ -59,8 +59,13 @@ dependencies:
   version: 1.1.0
 ```
 
-You are using the latest deployment strategy
+You are using the latest deployment strategy.
 
+How to configure your deployment is documented [here](/app/development/configuration/deployment)
+
+{{%notice info%}}
+Newer version are available. If the new version is a major version please note that there could be breaking changes.
+{{%/notice%}}
 ## Migrating to new deployment strategy
 
 The migration is fairly simple and involves three changes in your deployment folder:

--- a/content/community/changelog/deployment/migration/_index.nb.md
+++ b/content/community/changelog/deployment/migration/_index.nb.md
@@ -60,6 +60,12 @@ dependencies:
 
 Benytter din applikasjon siste deployment strategi.
 
+Hvordan du konfigurerer din deployment er dokumentert [her](/nb/app/development/configuration/deployment)
+
+{{%notice info%}}
+Nye  versjoner er tilgjengelige. Hvis det er ny major versjon må du være obs på breaking changes.
+{{%/notice%}}
+
 ## Migrere til ny deployment strategi
 
 Migreringen er rimelig enkel og involverer bare tre endringer i mappen `deployment`:


### PR DESCRIPTION
Make it clear that there are newer versions available in the migration guide