### PR TITLE
chore: add link to github releases and roadmap for app-frontend

### DIFF
--- a/content/community/changelog/app-frontend/v3/whats-new/_index.en.md
+++ b/content/community/changelog/app-frontend/v3/whats-new/_index.en.md
@@ -4,6 +4,10 @@ description: Overview of changes introduced in v3 of app frontend.
 toc: true
 ---
 
+Changelog for app-frontend can now be [found on Github Releases](https://github.com/Altinn/app-frontend-react/releases).
+
+For a high-level overview of [upcoming changes, you can check out the roadmap](https://github.com/Altinn/altinn-roadmap/issues).
+
 ## 3.37.2 (2022-05-20) - Dependency patching
 Patching of external dependencies for week 20 of 2022.
 

--- a/content/community/changelog/app-frontend/v3/whats-new/_index.nb.md
+++ b/content/community/changelog/app-frontend/v3/whats-new/_index.nb.md
@@ -4,6 +4,10 @@ description: Oversikt over endringer som ble introdusert i v3 av app frontend.
 toc: true
 ---
 
+Endringslogg for app-frontend er nå [tilgjengelig på Github Releases](https://github.com/Altinn/app-frontend-react/releases).
+
+For å se en oversikt over [endringer som kommer snart kan du se på roadmap](https://github.com/Altinn/altinn-roadmap/issues).
+
 ## 3.37.2 (2022-05-20) - Oppdaterte avhengigheter
 Oppdaterte eksterne avhengigheter for uke 20 av 2022.
 


### PR DESCRIPTION
Since we are now using Github Releases, and automatically generate the changelog on release, we no longer have to maintain this list manually.