### PR TITLE
docs: change title for options based on the datamodel

### DIFF
--- a/content/app/development/data/options/_index.en.md
+++ b/content/app/development/data/options/_index.en.md
@@ -10,10 +10,10 @@ Altinn offers two different ways an application can use code lists - static and 
 Checkbox, Dropdown, and RadioButton components will automatically be able to fetch such lists if you connect the component to the option id in question.
 
 ## Static codelists from the application repository
-By adding json based option files in the application repository, the application will automatically read the file and expose it through the options api. For this to work, the files must be placed in the `App/options/` folder and be named according to the following conventions `{optionId}.json` for the application to recognize them. 
+
+By adding json based option files in the application repository, the application will automatically read the file and expose it through the options api. For this to work, the files must be placed in the `App/options/` folder and be named according to the following conventions `{optionId}.json` for the application to recognize them.
 
 For example if you have a list of countries in a file named `countries.json`, the optionId would be `countries`, and would be exposed through the api at `{org}/{app}/api/options/countries`. The static codelists should be in a special format as shown below:
-
 
 ```json
 [
@@ -35,16 +35,16 @@ For example if you have a list of countries in a file named `countries.json`, th
 Note that the `label` field can be a key to a text resource (as shown above for sweden) or plain text.
 
 ## Dynamic codelists generated runtime
+
 As an alternative to the static files you can have code that determines what the lists should be during runtime. This makes it possible to expose dynamic values that for instance are filtered or looked up in external sources. Dynamic codelists can either be open and accessible to all or secured and limited to those with read access to the instance.
 
 In versions prior to 4.24.0 this was done by overriding the `GetOptions` method in `App.cs`. This method is now deprecated and is replaced by putting the option code in separate classes implementing an interface and registering the implementation in the application dependency injection container. This allows for better separation, inject dependencies into the constructor, pass in language and other query parameters and generally handle all aspects of the implementation as you see fit.
 
 For codelists that are open you implement the `IAppOptionsProvider` interface and for codelists that should be secured you implement the `IInstanceAppOptionsProvider` interface. The pattern is the same for both, and the models returned is the same, but the implementation is kept separate to avoid exposing data that should be secured.
 
-
 ### Open dynamic codelists
-Below you find an example of how to implement a open custom options provider. The url will will still be exposed from the same endpoint as before `{org}/{app}/api/options/countires`.
 
+Below you find an example of how to implement a open custom options provider. The url will will still be exposed from the same endpoint as before `{org}/{app}/api/options/countires`.
 
 ```C#
 using Altinn.App.Common.Models;
@@ -85,16 +85,17 @@ namespace Altinn.App.Core
 ```
 
 For your implementation to be picked up you need to add the following line in your `Startup.cs` (or `Program.cs` in .NET 6):
+
 ```csharp
 services.AddTransient<IAppOptionsProvider, CountryAppOptionsProvider>();
 ```
 
 Note that you can have multiple registrations of this interface. The correct implementation is resolved by finding the one with the correct id.
 
-The interface has a property `Id`, which should be set to the optionId, and a method `GetAppOptionsAsync` for resolving the options. This method accepts a language code and a dictionary of key/value pairs. Both parameters will typically be query parameters picked up from the controller and passed in. Allthough language could be put in the dictionary as well it's decided to be explicit on this particular parameter. 
+The interface has a property `Id`, which should be set to the optionId, and a method `GetAppOptionsAsync` for resolving the options. This method accepts a language code and a dictionary of key/value pairs. Both parameters will typically be query parameters picked up from the controller and passed in. Allthough language could be put in the dictionary as well it's decided to be explicit on this particular parameter.
 
 > Language codes should be based on ISO 639-1 or the W3C IANA Language Subtag Registry. The latter is built uppon the ISO 639-1 standard but is guaranties uniques of the codes, where as ISO 639-1 have conflicting usage for some codes.
-> 
+>
 
 ### Secured dynamic options
 
@@ -154,7 +155,9 @@ namespace Altinn.App.Core
 }
 
 ```
+
 For your implementation to be picked up you need to add the following line in your `Startup.cs` (or `Program.cs` in .NET 6):
+
 ```csharp
 services.AddTransient<IInstanceAppOptionsProvider, ChildrenAppOptionsProvider>();
 ```
@@ -183,7 +186,9 @@ The final configuration needed is the `secure`-boolean on the component. Example
 ```
 
 ## Connect the component to options (code list)
+
 This is done by adding the optionId you would like to refer to either through the component UI in Designer or direcytly in `FormLayout.json` as shown below:
+
 ```json
 {
     "id": "8e6f7b2f-fcf0-438d-8336-c1a8e1e03f44",
@@ -194,8 +199,8 @@ This is done by adding the optionId you would like to refer to either through th
 }
 ```
 
-
 ## Pass query parameters when fetching options
+
 Options supports query parameters when making the api call. `language` is added automatically, and you can also add custom parameters by defining `mapping` on the component.
 
 ```json
