### PR TITLE
Errors in API swagger

### DIFF
--- a/static/swagger/altinn-app-v1.json
+++ b/static/swagger/altinn-app-v1.json
@@ -366,7 +366,15 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Success",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type":"string",
+                  "format": "binary"
+                }
+              }
+            }
           }
         }
       },
@@ -3395,10 +3403,12 @@
             "nullable": true
           },
           "readStatus": {
-            "$ref": "#/components/schemas/ReadStatus"
+            "$ref": "#/components/schemas/ReadStatus",
+            "nullable": true
           },
           "substatus": {
-            "$ref": "#/components/schemas/Substatus"
+            "$ref": "#/components/schemas/Substatus",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -3513,7 +3523,8 @@
             "nullable": true
           },
           "currentTask": {
-            "$ref": "#/components/schemas/ProcessElementInfo"
+            "$ref": "#/components/schemas/ProcessElementInfo",
+            "nullable": true
           },
           "ended": {
             "type": "string",

--- a/static/swagger/altinn-platform-storage-v1.json
+++ b/static/swagger/altinn-platform-storage-v1.json
@@ -428,7 +428,15 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Success",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type":"string",
+                  "format": "binary"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request",


### PR DESCRIPTION
I'm using nswag to generate api clients from the swagger files, and I'm having some issues getting the generated clients to work. These are the changes I needed to make.

*  **app and storage** /{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/data/{dataGuid}
  declares empty result (should be binary) 
* **app** Some references declared non nullable causes generated clients to error when they are not present. (This made the `/complete` endpoint unusable with the generated client since the returned object was null where it was declared to not be nullable.)
  
PS: I know these are autogenerated, so merging this would not be a great solution. I just can't see how to make these changes with the annotations. I tried to upgrade `Altinn.Platform.Storage.Interface` to `netstandard2.1` to use C#8 nullable reference types, but that requires annotating 93 properties I don't know if should be nullable or not.