### PR TITLE
doc: Update V6 upgrade doc to point to specific commit id instead of latest version of Program.cs

### DIFF
--- a/content/community/changelog/app-nuget/v6/breaking-changes/_index.en.md
+++ b/content/community/changelog/app-nuget/v6/breaking-changes/_index.en.md
@@ -74,7 +74,7 @@ Follow the instructions below to ensure that the app is compatible with version 
     ```
 
 3. Update program.cs  
-   The structure of program.cs has changed for dot net 6. Copy code from [this file](https://github.com/Altinn/app-template-dotnet/blob/main/src/App/Program.cs). 
+   The structure of program.cs has changed for dot net 6. Copy code from [this file](https://github.com/Altinn/app-template-dotnet/blob/5bcad2d485b3806b127604f2434d3ab833a7d142/src/App/Program.cs). 
 
 4. Add custom service referances  
    If you have already added custom services and other changes to startup.cs and program.cs you need to add it to program.vs

--- a/content/community/changelog/app-nuget/v6/breaking-changes/_index.nb.md
+++ b/content/community/changelog/app-nuget/v6/breaking-changes/_index.nb.md
@@ -73,7 +73,7 @@ Follow the instructions below to ensure that the app is compatible with version 
     ```
 
 3. Update program.cs  
-   The structure of program.cs has changed for dot net 6. Copy code from [this file](https://github.com/Altinn/app-template-dotnet/blob/main/src/App/Program.cs). 
+   The structure of program.cs has changed for dot net 6. Copy code from [this file](https://github.com/Altinn/app-template-dotnet/blob/5bcad2d485b3806b127604f2434d3ab833a7d142/src/App/Program.cs). 
 
 4. Add custom service referances  
    If you have already added custom services and other changes to startup.cs and program.cs you need to add it to program.vs


### PR DESCRIPTION
## Description
To avoid issues when Program.cs changes in V7.

## Related Issue(s)
https://github.com/Altinn/app-template-dotnet/issues/125