@@ -266,6 +271,7 @@ During PDF-generation the app will try to call the same option endpoint as app-f
 We currently has a weakness where mapping paramteres not are included in this request, see issue [#7903.](https://github.com/Altinn/altinn-studio/issues/7903)
 
 A possible workaround here is to return an empty array when the PDF-generator asks for options with empty query params, example:
+
 ```c#
             string someArg = keyValuePairs.GetValueOrDefault("someArg");
             string someOtherArg = keyValuePairs.GetValueOrDefault("someOtherArg");
@@ -274,17 +280,19 @@ A possible workaround here is to return an empty array when the PDF-generator as
                 return await Task.FromResult(new List<AppOption>());
             }
 ```
+
 Notice that this wil result in the option value and not the label being present as the end users answer.
 {{% /notice%}}
 
-## Options based on repeating groups from Redux
+## Options based on repeating groups from the data model
 
-Traditional options are based on resources fetched from the backend. 
-This approach differs a bit from this, as it enables setting up a direct connection from the options to the form data that is stored in app frontend. 
+Traditional options are based on resources fetched from the backend.
+This approach differs a bit from this, as it enables setting up a direct connection from the options to the form data that is stored in app frontend.
 A use case here would typically be if the user fills out a repeating list of data that should later be selected in a dropdown/checkbox/radiobutton.
 
 ### Configuration
-To set up options from redux we have set up a new property on `RadioButtons`, `Checkboxes`, and `Dropdown`-components called `source`. 
+
+To set up options from redux we have set up a new property on `RadioButtons`, `Checkboxes`, and `Dropdown`-components called `source`.
 This property contains the fields `group`, `label`, and `value`. Example:
 
 ```json
@@ -301,6 +309,7 @@ This property contains the fields `group`, `label`, and `value`. Example:
 ```
 
 Explanation:
+
 - **group** - the group field in the data model to base the options on
 - **label** - a reference to a text id to be used as the label for each iteration of the group, see more below.
 - **value** - a reference to a field in the group that should be used as the option value. Notice that we set up this `[{0}]` syntax. Here the `{0}` will be replaced by each index of the group.
@@ -334,5 +343,5 @@ Example text resource connected:
 }
 ```
 
-In the example above we have two parameters in the text which is referencing fields in the group. 
+In the example above we have two parameters in the text which is referencing fields in the group.
 We also recognize the `[{0}]` syntax in the `key` prop which enables the usage of this label for each index in the group.

--- a/content/app/development/data/options/_index.nb.md
+++ b/content/app/development/data/options/_index.nb.md
@@ -285,7 +285,7 @@ En mulig workaround her er å returnere en tom array i det PDF-generatoren spør
 Merk at dette vil resultere i at PDF vil vise verdien valgt og ikke label som sluttbrukers svar.
 {{% /notice%}}
 
-## Options (kodelister) basert på repeterende grupper i datamodellen
+## Options basert på repeterende grupper i datamodellen
 
 Tradisjonelle options baserer seg på ressurser hentet fra backend.
 Denne måten å gjøre ting på endrer seg litt på dette, da det muliggjør å sette opp en direkte kobling fra komponent til skjemadata som ligger lagret i app frontend.

--- a/content/app/development/data/options/_index.nb.md
+++ b/content/app/development/data/options/_index.nb.md
@@ -11,7 +11,7 @@ Checkbox, Dropdown og RadioButton komponenter vil automatisk kunne hente ut en s
 
 ## Statisk kodeliste fra app-repo
 
-Ved å legge json-lister i options mappen i app repo vil appen automatisk lese denne filen og eksponere det gjennom options-apiet. 
+Ved å legge json-lister i options mappen i app repo vil appen automatisk lese denne filen og eksponere det gjennom options-apiet.
 Options filene må ligge under `App/options/` og vil bli differensiert ved hjelp av navngivningen på json-filen. F.eks `land.json`. Her vil da optionsId være `land`, og vil være eksponert gjennom endepunktet `{org}/{app}/api/options/land`.
 Kodelistene må være på et spesifikt format. Eksempel på en kodeliste som inneholder land (`App/options/land.json`):
 
@@ -43,6 +43,7 @@ I versjoner eldre enn 4.24.0 ble dette gjort ved å legge til kode i metoden `Ge
 For kodelister som er åpne implementerer man `IAppOptionsProvider` interfacet, mens for kodelister som skal være sikret implementerer man `IInstanceAppOptionsProvider`. Fremgangsmåten er den samme for begge to og modellen som returneres er lik. Men implementeringen holdes adskilt for ikke å eksponere verdier som skulle vært sikret.
 
 ### Åpne dynamiske kodelister
