### PR TITLE
Added hugo config version to expand shortcode so it works with '%'

### DIFF
--- a/themes/hugo-theme-altinn/layouts/shortcodes/expandbold.html
+++ b/themes/hugo-theme-altinn/layouts/shortcodes/expandbold.html
@@ -1,0 +1,18 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+
+<div class="expand">
+    <div class="expand-label" style="cursor: pointer;"
+        onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fa fa-chevron-down' : 'fa fa-chevron-right';});});">
+        <i style="font-size:small;" class="fa fa-chevron-right"></i>
+        <span>
+            {{ with .Get 0 }}
+            <strong>{{.}}</strong>
+            {{else}}
+            <strong>Expand me...</strong>
+            {{end}}
+        </span>
+    </div>
+    <div class="expand-content" style="display: none;">
+        {{.Inner | safeHTML}}
+    </div>
+</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Created a version of the `expand` shortcode with a slightly larger arrow and bold header.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
