### PR TITLE
Fixed spelling and improved grammar of English dev course docs.

### DIFF
--- a/content/app/app-dev-course/case/_index.en.md
+++ b/content/app/app-dev-course/case/_index.en.md
@@ -1,15 +1,15 @@
 ---
 title: Case description
-description: Description of the municipalitys requirements and wishes for the service.
+description: Description of the municipality's requirements and wishes for the service.
 linktitle: Case
 tags: [apps, case, training]
 weight: 10
 ---
 Sogndal is in need of more young residents and wishes to become a desirable 
-municipality for young adults and others who wishes to settle down.
+municipality for young adults and others who wish to settle down.
 
 That is why they wish to create a service in Altinn aimed at people 
-who is moving to Sogndal over the next six months.
+who are moving to Sogndal over the next six months.
 
 By collecting data about newcomers at an early point, the municipality may facilitate 
 and customize the services to the newcomers before the first moving box has even been packed.
@@ -24,7 +24,7 @@ Sogndal has a few requirements for the services described in the sections below.
 - The application must have a sensible name that makes it easy to find it again among the large number
 of repositories, Sogndal keeps in Altinn Studio.
 
-- There are no preliminary plans for yearly revisions of the app,
+- There are currently no plans for yearly revisions of the app,
 so the year does not need to be taken into account.
 
 There is a wish that one or more of the words "newcomer" and "Sogndal" is included in the name.
@@ -35,9 +35,9 @@ There is a wish that one or more of the words "newcomer" and "Sogndal" is includ
 {{% expandlarge id="first-page-datacollecting-expandable" header="Requirements" %}}
 
 - Name and age of the person who is a newcomer
-  - Firstname
-  - Middlename (optional)
-  - Lastname
+  - First name  
+  - Middle name (optional)
+  - Last name
   - Age
 - Address of the person who is a newcomer
   - Street address
@@ -54,7 +54,7 @@ There is a wish that one or more of the words "newcomer" and "Sogndal" is includ
 
 - All input fields should have descriptive labels that clarify what should be filled in.
 - The application must be available in bokmål, nynorsk and english.
-  In a first edition it is sufficient that only one of these languages is available.
+  For the first edition it is sufficient that only one of these languages is available.
 - It is important that the title of the application sounds good and is descriptive of the service.
 
 {{% /expandlarge %}}
@@ -81,9 +81,9 @@ The following is desirable to be similar in the application:
 
 A user who does not meet the requirements for the form should be stopped as early as possible in the process.
 
-On the information page, the user should be able to state whether the form applies to them or not.
+On the information page the user should be able to select whether or not the form applies to them.
 
-How this is done is optional, and the field `Innflytter.KanBrukeSkjema` in the datamodel is possible to use for this purpose.
+How this is done is optional, the field `Innflytter.KanBrukeSkjema` in the datamodel can be used for this purpose.
 
 Based on the answer, the user will be sent to either _Track 1_ or _Track 2_.
 
@@ -115,7 +115,7 @@ Based on the answer, the user will be sent to either _Track 1_ or _Track 2_.
   - Email: Innflytter.Kontaktinformasjon.Epost
   - Phone number: Innflytter.Kontaktinformasjon.Telefonnummer
   - Age: Innflytter.Alder
-- It should **not** be possible to change the prefilled name and age
+- It should **not** be possible to change any of the prefilled names and the age
 - It should be possible to change the prefilled email and phone number
 
 {{% /expandlarge %}}
@@ -215,10 +215,10 @@ Du er ikke velkommen til vår kommune. Beklager!
 ### Data processing of invalid street address
 {{% expandlarge id="dataprocessing-expandable" header="Requirements" %}}
 
-One of the data processors of Sogndal is sick of manually correcting a street address that often is being incorrectly entered by newcomers.
-Therefore, we wish to programmatic correct this while the user is filling out the app.
+There is an address in Sogndal which is often misspelled by newcomers which leads to case workers having to spend a lot of time manually correcting it.
+Therefore, we want the app to automatically fix this mistake when the misspelled address is detected.
 
