### PR TITLE
Grid cell option updates

### DIFF
--- a/content/app/development/ux/components/grid/_index.en.md
+++ b/content/app/development/ux/components/grid/_index.en.md
@@ -245,19 +245,41 @@ be displayed when the component is displayed outside of a Grid - such as on [sma
 
 ### Widths, text and alignment
 
-Adding `columnOptions` in a cell in a header row makes it is possible to configure the width, text alignment, and number
-of lines to show in a cell for the headers column. `columnOptions` contain the following properties.
+There ar multiple properties on a cell that can be used to control the width, text and alignment of a cell, and how
+much text is displayed before it is truncated. These options are:
 
-- `width` - set to a string value containing a percentage, ex: `"25%"`, or `"auto"` (default).
-- `alignText` - choose between `"left"`, `"center"` or `"right"` to align text in table cell accordingly.
-- `textOverflow` - is used to controll behaviour when text content is too large for a table cell and contains the
-    following options
-  - `lineWrap` - set to `false` in order to turn of linebreaking. Default is `true`.
-  - `maxHeight` - sets number of lines before overflowing text is hidden with an elipsis (...). `"maxHeight": 0` results
-      in turning off linebreaking.
+- `width` - The width of the column. The value can contain a percentage, for example `"25%"`, or `"auto"` (default).
+  Should be set on the first column, and will then apply to all cells in that column.
+- `alignText` - Choose between `"left"`, `"center"` or `"right"` to align the text in the cell accordingly.
+  This has no effect for cells with components, only cells with text.
+- `textOverflow` - Used to control the behavior when the text content is too large to fit in a cell.
+  Has no effect for cells with components, only cells with text.
+  - `lineWrap` - The text will wrap to the next line. This is the default behavior. Set to `false` to disable.
+  - `maxHeight` - The text will be truncated after a certain number of lines. Set to `0` to disable.
 
-You can also override a columns `alignText` and `textOverflow` for a single text-cell if needed, by specifying those
-attributes directly in the text-cell.
+You can override a column's `alignText` and `textOverflow` settings for a specific text cell by adding the attributes
+directly to the selected text cell.
+
+Example:
+```json
+{
+  "cells": [
+    {
+      "text": "Cell 1",
+      "width": "25%",
+      "alignText": "left",
+      "textOverflow": {
+        "lineWrap": false,
+        "maxHeight": 0
+      }
+    },
+    {
+      "component": "myComponent",
+      "width": "75%"
+    }
+  ]
+}
+```
 
 ## Mobile support
 

--- a/content/app/development/ux/components/grid/_index.nb.md
+++ b/content/app/development/ux/components/grid/_index.nb.md
@@ -245,18 +245,42 @@ vises utenfor en Grid - som på [mindre skjermer](#mobilvisning) og i [et sammen
 
 ### Bredder, tekst og justering
 
-Ved å legge på `columnOptions` på en celle i en `header` rad er det mulig å konfigurere bredden, tekst plassering, og
-anntall linjer som vises før overfløding tekst skjules. `columnOptions` inneholder følgende attributter.
+Det finnes flere opsjoner på en celle for å konfigurere bredde, tekst plassering, og
+anntall linjer som kan vises før resten av teksten skjules. Følgende opsjoner finnes:
 
-- `width` - streng verdi som inneholder en prosent, ex: `"25%"`, eller `"auto"` (default).
-- `alignText` - velg mellom `"left"`, `"center"` eller `"right"` for å plassere tekst i celler tilsvarende.
-- `textOverflow` - brukes for å kontrollere oppførsel når tekst innhold er for stort til å vises i en celle.
-  - `lineWrap` - sett til `false` for å skru av skjuling av overflødig tekst. Default er `true`.
-  - `maxHeight` - setter et maks antall tillatte linjer før tekst skjules med utellatelsestegn (...). `"maxHeight": 0`
+- `width` - Bredden til kolonnen. Verdien kan inneholde en prosent, for eks.: `"25%"`, eller `"auto"` (standardverdi).
+  Bør settes på den første kolonnen, og vil da gjelde for alle celler i den kolonnen.
+- `alignText` - Velg mellom `"left"`, `"center"` eller `"right"` for å plassere teksten i cellen tilsvarende.
+  Dette har ingen effekt for celler med komponenter, kun celler med tekst.
+- `textOverflow` - Brukes for å kontrollere oppførsel når tekstinnhold er for stort til å vises i en celle.
+  Har ingen effekt for celler med komponenter, kun celler med tekst.
+  - `lineWrap` - Sett til `false` for å skru av skjuling av overflødig tekst. Standardverdi er `true`.
+  - `maxHeight` - Setter et maks antall tillatte linjer før tekst skjules med utellatelsestegn (...). `"maxHeight": 0`
     resulterer i å skru av skjuling av overflødig tekst.
 
 Du can overstyre en kollonnes valg for `alignText` og `textOverflow` for en spesifikk text-celle, ved å legge
 attributtene til direkte i den valgte text-cellen.
+
+Eksempel: 
+```json
+{
+  "cells": [
+    {
+      "text": "Celle 1",
+      "width": "25%",
+      "alignText": "left",
+      "textOverflow": {
+        "lineWrap": false,
+        "maxHeight": 0
+      }
+    },
+    {
+      "component": "minKomponent",
+      "width": "75%"
+    }
+  ]
+}
+```
 
 ## Mobilvisning
 


### PR DESCRIPTION
## Description
Rewriting the grid text width/alignment/overflow options docs, as it referred to an object that is only used in repeating groups (not in the Grid component). Adding an example for clarity.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
