### PR TITLE
Removing references to redux

### DIFF
--- a/content/app/development/data/options/_index.en.md
+++ b/content/app/development/data/options/_index.en.md
@@ -292,10 +292,10 @@ A use case here would typically be if the user fills out a repeating list of dat
 
 ### Configuration
 
-To set up options from redux we have set up a new property on `RadioButtons`, `Checkboxes`, and `Dropdown`-components called `source`.
+To set up options from the data model we have set up a new property on `RadioButtons`, `Checkboxes`, and `Dropdown`-components called `source`.
 This property contains the fields `group`, `label`, and `value`. Example:
 
-```json
+```json {hl_lines=["5-9"]}
       {
         "id": "dropdown-component-id",
         "type": "Dropdown",

--- a/content/app/development/data/options/_index.nb.md
+++ b/content/app/development/data/options/_index.nb.md
@@ -293,10 +293,10 @@ Et typisk bruksområde for dette er om brukeren fyller ut en liste med data som 
 
 ### Konfigurasjon
 
-For å sette opp options fra redux har vi laget en nytt objekt som kan brukes på komponentene `RadioButtons`, `Checkboxes` og `Dropdown` som vi har kalt `source`.
+For å sette opp options fra datamodellen har vi laget en nytt objekt som kan brukes på komponentene `RadioButtons`, `Checkboxes` og `Dropdown` som vi har kalt `source`.
 Dette nye objektet inneholder feltene `group`, `label` og `value`. Eksempel:
 
-```json
+```json {hl_lines=["5-9"]}
       {
         "id": "dropdown-component-id",
         "type": "Dropdown",

--- a/content/community/changelog/app-frontend/v3/whats-new/_index.en.md
+++ b/content/community/changelog/app-frontend/v3/whats-new/_index.en.md
@@ -75,8 +75,8 @@ The `width` attributte on `img` element can only be [a number that represents px
 The width declaration was moved to inline styling instead to resolve this issue.
 Issue [#14](https://github.com/Altinn/app-frontend-react/issues/14). 
 
-## 3.34.0 (2022-04-11) - Options from Redux
-Added possibility to setup options from repeating groupes in Redux. Read more on [docs.](/app/development/data/options/#options-based-on-repeating-groups-from-the-data-model)
+## 3.34.0 (2022-04-11) - Options from the data model
+Added possibility to setup options from repeating groups in the data model. Read more on [docs.](/app/development/data/options/#options-based-on-repeating-groups-from-the-data-model)
 Issue [#7626](https://github.com/Altinn/altinn-studio/issues/7626). 
 
 ## 3.33.5 (2022-04-11) - External dependency patching

--- a/content/community/changelog/app-frontend/v3/whats-new/_index.nb.md
+++ b/content/community/changelog/app-frontend/v3/whats-new/_index.nb.md
@@ -76,8 +76,8 @@ Issue [#11](https://github.com/Altinn/app-frontend-react/issues/11).
 Width deklarasjonen ble flyttet til inline styling for å løse problemet.
 Issue [#14](https://github.com/Altinn/app-frontend-react/issues/14). 
 
-## 3.34.0 (2022-04-11) - Options fra Redux
-La til støtte for å sette opp options (kodelister) fra repeterende grupper i Redux staten. Les mer på [docs.](/nb/app/development/data/options/#options-basert-på-repeterende-grupper-i-datamodellen)
+## 3.34.0 (2022-04-11) - Options fra datamodellen
+La til støtte for å sette opp options (kodelister) fra repeterende grupper i datamodellen. Les mer på [docs.](/nb/app/development/data/options/#options-basert-på-repeterende-grupper-i-datamodellen)
 Issue [#7626](https://github.com/Altinn/altinn-studio/issues/7626). 
 
 ## 3.33.5 (2022-04-11) - Oppdaterte ekstern avhengighet


### PR DESCRIPTION
## Description
Our documentation describes building options dynamically from the data model, but referred to redux (the react state library used _to store the data model_). This is a very technical (and irrelevant) detail in the documentation.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/530