### PR TITLE
Correcting link for eformidling shipment monitor

### DIFF
--- a/content/app/development/configuration/eformidling/_index.nb.md
+++ b/content/app/development/configuration/eformidling/_index.nb.md
@@ -312,8 +312,8 @@ I tilfellet ugyldige forsendelser, herunder manglende vedlegg eller feil i arkiv
 vil forsendelsen feile uten eksplisitt varsling til sluttbruker eller tjenesteeier.
 {{% /notice%}}
 
-Integrasjonspunktet eksponerer endepunkter der man kan følge statusen for en forsendelse. 
-`https://platform.altinn.no/eformidling/api/conversations?messageId={instanceGuid}`
+Integrasjonspunktet eksponerer endepunkter der man kan følge statusen for en forsendelse i testmiljø (tt02). 
+`https://platform.tt02.altinn.no/eformidling/api/conversations?messageId={instanceGuid}`
 
 Bytt ut `{instanceGuid}` med guiden til instansen som er blitt innsendt.
 


### PR DESCRIPTION
Link changed to include tt02, explanation slightly more specific. 

Since appdevs don't have access to the equivalent for prod is not included
<!--- Provide a general summary of your changes in the Title above -->