+
 Under finner du et eksempel på hvordan dette kan settes opp for en åpen kodeliste. Her vil man få ut den oppsatte kodelisten i det appen får et kall mot `{org}/{app}/api/options/countries`.
 
 ```C#
@@ -84,6 +85,7 @@ namespace Altinn.App.Core
 ```
 
 For at denne implementasjonen skal plukkes opp av applikasjonen må den registreres i `Startup.cs` (eller `Program.cs` i .NET 6):
+
 ```csharp
 services.AddTransient<IAppOptionsProvider, CountryAppOptionsProvider>();
 ```
@@ -92,9 +94,8 @@ Legg merke til at du kan ha mange implementasjoner av dette interfacet. Den rett
 
 Interfacene har en egenskap `Id`, som skal settes til til den id'en man skal spørre etter, og en metode `GetAppOptionsAsync` som returnerer selve kodelisten. Denne metoden tar i mot språk og en liste med key/value par som typisk er query parametre som plukkes opp av kontrolleren og sendes inn. Selv om språk kunne vært et key/value par og sånn sett hvert i listen, så er denne lagt utenfor for å være eksplisitt på språk.
 
-
 > Språkkoder bør baseres på ISO 639-1 standarden eller W3C IANA Language Subtag Registry standarden. Sistnevnte bygger på ISO 639-1 standarden men garanterer at alle kodene er unike, noe ISO 639-1 ikke gjør.
-> 
+>
 
 ### Sikrede dynamiske kodelister
 
