### PR TITLE
Update Tracks doc for v6 and 7.

### DIFF
--- a/content/app/development/ux/pages/tracks/_index.en.md
+++ b/content/app/development/ux/pages/tracks/_index.en.md
@@ -150,7 +150,7 @@ To overrule default dynamic tracks, two changes must be made.
     ```
 2. Register you custom implementation in the _Program.cs_ class     
     ```C#
-    services.AddTransient<IPageOrder, PageOrder>();
+    services.AddTransient<IPageOrder, CustomOrder>();
     ```
     This ensuers your custom code is known to the application and that it will be executed.
 

--- a/content/app/development/ux/pages/tracks/_index.nb.md
+++ b/content/app/development/ux/pages/tracks/_index.nb.md
@@ -149,9 +149,9 @@ For å overstyre standard sporvalg må det gjøres to endringer.
 
     }
     ```
-2. Registrer din implementering i _Startup.cs_ eller _Program.cs_ klassen (.Net 6)
+2. Registrer din implementering i _Program.cs_ klassen (.Net 6)
     ```C#
-    services.AddTransient<IPageOrder, PageOrder>();
+    services.AddTransient<IPageOrder, CustomOrder>();
     ```
     Dette sørger for at din kode er kjent for applikasjonen og at koden blir kjørt når den skal.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Startup.cs was removed from v6. 

AddTransient<IPageOrder, CustomOrder>(); is correct since the class in step 1 is CustomOrder : IPageOrder

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
