### PR TITLE
expressions doc changes and new example

### DIFF
--- a/content/app/development/logic/expressions/_index.en.md
+++ b/content/app/development/logic/expressions/_index.en.md
@@ -140,7 +140,9 @@ alle steder der det brukes. TextResourceBindigs for repeterende grupper finner d
 Her endrer vi teksten til redigeringsknappen i en repeterende gruppe basert på om `IsPrefill` er satt til `true` i
 en gitt adresse i datamodellen. Dersom `IsPrefill` er `true` for en adresse, vil raden som viser frem den adressen ha en
 redigerings-knapp med teksten `"View"`. Hvis `IsPrefill` er `false` blir teksten på knappen til den spesifikke raden
-`"Edit"`. Det er verdt å merke seg at dersom et oppslag på `IsPrefill` gir resultatet `null`(ikke funnet) så konverteres
+`"Edit"`. 
+
+Det er verdt å merke seg at dersom et oppslag på `IsPrefill` gir resultatet `null`(ikke funnet) så konverteres
 resultatet til `false` når det blir brukt i en `if`. Les mer detaljert om dette i seksjonene [if](#func-if) og [datatyper](#datatyper)
 
 ```json

--- a/content/app/development/logic/expressions/_index.en.md
+++ b/content/app/development/logic/expressions/_index.en.md
@@ -107,7 +107,7 @@ for eksempel 45 år gammel, returneres teksten:
 
 For en person som er 62 år returneres teksten:
 
-**At 62, your are eligble for retirement**
+**At 62, your are eligible for retirement**
 
 Og for en person som er 15 år (eller yngre, som f.eks. en 4-åring), returneres teksten:
 

--- a/content/app/development/logic/expressions/_index.en.md
+++ b/content/app/development/logic/expressions/_index.en.md
@@ -132,8 +132,42 @@ Dynamiske uttrykk er foreløpig tilgjengelig for bruk i disse egenskapene, som d
 | [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.saveAndNextButton`                        | [Boolsk](#boolske-verdier) | ✅        | ❌       |
 | Alle                                                      | `textResourceBindings.[textResourceBinding]` *  | [Streng](#strenger)        | ✅        | ❌       |
 
-*= Hvilke verdier man kan overstyre med textResourceBindings varierer fra komponent til komponent, men vil fungere på
+\* = Hvilke verdier man kan overstyre med textResourceBindings varierer fra komponent til komponent, men vil fungere på
 alle steder der det brukes. TextResourceBindigs for repeterende grupper finner du [her](../../ux/fields/grouping/setup#textresourcebindings)
+
+{{% expandlarge id="rep-group-edit-button-text" header="Eksempel: Styre redigeringsknapp-tekst i repeterende gruppe" %}}
+
+Her endrer vi teksten til redigeringsknappen i en repeterende gruppe basert på om `IsPrefill` er satt til `true` i
+en gitt adresse i datamodellen. Dersom `IsPrefill` er `true` for en adresse, vil raden som viser frem den adressen ha en
+redigerings-knapp med teksten `"View"`. Hvis `IsPrefill` er `false` blir teksten på knappen til den spesifikke raden
+`"Edit"`. Det er verdt å merke seg at dersom `IsPrefill` ikke er satt til hverken `true` eller `false` så vil uttrykket
+tolke verdien som `false`.
+
+```json
+{
+   "id": "repeatingAddressGroup",
+   "type": "Group",
+   "children": [
+      "field-id-one",
+      "field-id-two",
+   ],
+   "dataModelBindings": {
+      "group": "Citizen.FormerAdresses"
+   },
+   "maxCount": 10,
+   "textResourceBindings": {
+      "edit_button_open": [
+      "if",
+      [ "dataModel", "Citizen.FormerAdresses.IsPrefill" ],
+      "View",
+      "else",
+      "Edit"
+      ]
+   }
+}
+```
+
+{{% /expandlarge %}}
 
 ### Testing, feilsøking og utvikling av uttrykk
 

--- a/content/app/development/logic/expressions/_index.en.md
+++ b/content/app/development/logic/expressions/_index.en.md
@@ -140,7 +140,7 @@ alle steder der det brukes. TextResourceBindigs for repeterende grupper finner d
 Her endrer vi teksten til redigeringsknappen i en repeterende gruppe basert på om `IsPrefill` er satt til `true` i
 en gitt adresse i datamodellen. Dersom `IsPrefill` er `true` for en adresse, vil raden som viser frem den adressen ha en
 redigerings-knapp med teksten `"View"`. Hvis `IsPrefill` er `false` blir teksten på knappen til den spesifikke raden
-`"Edit"`. 
+`"Edit"`.
 
 Det er verdt å merke seg at dersom et oppslag på `IsPrefill` gir resultatet `null`(ikke funnet) så konverteres
 resultatet til `false` når det blir brukt i en `if`. Les mer detaljert om dette i seksjonene [if](#func-if) og [datatyper](#datatyper)

--- a/content/app/development/logic/expressions/_index.en.md
+++ b/content/app/development/logic/expressions/_index.en.md
@@ -140,8 +140,8 @@ alle steder der det brukes. TextResourceBindigs for repeterende grupper finner d
 Her endrer vi teksten til redigeringsknappen i en repeterende gruppe basert på om `IsPrefill` er satt til `true` i
 en gitt adresse i datamodellen. Dersom `IsPrefill` er `true` for en adresse, vil raden som viser frem den adressen ha en
 redigerings-knapp med teksten `"View"`. Hvis `IsPrefill` er `false` blir teksten på knappen til den spesifikke raden
-`"Edit"`. Det er verdt å merke seg at dersom `IsPrefill` ikke er satt til hverken `true` eller `false` så vil uttrykket
-tolke verdien som `false`.
+`"Edit"`. Det er verdt å merke seg at dersom et oppslag på `IsPrefill` gir resultatet `null`(ikke funnet) så konverteres
+resultatet til `false` når det blir brukt i en `if`. Les mer detaljert om dette i seksjonene [if](#func-if) og [datatyper](#datatyper)
 
 ```json
 {

--- a/content/app/development/logic/expressions/_index.nb.md
+++ b/content/app/development/logic/expressions/_index.nb.md
@@ -139,8 +139,10 @@ alle steder der det brukes. TextResourceBindigs for repeterende grupper finner d
 Her endrer vi teksten til redigeringsknappen i en repeterende gruppe basert på om `IsPrefill` er satt til `true` i
 en gitt adresse i datamodellen. Dersom `IsPrefill` er `true` for en adresse, vil raden som viser frem den adressen ha en
 redigerings-knapp med teksten `"View"`. Hvis `IsPrefill` er `false` blir teksten på knappen til den spesifikke raden
-`"Edit"`. Det er verdt å merke seg at dersom et oppslag på `IsPrefill` gir resultatet `null`(ikke funnet) så konverteres
-resultatet til `false` når det blir brukt i en `if`. Les mer om dette i seksjonene [if](#func-if) og [datatyper](#datatyper)
+`"Edit"`.
+
+Det er verdt å merke seg at dersom et oppslag på `IsPrefill` gir resultatet `null`(ikke funnet) så konverteres
+resultatet til `false` når det blir brukt i en `if`. Les mer detaljert om dette i seksjonene [if](#func-if) og [datatyper](#datatyper)
 
 ```json
 {

--- a/content/app/development/logic/expressions/_index.nb.md
+++ b/content/app/development/logic/expressions/_index.nb.md
@@ -139,8 +139,8 @@ alle steder der det brukes. TextResourceBindigs for repeterende grupper finner d
 Her endrer vi teksten til redigeringsknappen i en repeterende gruppe basert på om `IsPrefill` er satt til `true` i
 en gitt adresse i datamodellen. Dersom `IsPrefill` er `true` for en adresse, vil raden som viser frem den adressen ha en
 redigerings-knapp med teksten `"View"`. Hvis `IsPrefill` er `false` blir teksten på knappen til den spesifikke raden
-`"Edit"`. Det er verdt å merke seg at dersom `IsPrefill` ikke er satt til hverken `true` eller `false` så vil uttrykket
-tolke verdien som `false`.
+`"Edit"`. Det er verdt å merke seg at dersom et oppslag på `IsPrefill` gir resultatet `null`(ikke funnet) så konverteres
+resultatet til `false` når det blir brukt i en `if`. Les mer om dette i seksjonene [if](#func-if) og [datatyper](#datatyper)
 
 ```json
 {

--- a/content/app/development/logic/expressions/_index.nb.md
+++ b/content/app/development/logic/expressions/_index.nb.md
@@ -126,9 +126,9 @@ Dynamiske uttrykk er foreløpig tilgjengelig for bruk i disse egenskapene, som d
 | Skjemakomponenter                                         | `required`                                      | [Boolsk](#boolske-verdier) | ✅        | ✅       |
 | Skjemakomponenter                                         | `readOnly`                                      | [Boolsk](#boolske-verdier) | ✅        | ❌       |
 | [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.addButton`                                | [Boolsk](#boolske-verdier) | ✅        | ❌       |
-| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.saveButton` *                             | [Boolsk](#boolske-verdier) | ✅        | ❌       |
-| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.deleteButton` *                           | [Boolsk](#boolske-verdier) | ✅        | ❌       |
-| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.saveAndNextButton` *                      | [Boolsk](#boolske-verdier) | ✅        | ❌       |
+| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.saveButton`                               | [Boolsk](#boolske-verdier) | ✅        | ❌       |
+| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.deleteButton`                             | [Boolsk](#boolske-verdier) | ✅        | ❌       |
+| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.saveAndNextButton`                        | [Boolsk](#boolske-verdier) | ✅        | ❌       |
 | Alle                                                      | `textResourceBindings.[textResourceBinding]` *  | [Streng](#strenger)        | ✅        | ❌       |
 
 \* = Hvilke verdier man kan overstyre med textResourceBindings varierer fra komponent til komponent, men vil fungere på

--- a/content/app/development/logic/expressions/_index.nb.md
+++ b/content/app/development/logic/expressions/_index.nb.md
@@ -107,7 +107,7 @@ for eksempel 45 år gammel, returneres teksten:
 
 For en person som er 62 år returneres teksten:
 
-**At 62, your are eligble for retirement**
+**At 62, your are eligible for retirement**
 
 Og for en person som er 15 år (eller yngre, som f.eks. en 4-åring), returneres teksten:
 
@@ -119,19 +119,54 @@ Og for en person som er 15 år (eller yngre, som f.eks. en 4-åring), returneres
 
 Dynamiske uttrykk er foreløpig tilgjengelig for bruk i disse egenskapene, som definert i [layout-filer](../../ux/pages).
 
-| Komponenter                                               | Egenskap                   | Forventet verdi            | Frontend | Backend |
-|-----------------------------------------------------------|----------------------------|----------------------------|----------|---------|
-| [Sider/layouts](#viseskjule-hele-sider)                   | `hidden`                   | [Boolsk](#boolske-verdier) | ✅        | ✅       |
-| Alle                                                      | `hidden`                   | [Boolsk](#boolske-verdier) | ✅        | ✅       |
-| Skjemakomponenter                                         | `required`                 | [Boolsk](#boolske-verdier) | ✅        | ✅       |
-| Skjemakomponenter                                         | `readOnly`                 | [Boolsk](#boolske-verdier) | ✅        | ❌       |
-| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.addButton`           | [Boolsk](#boolske-verdier) | ✅        | ❌       |
-| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.saveButton` *        | [Boolsk](#boolske-verdier) | ✅        | ❌       |
-| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.deleteButton` *      | [Boolsk](#boolske-verdier) | ✅        | ❌       |
-| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.saveAndNextButton` * | [Boolsk](#boolske-verdier) | ✅        | ❌       |
+| Komponenter                                               | Egenskap                                        | Forventet verdi            | Frontend | Backend |
+|-----------------------------------------------------------|-------------------------------------------------|----------------------------|----------|---------|
+| [Sider/layouts](#viseskjule-hele-sider)                   | `hidden`                                        | [Boolsk](#boolske-verdier) | ✅        | ✅       |
+| Alle                                                      | `hidden`                                        | [Boolsk](#boolske-verdier) | ✅        | ✅       |
+| Skjemakomponenter                                         | `required`                                      | [Boolsk](#boolske-verdier) | ✅        | ✅       |
+| Skjemakomponenter                                         | `readOnly`                                      | [Boolsk](#boolske-verdier) | ✅        | ❌       |
+| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.addButton`                                | [Boolsk](#boolske-verdier) | ✅        | ❌       |
+| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.saveButton` *                             | [Boolsk](#boolske-verdier) | ✅        | ❌       |
+| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.deleteButton` *                           | [Boolsk](#boolske-verdier) | ✅        | ❌       |
+| [Repeterende grupper](../../ux/fields/grouping/repeating) | `edit.saveAndNextButton` *                      | [Boolsk](#boolske-verdier) | ✅        | ❌       |
+| Alle                                                      | `textResourceBindings.[textResourceBinding]` *  | [Streng](#strenger)        | ✅        | ❌       |
 
-\* = Disse egenskapene kan foreløpig bare styres dynamisk for alle [repeterende grupper](../../ux/fields/grouping/repeating)
-på en gang, ikke for hver enkelt rad.
+\* = Hvilke verdier man kan overstyre med textResourceBindings varierer fra komponent til komponent, men vil fungere på
+alle steder der det brukes. TextResourceBindigs for repeterende grupper finner du [her](../../ux/fields/grouping/setup#textresourcebindings)
+
+{{% expandlarge id="rep-group-edit-button-text" header="Eksempel: Styre redigeringsknapp-tekst i repeterende gruppe" %}}
+
+Her endrer vi teksten til redigeringsknappen i en repeterende gruppe basert på om `IsPrefill` er satt til `true` i
+en gitt adresse i datamodellen. Dersom `IsPrefill` er `true` for en adresse, vil raden som viser frem den adressen ha en
+redigerings-knapp med teksten `"View"`. Hvis `IsPrefill` er `false` blir teksten på knappen til den spesifikke raden
+`"Edit"`. Det er verdt å merke seg at dersom `IsPrefill` ikke er satt til hverken `true` eller `false` så vil uttrykket
+tolke verdien som `false`.
+
+```json
+{
+   "id": "repeatingAddressGroup",
+   "type": "Group",
+   "children": [
+      "field-id-one",
+      "field-id-two",
+   ],
+   "dataModelBindings": {
+      "group": "Citizen.FormerAdresses"
+   },
+   "maxCount": 10,
+   "textResourceBindings": {
+      "edit_button_open": [
+      "if",
+      [ "dataModel", "Citizen.FormerAdresses.IsPrefill" ],
+      "View",
+      "else",
+      "Edit"
+      ]
+   }
+}
+```
+
+{{% /expandlarge %}}
 
 ### Testing, feilsøking og utvikling av uttrykk
 


### PR DESCRIPTION
Update expressions docs with an example of controlling edit button text in repeating groups using expressions for textResourceBindings.

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
