### PR TITLE
more robust insert shortcode

### DIFF
--- a/content/events/publish-events/get-started/api-access/_index.en.md
+++ b/content/events/publish-events/get-started/api-access/_index.en.md
@@ -7,4 +7,4 @@ description: A guide to requesting access to the event producer APIs
 
 ## Requesting required Maskinporten scope
 
-{{% insert "\content\events\request-maskinporten-scopes.md" "altinn:events.publish" "publishing events to Altinn"%}}
+{{% insert "content/events/request-maskinporten-scopes.md" "altinn:events.publish" "publishing events to Altinn"%}}

--- a/content/events/publish-events/get-started/api-access/_index.en.md
+++ b/content/events/publish-events/get-started/api-access/_index.en.md
@@ -7,4 +7,4 @@ description: A guide to requesting access to the event producer APIs
 
 ## Requesting required Maskinporten scope
 
-{{% insert "content\events\request-maskinporten-scopes.md" "altinn:events.publish" "publishing events to Altinn"%}}
+{{% insert "\content\events\request-maskinporten-scopes.md" "altinn:events.publish" "publishing events to Altinn"%}}

--- a/content/events/subscribe-to-events/get-started/api-access/_index.en.md
+++ b/content/events/subscribe-to-events/get-started/api-access/_index.en.md
@@ -8,5 +8,5 @@ description: Guide to requesting access to Altinns APIs
 ## Requesting required Maskinporten scope*
 \* Scope is only required when subscribing to events published to a non-Altinn App resource.
 
-{{% insert "\content\events\request-maskinporten-scopes.md" "altinn:events.subscribe" "subscribing to events"%}}
+{{% insert "content/events/request-maskinporten-scopes.md" "altinn:events.subscribe" "subscribing to events"%}}
 

--- a/content/events/subscribe-to-events/get-started/api-access/_index.en.md
+++ b/content/events/subscribe-to-events/get-started/api-access/_index.en.md
@@ -8,5 +8,5 @@ description: Guide to requesting access to Altinns APIs
 ## Requesting required Maskinporten scope*
 \* Scope is only required when subscribing to events published to a non-Altinn App resource.
 
-{{% insert "content\events\request-maskinporten-scopes.md" "altinn:events.subscribe" "subscribing to events"%}}
+{{% insert "\content\events\request-maskinporten-scopes.md" "altinn:events.subscribe" "subscribing to events"%}}
 

--- a/themes/hugo-theme-altinn/layouts/shortcodes/insert.html
+++ b/themes/hugo-theme-altinn/layouts/shortcodes/insert.html
@@ -19,5 +19,5 @@
   {{ $content | markdownify}}
 {{ end }}
 {{ else }}
-  File does not exist: {{ $filePath }}
+  Could not find section content. File does not exist: {{ $filePath }}
 {{ end }}

--- a/themes/hugo-theme-altinn/layouts/shortcodes/insert.html
+++ b/themes/hugo-theme-altinn/layouts/shortcodes/insert.html
@@ -6,8 +6,10 @@
  {{% insert [full file path] [variable 0]... [variable n]" %}}
  */}}
 
+{{ $filePath := .Get 0 }}
 
-{{ $content := readFile (.Get 0) }}
+{{ if fileExists $filePath }}
+{{ $content := readFile $filePath }}
 {{ if $content }}
 {{ range $index, $param := .Params }}
   {{ if ne $index 0 }}
@@ -15,4 +17,7 @@
 {{ end }}
   {{- end -}}
   {{ $content | markdownify}}
+{{ end }}
+{{ else }}
+  File does not exist: {{ $filePath }}
 {{ end }}


### PR DESCRIPTION
Added if check to the insert-shortcode. 
Build does not break if file does not exists or cannot be found. 
Error message is simply printed to the page where content should have been inserted. 