### PR TITLE
docs: differentiate between layout set and model

### DIFF
--- a/content/app/development/configuration/stateless/_index.en.md
+++ b/content/app/development/configuration/stateless/_index.en.md
@@ -46,7 +46,7 @@ Configuration of this is done in `applicationmetadata.json`. Example:
       "minCount": 0
     },
     {
-      "id": "Stateless",
+      "id": "Stateless-model",
       "allowedContentTypes": [
         "application/xml"
       ],
@@ -76,23 +76,23 @@ In `layout-sets.json` you add the actual set you are refering to from `applicati
     "sets": [
       {
         "id": "stateless",
-        "dataType": "Stateless"
+        "dataType": "Stateless-model"
       }
     ]
   }
 ```
 
-In the example above the layout-set `stateless` is referring to the datamodel `Stateless`. Example of an app structure for an application which is set up in this way:
+In the example above the layout-set `stateless` is referring to the datamodel `Stateless-model`. Example of an app structure for an application which is set up in this way:
 
 ```text
 ├───App
     ├───config
     ├───logic
     ├───models
-    │       Stateless.cs
-    │       Stateless.metadata.json
-    │       Stateless.schema.json
-    │       Stateless.xsd
+    │       Stateless-model.cs
+    │       Stateless-model.metadata.json
+    │       Stateless-model.schema.json
+    │       Stateless-model.xsd
     ├───ui
         │   layout-sets.json
         │
@@ -140,7 +140,7 @@ The datatype's `appLogic`-object needs a new setting, `"allowAnonymousOnStateles
       "minCount": 0
     },
     {
-      "id": "Stateless",
+      "id": "Stateless-model",
       "allowedContentTypes": [
         "application/xml"
       ],

--- a/content/app/development/configuration/stateless/_index.nb.md
+++ b/content/app/development/configuration/stateless/_index.nb.md
@@ -46,7 +46,7 @@ Konfigurasjonen av dette gjøres i `applicationmetadata.json`. Eksempel:
       "minCount": 0
     },
     {
-      "id": "Stateless",
+      "id": "Stateless-model",
       "allowedContentTypes": [
         "application/xml"
       ],
@@ -76,23 +76,23 @@ I `layout-sets.json` legger man så inn det aktuelle settet man referer til fra 
     "sets": [
       {
         "id": "stateless",
-        "dataType": "Stateless"
+        "dataType": "Stateless-model"
       }
     ]
   }
 ```
 
-I eksempelet over så referer layout-settet `stateless` til datamodellen `Stateless`. Eksempel app-struktur på en applikasjon som har satt opp på denne måten:
+I eksempelet over så referer layout-settet `stateless` til datamodellen `Stateless-model`. Eksempel app-struktur på en applikasjon som har satt opp på denne måten:
 
 ```text
 ├───App
     ├───config
     ├───logic
     ├───models
-    │       Stateless.cs
-    │       Stateless.metadata.json
-    │       Stateless.schema.json
-    │       Stateless.xsd
+    │       Stateless-model.cs
+    │       Stateless-model.metadata.json
+    │       Stateless-model.schema.json
+    │       Stateless-model.xsd
     ├───ui
         │   layout-sets.json
         │
@@ -141,7 +141,7 @@ Datatypen sitt `appLogic`-objekt må få en ny innstilling, `"allowAnonymousOnSt
       "minCount": 0
     },
     {
-      "id": "Stateless",
+      "id": "Stateless-model",
       "allowedContentTypes": [
         "application/xml"
       ],


### PR DESCRIPTION
The lower and upper-case naming of `Stateless` and `stateless` for the layout set and data model caused confusion when talking about how to configure a stateless app.

Now has a more explicit naming for the data model to make this easier to follow where the layout-set is named `stateless` and the model is called `Stateless-model`