### PR TITLE
Update _index.en.md

### DIFF
--- a/content/app/development/ux/pdf/_index.en.md
+++ b/content/app/development/ux/pdf/_index.en.md
@@ -218,7 +218,7 @@ The automatic layout includes a front page with instance information like sender
         "referenceNumber": true
         },
         "pageBreak": {
-          "breakAfter": true
+          "breakAfter": "always"
         }
       }
       ...


### PR DESCRIPTION
breakAfter does not use boolean, but uses:
auto | always | avoid

<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed from boolean to "always" on field breakAfter because boolean does not work.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
