### PR TITLE
Fikser active state bug i menyen

### DIFF
--- a/themes/hugo-theme-altinn/layouts/partials/header.html
+++ b/themes/hugo-theme-altinn/layouts/partials/header.html
@@ -48,7 +48,7 @@
       <div class="adocs-scrollcontainer">
         <div class="row">
             <div class="col-sm-12">
-              {{- partialCached "menu.html" . -}}
+              {{- partial "menu.html" . -}}
 
         <script>
           {{ template "activeMenus" dict "page" . "value" (printf "$(\"li.dd-item a[href='%s']\").parent().addClass(\"active\");" .RelPermalink) }}


### PR DESCRIPTION
[#612](https://github.com/Altinn/altinn-studio-docs/commit/eb425f199af0682a158bf424bbe68a2676442ecc#diff-457a6aeed5e65460e57e39c0b952970ed2572703857d63c16cb80a9fcee81280R51) introduserte en bug i active state i menyen da menu.html partial ble cachet, hvor tilstanden for hvilken side som er aktiv blir statisk. Det gjør at caret-ikonene i menyen rendres feil. Om man ser på f.eks. https://docs.altinn.studio/app/development/configuration/partytype/ vises "Authorization" som åpen, selv om vi står på siden Party types (🕺 ).

Denne PRen fikser bugen ved å ikke lenger cache menu-partial. Det vil muligens gjøre bygget treigere.