### PR TITLE
moving process templates to the docs repo

### DIFF
--- a/content/app/app-dev-course/modul5/_index.en.md
+++ b/content/app/app-dev-course/modul5/_index.en.md
@@ -30,11 +30,11 @@ The confirmation page is added automatically when the step is added to the BPMN 
 ![Updated process flow illsutrated](/app/app-dev-course/modul5/updated-process.png)
 
 {{% notice info %}}
-[Standard process flow is available on GitHub](https://github.com/Altinn/altinn-studio/tree/master/src/Altinn.Apps/AppTemplates/ProcessTemplates).
+[Standard process flow is available on GitHub](../../development/configuration/process).
 Can you find the one that matches the flow we wish to achieve here?
 
 If you want an extra challenge, you can edit the process flow manually or in a BPMN editor,
-and rather use [the template on process flow with data and confirmation step](https://raw.githubusercontent.com/Altinn/altinn-studio/master/src/Altinn.Apps/AppTemplates/ProcessTemplates/Data_Confirmation_Process.bpmn) as a solution.
+and rather use [the template on process flow with data and confirmation step](../../development/configuration/process/Data_Confirmation_Process.bpmn) as a solution.
 {{% /notice %}} 
 
 ### Requirements from the municipality

--- a/content/app/app-dev-course/modul5/_index.nb.md
+++ b/content/app/app-dev-course/modul5/_index.nb.md
@@ -30,11 +30,11 @@ Bekreftelsessiden blir lagt til automatisk når man legger til dette i BPMN-file
 ![Oppdatert prosessflyt illustrert](/app/app-dev-course/modul5/updated-process.png)
 
 {{% notice info %}}
-[Standard prosessflyter er tilgjengelige på GitHub](https://github.com/Altinn/altinn-studio/tree/master/src/Altinn.Apps/AppTemplates/ProcessTemplates).
+[Standard prosessflyter er tilgjengelige på GitHub](../../development/configuration/process).
 Finner du den som passer til flyten vi ønsker å oppnå her?
 
 Har du lyst på en ekstra utfordring, kan du redigere prosessflyten manuelt eller i et BPMN-redigeringsverktøy,
-og heller bruke [malen på prosessflyt med data og bekreftelsessteg](https://raw.githubusercontent.com/Altinn/altinn-studio/master/src/Altinn.Apps/AppTemplates/ProcessTemplates/Data_Confirmation_Process.bpmn) som fasit.
+og heller bruke [malen på prosessflyt med data og bekreftelsessteg](../../development/configuration/process/Data_Confirmation_Process.bpmn) som fasit.
 {{% /notice %}}
 
 ### Krav fra kommunen

--- a/content/app/development/configuration/process/Data_Confirmation_Process.bpmn
+++ b/content/app/development/configuration/process/Data_Confirmation_Process.bpmn
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions id="Altinn_Data_Confirmation_Process_Definition"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:altinn="http://altinn.no"
+  xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+  targetNamespace="http://bpmn.io/schema/bpmn" >
+  <bpmn2:process id="Altinn_Data_Confirmation_Process" isExecutable="false">
+    <bpmn2:startEvent id="StartEvent_1">
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:task id="Task_1" name="Fyll ut skjema" altinn:tasktype="data">
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+    </bpmn2:task>
+    <bpmn2:task id="Task_2" name="Bekreft skjemadata" altinn:tasktype="confirmation">
+      <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
+    </bpmn2:task>
+    <bpmn2:endEvent id="EndEvent_1">
+      <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn2:sequenceFlow id="SequenceFlow_2" sourceRef="Task_1" targetRef="Task_2" />
+    <bpmn2:sequenceFlow id="SequenceFlow_3" sourceRef="Task_2" targetRef="EndEvent_1" />
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+      <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Altinn_Data_Confirmation_Process">
+          <bpmndi:BPMNShape bpmnElement="StartEvent_1" id="_BPMNShape_StartEvent_2">
+              <dc:Bounds x="546" y="55" width="36" height="36"/>
+          </bpmndi:BPMNShape>
+          <bpmndi:BPMNShape bpmnElement="EndEvent_1" id="EndEvent_1_di">
+              <dc:Bounds x="546" y="686" width="36" height="36"/>
+          </bpmndi:BPMNShape>
+          <bpmndi:BPMNShape bpmnElement="Task_1" id="Task_1_di">
+              <dc:Bounds x="514" y="121" width="100" height="80"/>
+          </bpmndi:BPMNShape>
+          <bpmndi:BPMNShape bpmnElement="Task_2" id="Task_2_di">
+              <dc:Bounds x="514" y="353" width="100" height="80"/>
+          </bpmndi:BPMNShape>
+          <bpmndi:BPMNEdge bpmnElement="SequenceFlow_1" id="SequenceFlow_1_di">
+              <di:waypoint x="564" y="91"/>
+              <di:waypoint x="564" y="121"/>
+          </bpmndi:BPMNEdge>
+          <bpmndi:BPMNEdge bpmnElement="SequenceFlow_2" id="SequenceFlow_2_di">
+              <di:waypoint x="564" y="201"/>
+              <di:waypoint x="564" y="353"/>
+          </bpmndi:BPMNEdge>
+          <bpmndi:BPMNEdge bpmnElement="SequenceFlow_3" id="SequenceFlow_3_di">
+              <di:waypoint x="564" y="433"/>
+              <di:waypoint x="564" y="686"/>
+          </bpmndi:BPMNEdge>
+      </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/content/app/development/configuration/process/Data_Data_Data_Process.bpmn
+++ b/content/app/development/configuration/process/Data_Data_Data_Process.bpmn
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions id="Altinn_Data_Data_Data_Process_Definition"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:altinn="http://altinn.no"
+  xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd"
+  targetNamespace="http://bpmn.io/schema/bpmn" >
+  <bpmn2:process id="Altinn_Data_Data_Data_Process" isExecutable="false">
+    <bpmn2:startEvent id="StartEvent_1">
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:task id="Task_1" name="Fyll ut skjema 1" altinn:tasktype="data">
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+    </bpmn2:task>
+    <bpmn2:task id="Task_2" name="Fyll ut skjema 2" altinn:tasktype="data">
+      <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_3</bpmn2:outgoing>
+    </bpmn2:task>
+	<bpmn2:task id="Task_3" name="Fyll ut skjema 3" altinn:tasktype="data">
+      <bpmn2:incoming>SequenceFlow_3</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_4</bpmn2:outgoing>
+    </bpmn2:task>
+    <bpmn2:endEvent id="EndEvent_1">
+      <bpmn2:incoming>SequenceFlow_4</bpmn2:incoming>
+    </bpmn2:endEvent>
+
+    <bpmn2:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+    <bpmn2:sequenceFlow id="SequenceFlow_2" sourceRef="Task_1" targetRef="Task_2" />
+    <bpmn2:sequenceFlow id="SequenceFlow_3" sourceRef="Task_2" targetRef="Task_3" />
+    <bpmn2:sequenceFlow id="SequenceFlow_4" sourceRef="Task_3" targetRef="EndEvent_1" />
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ltinn_Data_Data_Data_Process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="186" y="55" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="186" y="686" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+        <dc:Bounds x="154" y="121" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_2_di" bpmnElement="Task_2">
+        <dc:Bounds x="154" y="353" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="204" y="91" />
+        <di:waypoint x="204" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
+        <di:waypoint x="204" y="201" />
+        <di:waypoint x="204" y="353" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_3_di" bpmnElement="SequenceFlow_3">
+        <di:waypoint x="204" y="433" />
+        <di:waypoint x="204" y="510" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Task_3_di" bpmnElement="Task_3">
+        <dc:Bounds x="154" y="510" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_4_di" bpmnElement="SequenceFlow_4">
+        <di:waypoint x="204" y="590" />
+        <di:waypoint x="204" y="686" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/content/app/development/configuration/process/Data_Process.bpmn
+++ b/content/app/development/configuration/process/Data_Process.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions id="Altinn_Data_Process_Definition"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xmlns:altinn="http://altinn.no"
+xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+targetNamespace="http://bpmn.io/schema/bpmn" >
+	<bpmn:process id="Altinn_Data_Process" isExecutable="false">
+		<bpmn:startEvent id="StartEvent_1">
+			<bpmn:outgoing>SequenceFlow_1</bpmn:outgoing>
+		</bpmn:startEvent>
+		<bpmn:task id="Task_1" name="Fyll ut skjema" altinn:tasktype="data">
+			<bpmn:incoming>SequenceFlow_1</bpmn:incoming>
+			<bpmn:outgoing>SequenceFlow_2</bpmn:outgoing>
+		</bpmn:task>
+		<bpmn:endEvent id="EndEvent_1">
+			<bpmn:incoming>SequenceFlow_2</bpmn:incoming>
+		</bpmn:endEvent>
+		<bpmn:sequenceFlow id="SequenceFlow_1" sourceRef="StartEvent_1" targetRef="Task_1" />
+		<bpmn:sequenceFlow id="SequenceFlow_2" sourceRef="Task_1" targetRef="EndEvent_1" />
+	</bpmn:process>
+	<bpmndi:BPMNDiagram id="BPMNDiagram_1">
+		<bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Altinn_Data_Process">
+			<bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+				<dc:Bounds x="156" y="81" width="36" height="36" />
+			</bpmndi:BPMNShape>
+			<bpmndi:BPMNShape id="Task_1_di" bpmnElement="Task_1">
+				<dc:Bounds x="300" y="59" width="100" height="80" />
+			</bpmndi:BPMNShape>
+			<bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+				<dc:Bounds x="512" y="81" width="36" height="36" />
+			</bpmndi:BPMNShape>
+			<bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+				<di:waypoint x="192" y="99" />
+				<di:waypoint x="300" y="99" />
+			</bpmndi:BPMNEdge>
+			<bpmndi:BPMNEdge id="SequenceFlow_2_di" bpmnElement="SequenceFlow_2">
+				<di:waypoint x="400" y="99" />
+				<di:waypoint x="512" y="99" />
+			</bpmndi:BPMNEdge>
+		</bpmndi:BPMNPlane>
+	</bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/content/app/development/configuration/process/_index.en.md
+++ b/content/app/development/configuration/process/_index.en.md
@@ -29,4 +29,10 @@ The current application template supports the following tasks:
 To change the process, you can manually edit the BPMN file with an text, XML or BPMN editor.
 It is stored in the app repo as `App/config/process/process.bpmn`.
 
+## Example Process Files
+
+* [Data_Confirmation_Process.bpmn](Data_Confirmation_Process.bpmn)
+* [Data_Data_Data_Process.bpmn](Data_Data_Data_Process.bpmn)
+* [Data_Process.bpmn](Data_Process.bpmn)
+
 {{<children>}}

--- a/content/app/development/configuration/process/_index.nb.md
+++ b/content/app/development/configuration/process/_index.nb.md
@@ -29,4 +29,10 @@ Nåværende applikasjonsmal støtter følgende tasks.
 For å endre på prosessen kan du manuelt redigere BPMN-filen med en valgfri XML- eller BPMN-editor.
 Den ligger lagret i app-repoet som `App/config/process/process.bpmn`.
 
+## Eksempler på process-filer
+
+* [Data_Confirmation_Process.bpmn](Data_Confirmation_Process.bpmn)
+* [Data_Data_Data_Process.bpmn](Data_Data_Data_Process.bpmn)
+* [Data_Process.bpmn](Data_Process.bpmn)
+
 {{<children>}}

--- a/content/technology/architecture/capabilities/runtime/processing/process/_index.md
+++ b/content/technology/architecture/capabilities/runtime/processing/process/_index.md
@@ -11,14 +11,14 @@ Apps created in Altinn Studio uses [BPMN 2.0 standard](https://www.omg.org/spec/
 to support different types of tasks in the process.
 
 The process is defined by the application developer in Altinn Studio.
-When a new app is created it a [basic process](https://github.com/Altinn/altinn-studio/blob/master/src/Altinn.Apps/AppTemplates/AspNet/App/config/process/process.bpmn) is created. 
+When a new app is created it a [basic process](https://github.com/Altinn/app-template-dotnet/blob/78416b72e230c37a7f55ff9c6251383a9b26a22b/src/App/config/process/process.bpmn) is created. 
 
 ## Supported Tasks
 Applications will support different processes with different types of task as part of the process.
 The current types of tasks is implemented and planned to be implemented. This list is not final.
 
 ### Data
-This is the task where the user or system create and updates data for one more datamodelles defined for the App.
+This is the task where the user or system create and updates data for one more data models defined for the App.
 
 ### Confirmation (backlog)
 This is a task where user can look at the data filled and then confirm it.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The process example files was a bit mal placed in the `altinn-studio` after we deceided to split the repo. These files is just used in this documentation, so we rather just place them here.

![image](https://user-images.githubusercontent.com/589907/215718265-23afdc8b-7af4-470b-a0b9-a0b6569938bf.png)


## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
