### PR TITLE
Fix secret link from settings

### DIFF
--- a/content/app/development/configuration/secrets/_index.en.md
+++ b/content/app/development/configuration/secrets/_index.en.md
@@ -13,9 +13,6 @@ Som applikasjonsutvikler administrerer man selv hemmelighetene som applikasjonen
 
 ## Konfigurer støtte for hemmeligheter i din app
 
-Hemmeligheter i app er støttet for nugetversjoner >= 1.2.2.
-[Se hvordan du oppdaterer nugetreferanser for applikasjonen din her](../update/#nuget-pakker).
-
 For å tilgjengeliggjøre hemmeligheter i applikasjonen må det gjøres oppdateringer i helm charten tilknyttet applikasjonen.
 
 I applikasjonsrepoet ditt finner du filen `values.yaml` i mappen _deployment_.

--- a/content/app/development/configuration/secrets/_index.nb.md
+++ b/content/app/development/configuration/secrets/_index.nb.md
@@ -13,9 +13,6 @@ Som applikasjonsutvikler administrerer man selv hemmelighetene som applikasjonen
 
 ## Konfigurer støtte for hemmeligheter i din app
 
-Hemmeligheter i app er støttet for nugetversjoner >= 1.2.2.
-[Se hvordan du oppdaterer nugetreferanser for applikasjonen din her](../update/#nuget-pakker).
-
 For å tilgjengeliggjøre hemmeligheter i applikasjonen må det gjøres oppdateringer i helm charten tilknyttet applikasjonen.
 
 I applikasjonsrepoet ditt finner du filen `values.yaml` i mappen _deployment_.

--- a/content/app/development/configuration/settings/_index.en.md
+++ b/content/app/development/configuration/settings/_index.en.md
@@ -86,4 +86,4 @@ Det er teknisk mulig å overstyre alle andre data kilder ved hjelp av kommandoli
 
 Hver applikasjonseier skal få tilgang til sitt eget Azure KeyVault for lagring av sensitive verdier. Altså verdier man ikke ønsker å ha synlig i kode eller konfigurasjonsfiler. Noen naturlig eksempler på dette er ting som brukernavn og passord for eksterne APIer en App skal benytte. Et sertifikat, privat nøkkel eller lignende.
 
-Per i dag blir ikke verdier fra KeyVault lest inn i konfigurasjonsstyringen av en App. Isteden må man benytte Secrets komponenten. Dette er dokumentert under [hemmeligheter](../../secrets).
+Per i dag blir ikke verdier fra KeyVault lest inn i konfigurasjonsstyringen av en App. Isteden må man benytte Secrets komponenten. Dette er dokumentert under [hemmeligheter](../secrets).

--- a/content/app/development/configuration/settings/_index.nb.md
+++ b/content/app/development/configuration/settings/_index.nb.md
@@ -85,4 +85,4 @@ Det er teknisk mulig å overstyre alle andre data kilder ved hjelp av kommandoli
 
 Hver applikasjonseier skal få tilgang til sitt eget Azure KeyVault for lagring av sensitive verdier. Altså verdier man ikke ønsker å ha synlig i kode eller konfigurasjonsfiler. Noen naturlig eksempler på dette er ting som brukernavn og passord for eksterne APIer en App skal benytte. Et sertifikat, privat nøkkel eller lignende.
 
-Per i dag blir ikke verdier fra KeyVault lest inn i konfigurasjonsstyringen av en App. Isteden må man benytte Secrets komponenten. Dette er dokumentert under [hemmeligheter](../../secrets).
+Per i dag blir ikke verdier fra KeyVault lest inn i konfigurasjonsstyringen av en App. Isteden må man benytte Secrets komponenten. Dette er dokumentert under [hemmeligheter](../secrets).


### PR DESCRIPTION
- A dead link revived
- Removed NuGet package version requirements under the assumption that all apps now have 1.2.2 or newer already.