### PR TITLE
Improve image component docs

### DIFF
--- a/content/app/development/ux/images/_index.en.md
+++ b/content/app/development/ux/images/_index.en.md
@@ -66,24 +66,25 @@ The image can also have separate sources for different languages. The default so
 
 ## Hosting images from apps
 
-If the image should be loaded from the app, you need to set up static hosting of files in the application.
+If the image should be loaded from the app, you need to set up static hosting of files in the application (if you have an older app).
 This is configured in _App/Startup.cs_, in the _Configure_ method. This will host all files that is inside the `/app/wwwroot` folder. If this folder does not exist, it needs to be created.
 If you want to refer to the file `app/wwwroot/bilde_nb.png` it can be reached at the following relative url `/org/app-name/bilde_nb.png`
 
-Swap out _org/app-name_ with your organisation and app name. Example:
+_applicationId_ is a variable from a few lines above containing _org/app-name_ from `applicationmetadata.json`:
 
 ```C# {linenos=false,hl_lines=[5]}
 public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
   {
     // ...
     app.UseRouting();
-    app.UseStaticFiles("/org/app-name");
+    app.UseStaticFiles('/' + applicationId);
     app.UseAuthentication();
     // ...
   }
 ```
 
-In _FormLayout.json_ the reference to the image should be a relative url that starts with _/org/app-name_ similar to what was set up as the static hosting. Example:
+In _FormLayout.json_ the reference to the image should be a relative url that starts with _/org/app-name_ similar to what was set up as the static hosting.
+You can also use the custom prefix `wwwroot` (without a starting `/`), that will be replaced with _/org/app-name_ before the image is loaded.
 
 ```json
 {
@@ -97,7 +98,7 @@ In _FormLayout.json_ the reference to the image should be a relative url that st
         },
         "image": {
           "src": {
-            "nb": "/org/app-name/bilde_nb.png"
+            "nb": "wwwroot/bilde_nb.png"
           },
           "width": "100%",
           "align": "center"

--- a/content/app/development/ux/images/_index.en.md
+++ b/content/app/development/ux/images/_index.en.md
@@ -66,7 +66,7 @@ The image can also have separate sources for different languages. The default so
 
 ## Hosting images from apps
 
-If the image should be loaded from the app, you need to set up static hosting of files in the application (if you have an older app).
+If the image should be loaded from the app, you need to set up static hosting of files in the application. This is automatically set up for applications created after december 2021. For older applications, you should follow the steps below.
 This is configured in _App/Startup.cs_, in the _Configure_ method. This will host all files that is inside the `/app/wwwroot` folder. If this folder does not exist, it needs to be created.
 If you want to refer to the file `app/wwwroot/bilde_nb.png` it can be reached at the following relative url `/org/app-name/bilde_nb.png`
 

--- a/content/app/development/ux/images/_index.nb.md
+++ b/content/app/development/ux/images/_index.nb.md
@@ -66,24 +66,25 @@ Bildet kan også ha ulik kilde i forskjellige språk. Standardkilde er _nb_, og 
 
 ## Hosting av bilder fra app
 
-Dersom bildet skal lastes fra appen, må man sette opp statisk hosting av filer i applikasjonen.
+Dersom bildet skal lastes fra appen, må man sette opp statisk hosting av filer i applikasjonen (hvis du har en gammel app).
 Dette konfigureres i _App/Startup.cs_, i _Configure_ metoden. Dette vil så hoste alle filer som ligger i `/app/wwwroot` mappen. Om denne mappen ikke finnes må den opprettes.
 Ønsker du å referer til filen `app/wwwroot/bilde_nb.png` så vil denne kunne nås med følgende path: `/org/app-name/bilde_nb.png`
 
-Bytt ut _org/app-name_ med din organisasjon og app navn. Eksempel:
+_applicationId_ er en variabel deklarert noen linjer opp og inneholder _org/app-name_ fra `applicationmetadata.json`:
 
 ```C# {linenos=false,hl_lines=[5]}
 public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
   {
     // ...
     app.UseRouting();
-    app.UseStaticFiles("/org/app-name");
+    app.UseStaticFiles('/' + applicationId);
     app.UseAuthentication();
     // ...
   }
 ```
 
-I _FormLayout.json_ må referansen til bildet være en relativ url som starter med _/org/app-name_ som ble satt opp i static hosting:
+I _FormLayout.json_ må referansen til bildet være en relativ url som starter med _/org/app-name_ som ble satt opp i static hosting.
+Du kan også bruke snarveien `wwwroot` (uten `/` først), som blir erstattet med _/org/app-name_ før bildet lastes.
 
 ```json
 {
@@ -97,7 +98,7 @@ I _FormLayout.json_ må referansen til bildet være en relativ url som starter m
         },
         "image": {
           "src": {
-            "nb": "/org/app-name/bilde_nb.png"
+            "nb": "wwwroot/bilde_nb.png"
           },
           "width": "100%",
           "align": "center"

--- a/content/app/development/ux/images/_index.nb.md
+++ b/content/app/development/ux/images/_index.nb.md
@@ -66,7 +66,7 @@ Bildet kan også ha ulik kilde i forskjellige språk. Standardkilde er _nb_, og 
 
 ## Hosting av bilder fra app
 
-Dersom bildet skal lastes fra appen, må man sette opp statisk hosting av filer i applikasjonen (hvis du har en gammel app).
+Dersom bildet skal lastes fra appen, må man sette opp statisk hosting av filer i applikasjonen. Dette er automatisk satt opp for applikasjoner laget etter desember 2021. For eldre applikasjoner, følg beskrivelsen nedenfor.
 Dette konfigureres i _App/Startup.cs_, i _Configure_ metoden. Dette vil så hoste alle filer som ligger i `/app/wwwroot` mappen. Om denne mappen ikke finnes må den opprettes.
 Ønsker du å referer til filen `app/wwwroot/bilde_nb.png` så vil denne kunne nås med følgende path: `/org/app-name/bilde_nb.png`
 


### PR DESCRIPTION
Docs changes related to https://github.com/Altinn/altinn-studio/pull/7484

* Suggest using `wwwroot` in image url
* use `applicationId` instead of instructing users to manually replace
  text in the instructions
* Suggest that UseStaticFiles might be pressent in newer apps.