-If the user enters `Sesame Street 1` in the field `Innflytter.Adresse.Gateadresse`, this should automatically be corrected to `Sesamsgate 1`.
-In all other cases, the field should remain the same.
+If the user enters `Sesame Street 1` in the field `Innflytter.Adresse.Gateadresse`, it should automatically be corrected to `Sesamsgate 1`.
+For all other addresses the field should remain the same.
 
 {{% /expandlarge %}}

--- a/content/app/app-dev-course/modul1/_index.en.md
+++ b/content/app/app-dev-course/modul1/_index.en.md
@@ -7,7 +7,7 @@ weight: 20
 ---
 
 In this module you will, based on the requirements of the municipality of Sogndal,
-be setting up the first page of your application for newcomers and verify that everything looks as expected locally.
+set up the first page of your application for newcomers and verify that everything looks as expected locally.
 
 **Topics covered in this module:**
 
@@ -15,22 +15,22 @@ be setting up the first page of your application for newcomers and verify that e
 - Add data model and connect fields
 - Develop app in local developing environment
 - Editing of text resources
-- Test application in local developement environment (LocalTest)
+- Test application in local development environment (LocalTest)
 
 ## Tasks
 
 {{% expandlarge id="create-new-application" header="Create new application" %}}
 
-Create the application in Altinn Studio with the organization that you have access to as an owner.
-Alternatively, you can create the application with you as the owner, if you are not testing it in a test environment.
+Create a new application in Altinn Studio, the owner should be an organization that you have access to.
+If you are only running the application locally you can set yourself as the owner.
 
 ### Requirements from the municipality
 
 - The application must have a sensible name that makes it easy to find it again among the large number
 of repositories Sogndal keeps in Altinn Studio.
 
-- There are no preliminary plans for yearly revisions of the app,
-so the year does not need to be taken into account.
+- There are currently no plans for yearly revisions of the app,
+  so the year does not need to be taken into account.
 
 There is a wish that one or more of the words "newcomer" and "Sogndal" is included in the name.
 
@@ -42,13 +42,13 @@ There is a wish that one or more of the words "newcomer" and "Sogndal" is includ
 
 {{% expandlarge id="upload-datamodel" header="Upload data model" %}}
 The municipality of Sogndal has created [a data model](/app/app-dev-course/modul1/datamodel.xsd)
-that represents data they wish to collect from future residents.
+representing data they wish to collect from future residents.
 
 {{% notice info %}}
-As an app developer you will in some cases have to create a data model 
-for a service yourself. You will then be able to use the data modelling tool in 
-Altinn Studio (launching Spring 2022), or use an existing data model as a starting point and 
-edit it in for example Visual Studio or a text editing program of your own choosing.
+In some cases you might have to create the data model 
+for a service yourself. This can be done by using the data modelling tool in 
+Altinn Studio (launching Spring 2022), or by using an existing model as a starting point and 
+editing it using a text editor.
 {{% /notice %}}
 
 
@@ -65,8 +65,8 @@ edit it in for example Visual Studio or a text editing program of your own choos
 - Which data is it the service owner wishes to collect here?
 - Which effect has **\<minOccurs\>** in the data model? You may notice that the field has a different value for _Innflytter.Fornavn_ and _Innflytter.Mellomnavn_.
 - Which other properties is set on the field _Innflytter.Mellomnavn_?
