### PR TITLE
Launched apps, update links on Norwegian page also

### DIFF
--- a/content/app/launched-apps/_index.en.md
+++ b/content/app/launched-apps/_index.en.md
@@ -16,7 +16,7 @@ weight: 800
   [Info](https://www.altinn.no/skjemaoversikt/statens-vegvesen/transportloyvegarantier/) | [Repo](https://altinn.studio/repos/svv/transportloyvegarantier) | [App](https://svv.apps.altinn.no/svv/transportloyvegarantier/)
 - Bestilling av tilgang til Medarbeiderundersøkelsen i staten (STAMI).  
   [Info](https://aip.stami.no/url/must-om-prosjektet) | [Repo](https://altinn.studio/repos/stami/mu-bestilling-2021) | [App](https://stami.apps.altinn.no/stami/mu-bestilling-2021/)
-- Avtalevilkår for Medarbeiderundersøkelsen i Staten (STAMI).  
+- Avtalevilkår for Medarbeiderundersøkelsen i staten (STAMI).  
   [Info](https://aip.stami.no/url/must-om-prosjektet) | [Repo](https://altinn.studio/repos/stami/mu-databehandler-2021) | [App](https://stami.apps.altinn.no/stami/mu-databehandler-2021/)
 - Mva-meldingen (Skatteetaten).  
   [Info](https://skatteetaten.github.io/mva-meldingen/) | [Repo](https://altinn.studio/repos/skd/mva-melding-innsending-v1)

--- a/content/app/launched-apps/_index.nb.md
+++ b/content/app/launched-apps/_index.nb.md
@@ -15,9 +15,9 @@ weight: 800
 - Transportløyvegarantier (Statens vegvesen).  
   [Info](https://www.altinn.no/skjemaoversikt/statens-vegvesen/transportloyvegarantier/) | [Repo](https://altinn.studio/repos/svv/transportloyvegarantier) | [Kjørende tjeneste](https://svv.apps.altinn.no/svv/transportloyvegarantier/)
 - Bestilling av tilgang til Medarbeiderundersøkelsen i staten (STAMI).  
-  [Info](https://stami.no/prosjekt/medarbeiderundersokelsen-i-staten-must/) | [Repo](https://altinn.studio/repos/stami/mu-bestilling-2021) | [Kjørende tjeneste](https://stami.apps.altinn.no/stami/mu-bestilling-2021/)
-- Avtalevilkår for Medarbeiderundersøkelsen i Staten (STAMI).  
-  [Info](https://stami.no/prosjekt/medarbeiderundersokelsen-i-staten-must/) | [Repo](https://altinn.studio/repos/stami/mu-databehandler-2021) | [Kjørende tjeneste](https://stami.apps.altinn.no/stami/mu-databehandler-2021/)
+  [Info](https://aip.stami.no/url/must-om-prosjektet) | [Repo](https://altinn.studio/repos/stami/mu-bestilling-2021) | [Kjørende tjeneste](https://stami.apps.altinn.no/stami/mu-bestilling-2021/)
+- Avtalevilkår for Medarbeiderundersøkelsen i staten (STAMI).  
+  [Info](https://aip.stami.no/url/must-om-prosjektet) | [Repo](https://altinn.studio/repos/stami/mu-databehandler-2021) | [Kjørende tjeneste](https://stami.apps.altinn.no/stami/mu-databehandler-2021/)
 - Mva-meldingen (Skatteetaten).  
   [Info](https://skatteetaten.github.io/mva-meldingen/) | [Repo](https://altinn.studio/repos/skd/mva-melding-innsending-v1)
 - Skattemeldingen (Skatteetaten).  


### PR DESCRIPTION
My previous PR updated only the English version of the launched-apps page, this PR updates the Norwegian also.

This PR also fixes a typo on both pages. (capital letter in "Staten" should be lower case)