### PR TITLE
Update Hugo expand shortcodes

### DIFF
--- a/themes/hugo-theme-altinn/layouts/shortcodes/expand.html
+++ b/themes/hugo-theme-altinn/layouts/shortcodes/expand.html
@@ -1,18 +1,18 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
+{{- $_hugo_config := `{ "version": 1 }` -}}
 
 <div class="expand">
 	<div class="expand-label" style="cursor: pointer;"
 		onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fa fa-chevron-down' : 'fa fa-chevron-right';});});">
 		<i style="font-size:x-small;" class="fa fa-chevron-right"></i>
 		<span>
-			{{ if .IsNamedParams }}
-				{{.Get "default" | default "Expand me..."}}
-			{{else}}
-				{{.Get 0 | default "Expand me..."}}
-			{{end}}
+			{{- if .IsNamedParams -}}
+				{{- .Get "default" | default "Expand me..." -}}
+			{{- else -}}
+				{{- .Get 0 | default "Expand me..." -}}
+			{{- end -}}
 		</span>
 	</div>
 	<div class="expand-content" style="display: none;">
-		{{.Inner | safeHTML}}
+		{{- .Inner | safeHTML -}}
 	</div>
 </div>

--- a/themes/hugo-theme-altinn/layouts/shortcodes/expandbold.html
+++ b/themes/hugo-theme-altinn/layouts/shortcodes/expandbold.html
@@ -1,18 +1,18 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
+{{- $_hugo_config := `{ "version": 1 }` -}}
 
 <div class="expand">
     <div class="expand-label" style="cursor: pointer;"
         onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? 'fa fa-chevron-down' : 'fa fa-chevron-right';});});">
         <i style="font-size:small;" class="fa fa-chevron-right"></i>
         <span>
-            {{ with .Get 0 }}
-            <strong>{{.}}</strong>
-            {{else}}
+            {{- with .Get 0 -}}
+            <strong>{{- . -}}</strong>
+            {{- else -}}
             <strong>Expand me...</strong>
-            {{end}}
+            {{- end -}}
         </span>
     </div>
     <div class="expand-content" style="display: none;">
-        {{.Inner | safeHTML}}
+        {{- .Inner | safeHTML -}}
     </div>
 </div>

--- a/themes/hugo-theme-altinn/layouts/shortcodes/expandlarge.html
+++ b/themes/hugo-theme-altinn/layouts/shortcodes/expandlarge.html
@@ -1,10 +1,10 @@
-{{ $_hugo_config := `{ "version": 1 }` }}
+{{- $_hugo_config := `{ "version": 1 }` -}}
 
-<div class="card adocs-expand" id="{{with .Get "id" }}{{.}}{{else}}expand-default{{end}}">
+<div class="card adocs-expand" id="{{- with .Get "id" -}}{{- . -}}{{- else -}}expand-default{{- end -}}">
 	<div>
 		<a
 			data-toggle="collapse"
-			href="#expandable-{{with .Get "id" }}{{.}}{{else}}expand-default{{end}}"
+			href="#expandable-{{- with .Get "id" -}}{{- . -}}{{- else -}}expand-default{{- end -}}"
 			role="tab"
 			aria-expanded="false"
 			class="a-collapse-title no-decoration collapsed a-h3"
@@ -12,17 +12,17 @@
 			<span class="a-dropdownCircleArrow">
 			<i class="ai ai-expand ai-sm"><span class="sr-only">Vis/skjul innhold</span></i>
 			</span>
-			{{with .Get "header" }}
-				{{.}}
-			{{else}}
+			{{- with .Get "header" -}}
+				{{- . -}}
+			{{- else -}}
 				expand-default
-			{{end}}
+			{{- end -}}
 		</a>
 	</div>
-	<div id="expandable-{{with .Get "id" }}{{.}}{{else}}expand-default{{end}}" class="a-collapseContent collapse" role="tabpanel">
+	<div id="expandable-{{- with .Get "id" -}}{{- . -}}{{- else -}}expand-default{{- end -}}" class="a-collapseContent collapse" role="tabpanel">
 		<div class="a-collapseContent-inside">
-			<a name="#{{with .Get "id" }}{{.}}{{else}}expand-default{{end}}"></a>
-			{{.Inner | safeHTML}}
+			<a name="#{{- with .Get "id" -}}{{- . -}}{{- else -}}expand-default{{- end -}}"></a>
+			{{- .Inner | safeHTML -}}
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added dashes inside curly braces in expandlarge, expand, and expandbold shortcodes.
This makes it possible to use nested expand shortcodes.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
