### PR TITLE
clearified docs on custom json schema message

### DIFF
--- a/content/app/development/logic/validation/_index.en.md
+++ b/content/app/development/logic/validation/_index.en.md
@@ -67,6 +67,26 @@ An example of how the extend the example previously presented with a custom erro
 
 The error text can be included directly. To enable language support, add a text key for a [text defined in the resource files](../../ux/texts).
 
+Notice that if you have a reference to a definition the error message must be added to the `property`-field and not the reference/definition.
+Example:
+```json {hl_lines=[5]}
+{
+  "properties": {
+    "person": {
+        "$ref" : "#/definitions/personDefinition",
+        "errorMessage": "myCustomError",
+    }
+  },
+  "definitions": {
+    "personDefinition" : {
+      "age": {
+        "type": "number"
+      },
+      ...
+  }
+}
+```
+
 {{% notice warning %}}
 Note that when the XSD is changed, the custom error messages will de removed from the JSON schema.
 In the future, there will be support for setting custom error messages in the data modelling tool in Altinn Studio. 

--- a/content/app/development/logic/validation/_index.nb.md
+++ b/content/app/development/logic/validation/_index.nb.md
@@ -51,7 +51,7 @@ Det er satt opp standard feilmeldinger for alle valideringene som gjøres på kl
 
 ### Egendefinerte feilmeldinger
 Det er mulig å definere egne feilmeldinger som skal vises når et felt får valideringsfeil. Dette gjøres ved å legge på en parameter `errorMessage` der 
-hvor feltet er definert i JSON schema. JSON schema filen ligger i mappen `App/models` og følger navne standard `*.schema.json`. 
+hvor feltet er definert i JSON schema. JSON schema filen ligger i mappen `App/models` og følger navnestandard `*.schema.json`. 
 
 F.eks., man kan utvide eksempelet over:
 
@@ -64,6 +64,26 @@ F.eks., man kan utvide eksempelet over:
 ```
 
 Man kan skrive ønsket tekst direkte inn her, eller bruke en tekstnøkkel for en [tekst definert i ressursfilene](../../ux/texts) for språkstøtte.
+
+Legg merke til at om man har en referanse til en definisjon så må feilmeldingen ligge på `property`-feltet, og ikke på referansen/definisjonen.
+Eksempel:
+```json {hl_lines=[5]}
+{
+  "properties": {
+    "person": {
+        "$ref" : "#/definitions/personDefinition",
+        "errorMessage": "myCustomError",
+    }
+  },
+  "definitions": {
+    "personDefinition" : {
+      "age": {
+        "type": "number"
+      },
+      ...
+  }
+}
+```
 
 {{% notice warning %}}
 Merk at ved XSD-endringer, så vil ev. egendefinerte feilmeldinger forsvinne da JSON schema filen genereres på nytt fra XSD. På sikt er det tenkt at 


### PR DESCRIPTION
added example to clarify that error message should be added to property and not definition