### PR TITLE
docs: add release notes for 3.10.0 of storage interface

### DIFF
--- a/content/community/changelog/storage-interfaces/v3/_index.en.md
+++ b/content/community/changelog/storage-interfaces/v3/_index.en.md
@@ -5,7 +5,7 @@ toc: true
 weight: 90
 ---
 ## 3.10.0 Extended ApplicationMetadata/AppLogic with _allowAnonymousOnStateless_ property
-- The `Application` model has been expanded with a new property `allowAnonymousOnStateless`to specify if data type can be accessed anonymously when used in stateless mode. Default is `false` as before and you need to opt in if you would like to enable anonymous access.
+- The `AppLogic` model has been expanded with a new property `allowAnonymousOnStateless`to specify if data type can be accessed anonymously when used in stateless mode. Default is `false` as before and you need to opt in if you would like to enable anonymous access.
 
 ## 3.9.0 Extended EFormidlingContract with _DPFShipmentType_ property
 - The `EFormidlingContract` model has been expanded with a new property `DPFShipmentType` to hold the DPF shipment type.

--- a/content/community/changelog/storage-interfaces/v3/_index.en.md
+++ b/content/community/changelog/storage-interfaces/v3/_index.en.md
@@ -4,6 +4,8 @@ description: Overview of changes introduced in v3 of the Altinn.Platform.Storage
 toc: true
 weight: 90
 ---
+## 3.10.0 Extended ApplicationMetadata/AppLogic with _allowAnonymousOnStateless_ property
+- The `Application` model has been expanded with a new property `allowAnonymousOnStateless`to specify if data type can be accessed anonymously when used in stateless mode. Default is `false` as before and you need to opt in if you would like to enable anonymous access.
 
 ## 3.9.0 Extended EFormidlingContract with _DPFShipmentType_ property
 - The `EFormidlingContract` model has been expanded with a new property `DPFShipmentType` to hold the DPF shipment type.

--- a/content/community/changelog/storage-interfaces/v3/_index.nb.md
+++ b/content/community/changelog/storage-interfaces/v3/_index.nb.md
@@ -5,6 +5,9 @@ toc: true
 weight: 90
 ---
 
+## 3.10.0 Extended ApplicationMetadata/AppLogic with _allowAnonymousOnStateless_ property
+- `Application` modellen har blitt utvidet med en ny egenskap `allowAnonymousOnStateless` som åpner for at en data type kan akksesseres anonymt når man kjører i stateless mode. Default er `false` som dagens funksjonalitet og du må eksplisitt sette den til `true` hvis du ønsker å tillatte annonym tilgang.
+
 ## 3.9.0 Utvidet EFormidlingContract med _DPFShipmentType_ Utvidet
 - `EFormidlingContract` modellen har blitt utvidet med en ny egenskap `DPFShipmentType`. 
 Verdien er en streng som representeres forsendelsestype hvis servicen er DPF.

--- a/content/community/changelog/storage-interfaces/v3/_index.nb.md
+++ b/content/community/changelog/storage-interfaces/v3/_index.nb.md
@@ -6,7 +6,7 @@ weight: 90
 ---
 
 ## 3.10.0 Extended ApplicationMetadata/AppLogic with _allowAnonymousOnStateless_ property
-- `Application` modellen har blitt utvidet med en ny egenskap `allowAnonymousOnStateless` som åpner for at en data type kan akksesseres anonymt når man kjører i stateless mode. Default er `false` som dagens funksjonalitet og du må eksplisitt sette den til `true` hvis du ønsker å tillatte annonym tilgang.
+- `AppLogic` modellen har blitt utvidet med en ny egenskap `allowAnonymousOnStateless` som åpner for at en data type kan akksesseres anonymt når man kjører i stateless mode. Default er `false` som dagens funksjonalitet og du må eksplisitt sette den til `true` hvis du ønsker å tillatte annonym tilgang.
 
 ## 3.9.0 Utvidet EFormidlingContract med _DPFShipmentType_ Utvidet
 - `EFormidlingContract` modellen har blitt utvidet med en ny egenskap `DPFShipmentType`. 


### PR DESCRIPTION
Adds release notes for 3.1.0 of storage interface introducing a new property for controlling anonymous access on stateless apps.