-- A _.C#_, _.metadata.json_ and _.schema.json_ file has been generated in addition to the _.xsd_ file you uploaded. What is the correlation between these files?
-- Some restrictions from the data model is not transferred to the _C#_-file, which ones? Some new properties has also been added, which ones?
+- A _.cs_, _.metadata.json_ and _.schema.json_ file has been generated in addition to the _.xsd_ file you uploaded. What is the correlation between these files?
+- Some restrictions from the data model are not transferred to the _C#_-file, which ones? Some new properties have also been added, which ones?
 
 ### Useful documentation
 - [Upload data model in Altinn Studio](/app/development/data/data-model/data-models-tool/#laste-opp--vise-datamodell)
@@ -89,7 +89,7 @@ It is possible to connect texts to components in both Altinn Studio and locally.
 
 ### Requirements from the municipality
 
-- All inputfields should have descriptive labels that clarifies what should be filled in.
+- All input fields should have descriptive labels that clarifies what should be filled in.
 - The application must be available in bokmål, nynorsk and english.
   In a first edition it is sufficient that only one of these languages is available.
 - It is important that the display name of the application sounds good and is descriptive of the service.
@@ -119,9 +119,9 @@ Based on the requirements from the municipality, can you now set up the first fo
 ### Requirments from the municipality
 
 - Name and age of the person who is a newcomer
-  - Firstname
-  - Middlename (optional)
-  - Lastname
+  - First name
+  - Middle name (optional)
+  - Last name
   - Age
 - Address of the person who is a newcomer
   - Street address
@@ -201,6 +201,6 @@ The service should be able to run on your local computer with LocalTest and you 
 **Remember to _push_ your local changes to make them available in Altinn Studio when you are happy with them.**
 
 ### Solution
-If you have not completed all the steps, we have an [example of a solution](https://altinn.studio/repos/ttd/tilflytter-sogndal-lf/src/branch/bolk/1) that you can use as inspiration.
+If you have not completed all the steps, we have an [example solution](https://altinn.studio/repos/ttd/tilflytter-sogndal-lf/src/branch/bolk/1) that you can use as inspiration.
 
 ![Screenshot of data collecting page](/app/app-dev-course/modul1/data-screenshot.png "Screenshot of data collecting page")

--- a/content/app/app-dev-course/modul2/_index.en.md
+++ b/content/app/app-dev-course/modul2/_index.en.md
@@ -52,7 +52,7 @@ Someone in the municipality has created a sketch of the informationpage.
 The following is desirable to be similar in the application:
  - Placing of pictures
  - Text size
- - Formating of text
+ - Formatting of text
 
 [Sketch of information page](/app/app-dev-course/modul2/infoside_tilflyttere.pdf)
 
@@ -62,20 +62,21 @@ The following is desirable to be similar in the application:
 
 - [Formatting of texts](/app/development/ux/texts/#formatting-of-texts)
 - [Add pictures to the application](/app/development/ux/images/#add-images-to-the-application)
-- [Set components side by side](/app/development/ux/styling/#components-placed-side-by-side-grid)
-- [File setup with multiple pages](/app/development/ux/pages/#setup)
-- [Administrate order of muntliple pages](/app/development/ux/pages/navigation/#order)
+- [Use of grid to control layout of components](/app/development/ux/styling/#components-placed-side-by-side-grid)
+- [Project structure when using multiple pages](/app/development/ux/pages/#setup)
+- [Change order of pages based on some condition](/app/development/ux/pages/tracks/#trigger-calculation-on-tracks-from-frontend)
 
 ### Knowledge check
 - Which file in the application repository has to be adjusted if you wish to manually change the page order of existing pages?
-- If you wish to rename a page, but Altinn Studio is not available, which files will need to be updated?
+- How can you rename a page without using Altinn Studio?
 - How can you get a text to break if the text string is not long enough to break naturally?
 {{% /expandlarge %}}
 
 
 {{% expandlarge id="dynamic-tracks" header="Alternate workflow" %}}
 
-In many cases, it is not relevant to answer all questions in a form, maybe because the answer is obvious or because it is not relevant based on an answer provided earlier in the form. In that case, dynamic tracks could be a good solution.
+In many cases, it is not relevant to answer all questions in a form, maybe because the answer is obvious or because it is not relevant based on an answer provided earlier in the form.
+In that case, dynamic tracks could be a good solution.
 
 By using dynamic tracks you will be able to control which parts of the application that will be visible for the user.
 
@@ -89,7 +90,7 @@ A user who does not meet the requirements for the form should be stopped as earl
 
 On the information page, the user should be able to state whether the form applies to them or not.
 
-How this is done is optional, and the field `Innflytter.KanBrukeSkjema` in the data model is possible to use for this purpose.
+How this is done is optional, the field `Innflytter.KanBrukeSkjema` in the data model can be used for this purpose.
 
 Based on the answer, the user will be sent to either _Track 1_ or _Track 2_.
 
@@ -119,18 +120,21 @@ https://www.sogndal.kommune.no/
 - [Formatting of texts](/app/development/ux/texts/#formatting-of-texts)
 
 ### Knowledge check
-- If a user goes back and changes their answer on the info page, will they then be displayed the data collecting pages?
-- If dynamic tracks is implemented further into the workflow and a user changes a choice, what will happen with the form data that was filled out prior to this, if the page is now hidden from the user?
+- If a user goes back and changes their answer on the info page, will they see the data collecting pages?
+- If dynamic tracks are implemented further along in the workflow and a user changes a choice, what will happen with the form data that was filled out prior to this, if the page is now hidden from the user?
 {{% /expandlarge %}}
 
 
 {{% expandlarge id="prefill-expandable" header="Prefill of personal information" %}}
 
-One of the benefits of Altinn is that you already have metadata containing information about both people and businesses available. By using prefill you can access data about the user and present this in an app, so that they will not have to fill out these fields. Typical prefill values are: name, address, email, etc.
+One of the benefits provided by Altinn is that metadata containing information about both people and businesses is already available available.
+By using prefill you can access data about the user and present this in an app, so that they will not have to fill out these fields.
+Typical prefill values are: name, address, email, etc.
 
-If the data is available in one of Altinn's prefill sources, this can be configured towards a field in the data model and be automatically populated once the form is created. If there are other uses for prefill, this can be solved using code in the application.
+Data that is available in one of Altinn's prefill sources can be mapped to a field in the data model and will be automatically set once the form is created.
+Other prefill sources can be configured and mapped to the data model through custom integrations.
 
-In this task, the focus has returned to the first data collecting page, and the goal is to prefill personal information about the user to save the user some time.
+The goal of this task is to prefill the user's personal information on the first page so that the user does not have to do this themselves.
 
 ### Requirements from the municipality
 
@@ -149,13 +153,13 @@ In this task, the focus has returned to the first data collecting page, and the 
 - [Available prefill sources](https://altinncdn.no/schemas/json/prefill/prefill.schema.v1.json)
 - [Prefill from national register and user profile](/app/development/data/prefill/config/)  
 - [Custom prefill](/app/development/data/prefill/custom)
-- [Description of the InstanceOwner object](../../../api/models/instance/#instanceowner) - This is where the social security number can be found.
+- [Description of the InstanceOwner object](../../../api/models/instance/#instanceowner) - This is where national identity number can be found.
   In the code, the properties are referred to with an uppercase first letter, not lowercase as in this overview.
 
-### Help with code: Calculating age from social security number
-This function calculates the age from the social security number. It is important to add `using System;` to the top of the file in order to make it work.
+### Help with code: Calculating age from national identity number
+This function calculates the age from the national identity number. It is important to add `using System;` to the top of the file in order to make it work.
 ```cs
-private static int CalculateAge(string sosialSecNumber)
+private static int CalculateAge(string nationalIDNum)
 {
     int MAX_D_NUMBER = 71;
     int MIN_D_NUMBER = 41;
@@ -163,10 +167,10 @@ private static int CalculateAge(string sosialSecNumber)
     int MIN_TEST_NUMBER = 81;
     int START_D_NUMBER = 40;
     int START_TEST_NUMBER = 80;
-    string stringDay = sosialSecNumber.Substring(0, 2);
-    string stringMonth = sosialSecNumber.Substring(2, 2);
-    string stringYear = sosialSecNumber.Substring(4, 2);
-    string stringIndivid = sosialSecNumber.Substring(6, 3);
+    string stringDay = nationalIDNum.Substring(0, 2);
+    string stringMonth = nationalIDNum.Substring(2, 2);
+    string stringYear = nationalIDNum.Substring(4, 2);
+    string stringIndivid = nationalIDNum.Substring(6, 3);
     int day = int.Parse(stringDay);
     int month = int.Parse(stringMonth);
     int year = int.Parse(stringYear);
@@ -221,8 +225,8 @@ private static int CalculateAge(string sosialSecNumber)
 ### Knowledge check
 - Is it possible to change a prefilled value once it is set?
 - How can you prevent a user from changing a prefilled value?
-- Not all norwegian citizens have a social security number,
-  some get assigned a [D-number](https://jusleksikon.no/wiki/F%C3%B8dselsnummer#D-nummer). How will you have to adjust your code to take this into account if for example age is based on a F-number or D-number that the user themselves enter?
+- Not all Norwegian citizens have a national identity number,
+  some get assigned a [D-number](https://jusleksikon.no/wiki/F%C3%B8dselsnummer#D-nummer). How will you have to adjust your code to take this into account if, for example, age is based on an F-number or D-number that the user themselves enter?
 {{% /expandlarge %}}
 
 
@@ -232,15 +236,14 @@ In this module you have expanded your application with more functionality in the
 adding more pages, configuring dynamic tracks to control user flow and setting up prefill of fields
 both with available data sources in Altinn and custom code.
 
-The service should run on your local computer with local test and you should be able to test both user flows
-and confirm that the right fields are prefilled.
+The service should run on your local computer with local test and you should be able to test both user flows and confirm that the right fields are prefilled.
 
 **Remember to _push_ your local changes, so that they are available in Altinn Studio when you're happy with them**
 
 ### Solution
-If you did not manage to complete all the steps, we have an [example of a solution](https://altinn.studio/repos/ttd/tilflytter-sogndal-lf/src/branch/bolk/2) that you can use as inspiration.
+If you did not manage to complete all the steps, we have an [example solution](https://altinn.studio/repos/ttd/tilflytter-sogndal-lf/src/branch/bolk/2) that you can use as inspiration.
 
-![Screenshot of info page](/app/app-dev-course/modul2/infopage-screenshot.png "Screen shot of info page")
+![Screenshot of info page](/app/app-dev-course/modul2/infopage-screenshot.png "Screenshot of info page")
 
 ![Screenshot of prefilled data collecting page](/app/app-dev-course/modul2/data-screenshot.png "Screenshot of prefilled data collecting page")
 

--- a/content/app/app-dev-course/modul3/_index.en.md
+++ b/content/app/app-dev-course/modul3/_index.en.md
@@ -10,7 +10,7 @@ weight: 20
 {{% /notice %}}
 
 
-In this module you are going to build and deploy the application to Altinns test environment (TT02) and verify that everything works as expected.
+In this module you are going to build and deploy the application to Altinn's test environment (TT02) and verify that everything works as expected.
 
 
 **Topics covered in this module:**
@@ -66,9 +66,8 @@ and add a descriptive comment of what the version includes.
 
 {{% expandlarge id="deploy-application" header="Deploy application" %}}
 
-By deploying an application to a test environment you will be able to test all integrations.
-In addition to this, TT02 is often used to verify an application is behaving as expected
-before deploying to production.
+Deploying an application to the test environment allows you to test all integrations.
+In addition to this, TT02 is often used to verify that an application works as expected before deploying to production.
 
 {{% notice info %}}
 To be able to deploy an application to TT02,
@@ -85,7 +84,7 @@ for the organization in Altinn Studio.
 
 ### Knowledge check
 - Is it possible to have two versions of one application in TT02 at the same time?
-- What happens if you deploy the same version of the application to the environment once more?
+- What happens if you try to deploy your application using an existing version number?
 - Will the application be available immediately after deployment?
 - Is it possible to remove an application from the environment after deployment?
 {{% /expandlarge %}}
@@ -96,11 +95,10 @@ At the deployment page you will find the direct link to your application.
 It is in the format _{org}.apps.tt02.altinn.no/{org}/{app}_
 
 
-Unless you're already logged in with a user,
-this link will bring you to Altinn's login page.
+Unless you're already logged in with a user this link will bring you to Altinn's login page.
 Your organization should have access to a set of test users, use one of these to log in.
 
-For internal people in Digdir: Use one of the test users you can find in [the test data set](https://pedia.altinn.cloud/testing/testdata/datasets/) and log in.
+Internal users in Digdir should use one of the test users found in [the test data set](https://pedia.altinn.cloud/testing/testdata/datasets/).
 
 **Test the different tracks and pages to confirm that the behaviour is as expected.**
 
@@ -108,9 +106,8 @@ For internal people in Digdir: Use one of the test users you can find in [the te
 
 ## Summary
 
-In this module you have built and deployed your application to TT02,
-logged into Altinn with a test user and testet your application.
+In this module you have built and deployed your application to TT02, logged into Altinn with a test user and tested your application.
 
 ### Solution
 
-If you did not manage to complete all the steps, we have an [example of a solution](https://altinn.studio/repos/ttd/tilflytter-sogndal-lf/src/branch/bolk/3) that you can use as inspiration.
+If you did not manage to complete all the steps, we have an [example solution](https://altinn.studio/repos/ttd/tilflytter-sogndal-lf/src/branch/bolk/3) that you can use as inspiration.

--- a/content/app/app-dev-course/modul4/_index.en.md
+++ b/content/app/app-dev-course/modul4/_index.en.md
@@ -6,7 +6,7 @@ tags: [apps, training, options, code lists, dynamics ]
 weight: 20
 ---
 
-In this module you're expanding the application you made in the previous modules to support even more of the [requirements of the municipality of Sogndal](../case/#requirements-from-the-municipality).
+In this module you're expanding the application you made in the previous modules to support more of the [requirements of the municipality of Sogndal](../case/#requirements-from-the-municipality).
 
 **Topics covered in this module:**
 
@@ -27,9 +27,8 @@ There are three ways to set up code lists in Altinn today
 
 1. Directly on the component through Altinn Studio or manually in _FormLayout.json_\*
 2. In a static json-file referred to in the component
-3. Programmatic in the application logic
+3. Programmatically through application logic (only available for radio buttons and check boxes)
 
-   \* only available on radio buttons and check boxes
 {{% /notice %}}
 
 In this task, you will get to try out all three ways to set up a code list.
@@ -41,7 +40,7 @@ The municipality of Sogndal wishes to collect information on the newcomers worki
 ### In Altinn Studio
 
   1. Create a new form page to collect data about working conditions
-  2. Set up a **radio button** component for _Sector_. Create the answer options `Offentlig` and `private` manually.
+  2. Set up a **radio button** component for _Sector_. Create the answer options `Offentlig` and `Privat` manually.
   3. Set up a **check box** component for _Industry_.
      Choose _Kodeliste_ as method for adding checkboxes and add _Kodeliste ID_ `industry`
 
@@ -86,14 +85,11 @@ The municipality of Sogndal wishes to collect information on the newcomers worki
 
 In some cases the values displayed in a code list may be attached to a different field in the form.
 
-The municipality of Sogndal wishes that the list of industries to choose from is personalised to what sector you work in.
-
-Read through the requirements from the municipality to see if you can help them.
+The municipality of Sogndal wants the list of industries to choose from to be personalised based on which sector the user works in.
 
 ### Requirements from the municipality
 
-We want the user to be presented with a different set of options for the industry choice
-based on which sector they are in.
+We want the user to be presented with a different set of options for the industry choice based on which sector they work in.
 
 - Private sector: [Standard list of industries](../industry.json)
 - Public sector: `State` and `Municipality`
@@ -124,14 +120,14 @@ If the user chooses `IKT (data/it)` under industry, a text with a link to our ov
 - Line 2 in the text should be a link that directs to: 
 https://sogndal.easycruit.com/index.html
 
-The text and link should **only** be visible if the user has chosen `IKT (data/it)`. In all other cases this will be hidden.
+The text and link should **only** be visible if the user has chosen `IKT (data/it)`.
 
 ### Useful documentation
 - [Add functions for dynamics](/app/development/logic/dynamic/#add-or-edit-functions-for-dynamics)
 - [Examples of use of dynamic in form](/app/development/logic/dynamic/#example-usage-of-dynamics-on-an-app)
 
 ### Knowledge check
-- If you add a new function to `RuleHandlerHelper` - where will these functions run?
+- If you add a new function to `RuleHandlerHelper` - where will it run?
   - Would dynamic work without this defined?
 - What is the correlation between functions defined in `RuleHandlerObject` and the file `RuleConfiguration.json`?
 
@@ -139,15 +135,14 @@ The text and link should **only** be visible if the user has chosen `IKT (data/i
 
 ## Summary
 
-In this module you have set up a dropdown list, radio buttons and checkboxes and added values for these components manually, programmatically and dynamically.
+In this module you have set up the dropdown list, radio button and checkbox components and added options for them manually, programmatically and dynamically.
 
-The service should run on your local computer with local test
-and you should be able to validate that the components present expected data values.
+The service should run on your local computer with local test and it should be possible to select the expected option from each component.
 
 **Remember to _push_ your local changes, so that they are available in Altinn Studio when you're happy with them**
 
 ### Solution
-If you did not manage to complete all the steps, we have an [example of a solution](https://altinn.studio/repos/ttd/tilflytter-sogndal-lf/src/branch/bolk/4) that you can use as inspiration.
+If you did not manage to complete all the steps, we have an [example solution](https://altinn.studio/repos/ttd/tilflytter-sogndal-lf/src/branch/bolk/4) that you can use as inspiration.
 
 ![Screenshot of collection of work information for private sector](/app/app-dev-course/modul4/arbeidsopplysninger-privat-screenshot.png "Screenshot of collection of work information for private sector")
 ![Screenshot of collection of work information for public sector](/app/app-dev-course/modul4/arbeidsopplysninger-offentlig-screenshot.png "Screenshot of collection of work information for public sector")

--- a/content/app/app-dev-course/modul5/_index.en.md
+++ b/content/app/app-dev-course/modul5/_index.en.md
@@ -20,21 +20,20 @@ In this module you are adding a process step in the application.
 {{% expandlarge id="process_description" header="Expand process with a confirmation step" %}}
 
 An Altinn App has a process flow that describes the different steps in the flow.
-The standard flow for a newly created application consists of one task; one fill out step.
+The standard flow for a newly created application consists of one task; the fill out step.
 
 ![Standard process flow illustrated](/app/app-dev-course/modul5/default-process.png)
 
 Your task is to expand the standard process flow with a confirmation step as illustrated below.
 The confirmation page is added automatically when the step is added to the BPMN file.
 
-![Updated process flow illsutrated](/app/app-dev-course/modul5/updated-process.png)
+![Updated process flow illustrated](/app/app-dev-course/modul5/updated-process.png)
 
 {{% notice info %}}
 [Standard process flow is available on GitHub](../../development/configuration/process).
 Can you find the one that matches the flow we wish to achieve here?
 
-If you want an extra challenge, you can edit the process flow manually or in a BPMN editor,
-and rather use [the template on process flow with data and confirmation step](../../development/configuration/process/Data_Confirmation_Process.bpmn) as a solution.
+If you want an extra challenge you can edit the process flow manually or in a BPMN editor, using [the template for process flow with data and confirmation step](../../development/configuration/process/Data_Confirmation_Process.bpmn) as an inspiration.
 {{% /notice %}} 
 
 ### Requirements from the municipality
@@ -60,8 +59,8 @@ At this point in the workflow, the user should be able to:
 
 {{% expandlarge id="authorization" header="Adding authorization rules for confirmation step" %}}
 
-Your application's Policy file is adapted to a standard process flow.
-Update the policy file so that it's authorization rules cover the new process step.
+Your application's policy file is adapted to a standard process flow.
+Update the policy file so that the authorization rules cover the new process step.
 
 ### Requirements from the municipality
 - The same role requirements should apply to both fill out and confirm an instance.
@@ -84,7 +83,7 @@ Update the policy file so that it's authorization rules cover the new process st
 - [Custom validation](/app/development/logic/validation/#how-to-add-custom-validation)
 
 ### Knowledge check
-- Which change would you suggest for the client to be able to meet this requirement without adding custom validation at this step?
+- Which change could be made to meet this requirement without adding custom validation at this step?
 {{% /expandlarge %}}
 
 
@@ -113,12 +112,11 @@ Før du sender inn vil vi anbefale å se over svarene dine. Du kan ikke endre sv
 
 In this module you have expanded the application with a confirmation step, customized the view and implemented validation and authorization rules attached to the process step.
 
-The service should be able to run on your local computer with local test
-and you should be able to test the new process step and confirm that the view is as desired.
+The service should be able to run on your local computer with local test and you should be able to test the new process step and confirm that the view is as desired.
 
 **Remember to _push_ your local changes, so that they are available in Altinn Studio when you're happy with them**
 
 ### Solution
-If you did not manage to complete all the steps, we have an [example of a solution](https://altinn.studio/repos/ttd/tilflytter-sogndal-lf/src/branch/bolk/5) that you can use as inspiration.
+If you did not manage to complete all the steps, we have an [example solution](https://altinn.studio/repos/ttd/tilflytter-sogndal-lf/src/branch/bolk/5) that you can use as inspiration.
 
 ![Screenshot of confirmation page](/app/app-dev-course/modul5/bekreftelsesside-screenshot.png "Screenshot of confirmation page")

--- a/content/app/app-dev-course/modul6/_index.en.md
+++ b/content/app/app-dev-course/modul6/_index.en.md
@@ -54,19 +54,19 @@ Du er ikke velkommen til vår kommune. Beklager!
 - [Single field validations](/app/development/logic/validation/#single-field-validation)
 
 ### Knowledge check
-- When are validations server-side running?
-- Why should validations added on the client side also be duplicated server-side?
+- When are server-side validations run?
+- Why is it not enough to only perform validation on the client-side?
 
 {{% /expandlarge %}}
 
 
 {{% expandlarge id="processing" header="Data processing" %}}
 ### Requirements from the municipality
-One of the data processors of Sogndal is sick of manually correcting a street address that often is being incorrectly entered by newcomers.
-Therefore, we wish to programmatic correct this while the user is filling out the app.
+There is an address in Sogndal which is often misspelled by newcomers which leads to case workers having to spend a lot of time manually correcting it.
+Therefore, we want the app to automatically fix this mistake when the misspelled address is detected.
 
-If the user enters `Sesame Street 1` in the field `Innflytter.Adresse.Gateadresse`, this should automatically be corrected to `Sesamsgate 1`.
-In all other cases, the field should remain the same.
+If the user enters `Sesame Street 1` in the field `Innflytter.Adresse.Gateadresse`, it should automatically be corrected to `Sesamsgate 1`.
+For all other addresses the field should remain the same.
 
 
 ### Useful documentation
@@ -75,7 +75,7 @@ In all other cases, the field should remain the same.
 
 ### Knowledge check
 - When is data processing running?
-- What seperates `ProcessDataWrite` and `ProcessDataRead`?
+- What separates `ProcessDataWrite` and `ProcessDataRead`?
 - What is the difference between DataProcessing and Calculations?
 
 {{% /expandlarge %}}
@@ -87,6 +87,6 @@ We have also had a look at how to set up custom **validations** in the backend f
 Lastly, we have looked at how to set up **data processing** that enables manipulation of data runtime.
 
 ### Solution
-If you did not manage to complete all the steps, we have an [example of a solution](https://altinn.studio/repos/ttd/tilflytter-sogndal-lf/src/branch/bolk/6) that you can use as inspiration.
+If you did not manage to complete all the steps, we have an [example solution](https://altinn.studio/repos/ttd/tilflytter-sogndal-lf/src/branch/bolk/6) that you can use as inspiration.
 
 ![Screenshot of data collecting page with repeating groups](/app/app-dev-course/modul6/data-rep-grupper-screenshot.png "Screenshot of data collecting page with repeating groups")


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
The improvements include:
  - use more common synonyms for certain words
  - remove irrelevant information in instructions
  - use national id number instead of Social Security number (which is only used in the U.S)
