### PR TITLE
Click logo to navigate to Studio dashboard

### DIFF
--- a/content/app/getting-started/create-app/_index.en.md
+++ b/content/app/getting-started/create-app/_index.en.md
@@ -8,7 +8,7 @@ weight: 150
 Altinn Studio is used to create applications (apps).
 An app could be anything from a simple form to a more  complex application with APIs, user interfaces, and everything in between.
 
-You create an app from the dashboard in Altinn Studio.
+You create an app from the [dashboard](https://altinn.studio/dashboard) in Altinn Studio. If you don't see the dashboard, click the logo in the upper left corner.
 
 ![Dashboard in Altinn Studio](overview.png "Dashboard - overview")
 
@@ -20,7 +20,7 @@ You create an app from the dashboard in Altinn Studio.
    
     _Name can **not** be changed after an app has been deployed._
 
-    >  **Rules for naming an aplication**
+    >  **Rules for naming an application**
     > - Name can only contain lower case alphanumeric characters and dash (-),
     > - Mane must begin with a letter
     > - Name mustend with a letter or a number
@@ -31,4 +31,3 @@ You create an app from the dashboard in Altinn Studio.
 Once the app is created, you will be forwarded to the created application.
 
 ![App created](app-created.png "App created")
- 

--- a/content/app/getting-started/create-app/_index.nb.md
+++ b/content/app/getting-started/create-app/_index.nb.md
@@ -8,11 +8,11 @@ weight: 150
 Altinn Studio brukes til å opprette applikasjoner (apps).
 En app kan være alt fra enkle skjemaer til større applikasjoner med både API-er og UI, og alt derimellom.
 
-Du lager en ny app fra dashboardet i Altinn Studio.
+Du lager en ny app fra [dashboardet](https://altinn.studio/dashboard) i Altinn Studio. Hvis du ikke ser dashboardet, klikk på logoen i øverste venstre hjørne.
 
 ![Dashboardet i Altinn Studio](overview.png "Dashboard - oversikt")
 
-1. Klikk på "**ny app**"-knappen i det øvre høyre hjørnet av dashboardet.
+1. Klikk på "**Opprett ny applikasjon**"-knappen i det øvre høyre hjørnet av dashboardet.
 2. Velg hvem som skal være **eier** av appen. Hvis du ikke har tilgang for noen organisasjoner, må du velge deg selv så du lager appen i din sandkasse.
 3. Legg inn **navnet** på appen. 
 
@@ -22,13 +22,13 @@ Du lager en ny app fra dashboardet i Altinn Studio.
     _Navnet kan **ikke** endres etter at appen er gått i produksjon._
 
     >  **Regler for navngivning av applikasjon**
-    > - Kan kun inneholde lowercase alfanumeriske tegn og bindestrek (-),
+    > - Kan kun inneholde små bokstaver, tall og bindestrek (-),
     > - Navnet må begynne med en bokstav
     > - Navnet må ende med en bokstav eller et tall
 
 
    
-1. Opprett appen ved å klikke "**Opprett applikasjon**".
+4. Opprett appen ved å klikke "**Opprett applikasjon**".
 
 ![Ny app popup](new-app.png "Opprett en ny app")
 


### PR DESCRIPTION
## Description
On first login I'm taken to altinn.studio/repos. I added a note to click on the logo if not taken directly to Studio dashboard (altinn.studio/dashboard) when logging in and added link to studio dashboard. Also fixed a few typos.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
