### PR TITLE
fixed translation of link titles

### DIFF
--- a/content/app/app-dev-course/modul2/_index.en.md
+++ b/content/app/app-dev-course/modul2/_index.en.md
@@ -2,7 +2,7 @@
 title: Module 2
 description: Add more pages, dynamic tracks and prefill
 
-linktitle: Modul 2
+linktitle: Module 2
 tags: [apps, training, prefill, sporvalg]
 weight: 20
 ---

--- a/content/app/app-dev-course/modul4/_index.en.md
+++ b/content/app/app-dev-course/modul4/_index.en.md
@@ -1,7 +1,7 @@
 ---
 title: Module 4
 description: Add code lists manually, progmatic and dynamically
-linktitle: Modul 4
+linktitle: Module 4
 tags: [apps, training, options, code lists, dynamics ]
 weight: 20
 ---

--- a/content/app/app-dev-course/modul5/_index.en.md
+++ b/content/app/app-dev-course/modul5/_index.en.md
@@ -1,7 +1,7 @@
 ---
-title: Modul 5
+title: Module 5
 description: Legge til bekreftelsessteg
-linktitle: Modul 5
+linktitle: Module 5
 tags: [apps, training, process, policy, autorisasjon, confirmation, bekreftelsessteg, validering ]
 weight: 20
 ---


### PR DESCRIPTION
Missing translation for link titles in app dev course