### PR TITLE
Correct direct links to permanent links

### DIFF
--- a/content/app/launched-apps/_index.en.md
+++ b/content/app/launched-apps/_index.en.md
@@ -15,9 +15,9 @@ weight: 800
 - Transportløyvegarantier (Statens vegvesen).  
   [Info](https://www.altinn.no/skjemaoversikt/statens-vegvesen/transportloyvegarantier/) | [Repo](https://altinn.studio/repos/svv/transportloyvegarantier) | [App](https://svv.apps.altinn.no/svv/transportloyvegarantier/)
 - Bestilling av tilgang til Medarbeiderundersøkelsen i staten (STAMI).  
-  [Info](https://stami.no/prosjekt/medarbeiderundersokelsen-i-staten-must/) | [Repo](https://altinn.studio/repos/stami/mu-bestilling-2021) | [App](https://stami.apps.altinn.no/stami/mu-bestilling-2021/)
+  [Info](https://aip.stami.no/url/must-om-prosjektet) | [Repo](https://altinn.studio/repos/stami/mu-bestilling-2021) | [App](https://stami.apps.altinn.no/stami/mu-bestilling-2021/)
 - Avtalevilkår for Medarbeiderundersøkelsen i Staten (STAMI).  
-  [Info](https://stami.no/prosjekt/medarbeiderundersokelsen-i-staten-must/) | [Repo](https://altinn.studio/repos/stami/mu-databehandler-2021) | [App](https://stami.apps.altinn.no/stami/mu-databehandler-2021/)
+  [Info](https://aip.stami.no/url/must-om-prosjektet) | [Repo](https://altinn.studio/repos/stami/mu-databehandler-2021) | [App](https://stami.apps.altinn.no/stami/mu-databehandler-2021/)
 - Mva-meldingen (Skatteetaten).  
   [Info](https://skatteetaten.github.io/mva-meldingen/) | [Repo](https://altinn.studio/repos/skd/mva-melding-innsending-v1)
 - Skattemeldingen (Skatteetaten).  


### PR DESCRIPTION
The "Info" link of STAMIs two first services pointed at the temporary project page directly. They have been modified to point at a url-shortener, that will persist.