### PR TITLE
Fixing broken delimiters

### DIFF
--- a/content/api/authentication/enterpriseuser/_index.en.md
+++ b/content/api/authentication/enterpriseuser/_index.en.md
@@ -4,7 +4,7 @@ linktitle: Enterprise users
 description: Description how to use enterprise users in Altinn 3
 toc: true
 weight: 100
---
+---
 
 
 ## Overall description

--- a/content/api/authentication/enterpriseuser/_index.nb.md
+++ b/content/api/authentication/enterpriseuser/_index.nb.md
@@ -4,7 +4,7 @@ linktitle: Virksomhetsbruker
 description: Beskrivelse hvordan man kan benytte virksomhetsbrukere i Altinn 3
 toc: true
 weight: 100
---
+---
 
 ## Overordne beskrivelse
 

--- a/content/community/devops/roadmapprocess/_index.en.md
+++ b/content/community/devops/roadmapprocess/_index.en.md
@@ -1,4 +1,4 @@
---
+---
 title: Roadmap prosess
 description: Hvordan jobber vi med vår roadmap
 tags: [needstranslation]


### PR DESCRIPTION
I found some broken delimiters that prevented `hugo` from compiling the docs successfully