### PR TITLE
add release notes for v6.0.2 of nugets

### DIFF
--- a/content/community/changelog/app-nuget/v6/whats-new/_index.en.md
+++ b/content/community/changelog/app-nuget/v6/whats-new/_index.en.md
@@ -4,6 +4,13 @@ description: Overview of changes introduced in version 6.
 toc: true
 ---
 
+## 6.0.2 Dependency update and bugfix
+Updated eformidling dependency to 1.3.2 in [#13](https://github.com/Altinn/app-lib-dotnet/pull/13)
+
+Removed authentication on redirect endpoint in [#15](https://github.com/Altinn/app-lib-dotnet/pull/15)
+
+[View release on github](https://github.com/Altinn/app-lib-dotnet/releases/tag/v6.0.2)
+
 ## 6.0.1 Bugfix for changes in repeating groups
 
 This release fixes [a bug](https://github.com/Altinn/app-frontend-react/issues/319) where a change adding/removing rows

--- a/content/community/changelog/app-nuget/v6/whats-new/_index.nb.md
+++ b/content/community/changelog/app-nuget/v6/whats-new/_index.nb.md
@@ -4,6 +4,13 @@ description: Oversikt over endringer som ble introdusert i versjon 6.
 toc: true
 ---
 
+## 6.0.2 Dependency oppdatering og bugfix
+Oppdatert eformidling avhengighet til 1.3.2 i [#13](https://github.com/Altinn/app-lib-dotnet/pull/13)
+
+Fjernet autentisering på redirect endepunkt i [#15](https://github.com/Altinn/app-lib-dotnet/pull/15)
+
+[Se release på github](https://github.com/Altinn/app-lib-dotnet/releases/tag/v6.0.2)
+
 ## 6.0.1 Feilretting for endringer i repeterende grupper
 
 Denne versjonen fikser [en feil](https://github.com/Altinn/app-frontend-react/issues/319) hvor endringer som


### PR DESCRIPTION
## Description
add release notes for v6.0.2 of nugets

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
