### PR TITLE
change to eformidling monitoring link

### DIFF
--- a/content/app/development/configuration/eformidling/_index.en.md
+++ b/content/app/development/configuration/eformidling/_index.en.md
@@ -317,8 +317,8 @@ However, invalid shipments, including but not limited to missing attachments or 
 vil cause the shipment to fail without explicit warning the end user or app owner.
 {{% /notice%}}
 
-The integration point exposes endpoints that allow you to monitor the status of a shipment. 
-`https://platform.altinn.no/eformidling/api/conversations?messageId={instanceGuid}`
+The integration point exposes endpoints that allow you to monitor the status of a shipment in the test environment. 
+`https://platform.tt02.altinn.no/eformidling/api/conversations?messageId={instanceGuid}`
 
 Replace `{instanceGuid}` with the guid of the instance that has been archived.
 


### PR DESCRIPTION
EFormidling monitor page link without tt02 is not functional, this proposed change assumes previous link was not used for monitoring shipments in prod. environment.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
https://docs.altinn.studio/app/development/configuration/eformidling/
changes to link given in documentation:
 `https://platform.altinn.no/eformidling/api/conversations?messageId={instanceGuid}` => `https://platform.tt02.altinn.no/eformidling/api/conversations?messageId={instanceGuid}`

## Verification
Docs