@@ -156,6 +157,7 @@ namespace Altinn.App.Core
 ```
 
 For at denne implementasjonen skal plukkes opp av applikasjonen må den registreres i `Startup.cs` (eller `Program.cs` i .NET 6):
+
 ```csharp
 services.AddTransient<IInstanceAppOptionsProvider, ChildrenAppOptionsProvider>();
 ```
@@ -164,7 +166,7 @@ Legg merke til at du kan ha mange implementasjoner av dette interfacet. Den rett
 
 Interfacene har en egenskap `Id`, som skal settes til til den id'en man skal spørre etter, og en metode `GetAppOptionsAsync` som returnerer selve kodelisten. Denne metoden tar i mot språk og en liste med key/value par som typisk er query parametre som plukkes opp av kontrolleren og sendes inn. Selv om språk kunne vært et key/value par og sånn sett hvert i listen, så er denne lagt utenfor for å være eksplisitt på språk.
 
-Siste konfigurasjon som trengs er å legge til `secure`-boolean på den aktuelle komponenten. Eksempel: 
+Siste konfigurasjon som trengs er å legge til `secure`-boolean på den aktuelle komponenten. Eksempel:
 
 ```json {hl_lines=[13]}
       {
@@ -184,7 +186,9 @@ Siste konfigurasjon som trengs er å legge til `secure`-boolean på den aktuelle
 ```
 
 ## Koble en komponent til kodeliste
+
 Dette gjøres ved å legge til feltet optionsId som referer til hvilken option (kodeliste) man ønsker refere til. Eksempel:
+
 ```json
 {
     "id": "8e6f7b2f-fcf0-438d-8336-c1a8e1e03f44",
@@ -196,8 +200,8 @@ Dette gjøres ved å legge til feltet optionsId som referer til hvilken option (
 }
 ```
 
-
 ## Sende med query parametere ved henting av options
+
 Options støtter query parameters når det gjøres api kall. `language` er satt opp automatisk, men man kan også legge til egendefinerte parametere ved å sette opp `mapping` på den aktuelle komponenten.
 
 ```json
@@ -264,10 +268,11 @@ For nøsta repeterende grupper vil man følge det samme mønsteret, men med en e
 For et komplett eksempel kan du se vår [demo app.](https://altinn.studio/repos/ttd/dynamic-options-rep)
 
 {{%notice warning%}}
-Under PDF-generering vil appen prøve å kalle det samme options-endepunktet som app-frontend gjør. 
+Under PDF-generering vil appen prøve å kalle det samme options-endepunktet som app-frontend gjør.
 Vi har foreløpig en svakhet ved at eventuelle mapping-parametere ikke blir inkludert i denne forespørselen, se issue [#7903.](https://github.com/Altinn/altinn-studio/issues/7903)
 
 En mulig workaround her er å returnere en tom array i det PDF-generatoren spør om options med tomme query-parametere, eksempel:
+
 ```c#
             string someArg = keyValuePairs.GetValueOrDefault("someArg");
             string someOtherArg = keyValuePairs.GetValueOrDefault("someOtherArg");
@@ -280,13 +285,14 @@ En mulig workaround her er å returnere en tom array i det PDF-generatoren spør
 Merk at dette vil resultere i at PDF vil vise verdien valgt og ikke label som sluttbrukers svar.
 {{% /notice%}}
 
-## Options basert på repeterende grupper i Redux
+## Options (kodelister) basert på repeterende grupper i datamodellen
 
 Tradisjonelle options baserer seg på ressurser hentet fra backend.
 Denne måten å gjøre ting på endrer seg litt på dette, da det muliggjør å sette opp en direkte kobling fra komponent til skjemadata som ligger lagret i app frontend.
 Et typisk bruksområde for dette er om brukeren fyller ut en liste med data som man senere i skjema ønsker å kunne velge mellom i en nedtrekksliste eller liknende.
 
 ### Konfigurasjon
+
 For å sette opp options fra redux har vu laget en nytt objekt som kan brukes på komponentene `RadioButtons`, `Checkboxes` og `Dropdown` som vi har kalt `source`.
 Dette nye objektet inneholder feltene `group`, `label` og `value`. Eksempel:
 
@@ -304,6 +310,7 @@ Dette nye objektet inneholder feltene `group`, `label` og `value`. Eksempel:
 ```
 
 Forklaring:
+
 - **group** - gruppen i datamodellen man baserer options på.
 - **label** - en referanse til en text id som brukes som label for hver iterasjon av gruppen. Se mer under.
 - **value** - en referanse til det feltet i gruppen som skal bruke som option verdi. Legg merke til `[{0}]` syntaxen. Her vil `{0}` bli erstattet med den aktuelle indeksen for hvert element i gruppen.
@@ -313,7 +320,7 @@ Merk at **value** feltet må være unikt for hvert element. Om man ikke har et f
 For **label** feltet må vi definere en tekst ressurs som kan bli brukt som label for hver repetisjon av gruppen.
 Dette følger samme syntax som **value**, og vil være kjent for deg om du har brukt [variabler i tekst](../../ux/texts).
 
-Eksempel: 
+Eksempel:
 
 ```json
 {
@@ -338,4 +345,4 @@ Eksempel:
 ```
 
 I dette eksempelet har vi satt opp to parametere i teksten som refererer til felter i gruppen.
-Vi kjenner også igjen `[{0}]` syntaksen i `key` feltet som muliggjør gjenbruk av labelen for hver index i gruppen. 
+Vi kjenner også igjen `[{0}]` syntaksen i `key` feltet som muliggjør gjenbruk av labelen for hver index i gruppen.

--- a/content/community/changelog/app-frontend/v3/whats-new/_index.en.md
+++ b/content/community/changelog/app-frontend/v3/whats-new/_index.en.md
@@ -76,7 +76,7 @@ The width declaration was moved to inline styling instead to resolve this issue.
 Issue [#14](https://github.com/Altinn/app-frontend-react/issues/14). 
 
 ## 3.34.0 (2022-04-11) - Options from Redux
-Added possibility to setup options from repeating groupes in Redux. Read more on [docs.](/app/development/data/options/#options-based-on-repeating-groups-from-redux)
+Added possibility to setup options from repeating groupes in Redux. Read more on [docs.](/app/development/data/options/#options-based-on-repeating-groups-from-the-data-model)
 Issue [#7626](https://github.com/Altinn/altinn-studio/issues/7626). 
 
 ## 3.33.5 (2022-04-11) - External dependency patching

--- a/content/community/changelog/app-frontend/v3/whats-new/_index.nb.md
+++ b/content/community/changelog/app-frontend/v3/whats-new/_index.nb.md
@@ -77,7 +77,7 @@ Width deklarasjonen ble flyttet til inline styling for å løse problemet.
 Issue [#14](https://github.com/Altinn/app-frontend-react/issues/14). 
 
 ## 3.34.0 (2022-04-11) - Options fra Redux
-La til støtte for å sette opp options (kodelister) fra repeterende grupper i Redux staten. Les mer på [docs.](/app/development/data/options/#options-based-on-repeating-groups-from-redux)
+La til støtte for å sette opp options (kodelister) fra repeterende grupper i Redux staten. Les mer på [docs.](/nb/app/development/data/options/#options-basert-på-repeterende-grupper-i-datamodellen)
 Issue [#7626](https://github.com/Altinn/altinn-studio/issues/7626). 
 
 ## 3.33.5 (2022-04-11) - Oppdaterte ekstern avhengighet


### PR DESCRIPTION
Changed title for options based on repeating groups in the data model to be more understandable for the app developers and not expose implementation details that strictly do not matter.

Also some fixing of linting rules. 