### PR TITLE
Update _index.en.md

### DIFF
--- a/content/app/development/ux/fields/grouping/setup/_index.en.md
+++ b/content/app/development/ux/fields/grouping/setup/_index.en.md
@@ -47,7 +47,7 @@ En gruppe defineres på følgende måte i FormLayout.json:
 | id                    | Ja      | Unik ID, tilsvarer ID på andre komponenter. Må være unik i FormLayout.json-filen.                                                         |
 | type                  | Ja      | MÅ være "group". Sier at dette er en gruppe.                                                                                              |
 | dataModelBindings     | Nei     | MÅ være satt for repeterende grupper, med `group`-parameteren som i eksempelet over. Skal peke på den repeterende gruppen i datamodellen. |
-| textResourceBindings  | Nei     | Kan være satt for repeterende grupper, se [beskrivelse.](#textResourceBindings)                                                            |
+| textResourceBindings  | Nei     | Kan være satt for repeterende grupper, se [beskrivelse.](#textresourcebindings)                                                            |
 | maxCount              | Ja      | Antall ganger en gruppe kan repetere. Settes til `1` om gruppen ikke er repeterende.                                                      |
 | children              | Ja      | Liste over de feltene som skal inngå i gruppen. Her brukes felt-id fra FormLayout.json                                                    |
 | tableHeaders          | Nei     | Liste over komponentener som skal inngå som en del av tabbel header feltene. Om ikke spesifisert så vises alle komponentene.              |                                                           |


### PR DESCRIPTION
The link to "beskrivelse" only brings me back to the top of the page. When I change it to #textresourcebindings with lowercase letters, it goes where it is supposed to (I don't understand why though...

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
