### PR TITLE
fix(Alert): update docs to reflect using body as textResourceBindings instead of description

### DIFF
--- a/content/app/development/ux/components/alertComponent/_index.en.md
+++ b/content/app/development/ux/components/alertComponent/_index.en.md
@@ -27,7 +27,7 @@ The severity of the alert. This affects the styling of the alert.
 
 #### textResourceBindings
 
-`title` and `description` can be configured with `textResourceBindings` to display text from the resource file.
+`title` and `body` can be configured with `textResourceBindings` to display text from the resource file.
 
 ## Accessibility
 
@@ -51,7 +51,7 @@ An alert with `severity` `"info"`
   "type": "Alert",
   "textResourceBindings": {
     "title": "Vedrørende navneendring",
-    "description": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
+    "body": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
   },
   "severity": "info"
 }
@@ -72,7 +72,7 @@ An alert with `severity` `"success"`
   "type": "Alert",
   "textResourceBindings": {
     "title": "Vedrørende navneendring",
-    "description": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
+    "body": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
   },
   "severity": "success"
 }
@@ -92,7 +92,7 @@ An alert with `severity` `"warning"`
   "type": "Alert",
   "textResourceBindings": {
     "title": "Vedrørende navneendring",
-    "description": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
+    "body": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
   },
   "severity": "warning"
 }
@@ -112,7 +112,7 @@ An alert with `severity` `"danger"`
   "type": "Alert",
   "textResourceBindings": {
     "title": "Vedrørende navneendring",
-    "description": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
+    "body": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
   },
   "severity": "danger"
 }

--- a/content/app/development/ux/components/alertComponent/_index.nb.md
+++ b/content/app/development/ux/components/alertComponent/_index.nb.md
@@ -27,7 +27,7 @@ Alvorlighetsgraden til varselet. Dette påvirker utseendet til varselet.
 
 #### textResourceBindings
 
-`title` og `description` kan konfigureres med `textResourceBindings` for å vise tekst fra ressursfilen.
+`title` og `body` kan konfigureres med `textResourceBindings` for å vise tekst fra ressursfilen.
 
 ## Tilgjengelighet
 
@@ -52,7 +52,7 @@ En alert med `severity` `"info"`
   "type": "Alert",
   "textResourceBindings": {
     "title": "Vedrørende navneendring",
-    "description": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
+    "body": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
   },
   "severity": "info"
 }
@@ -73,7 +73,7 @@ En alert med `severity` `"success"`
   "type": "Alert",
   "textResourceBindings": {
     "title": "Vedrørende navneendring",
-    "description": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
+    "body": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
   },
   "severity": "success"
 }
@@ -93,7 +93,7 @@ En alert med `severity` `"warning"`
   "type": "Alert",
   "textResourceBindings": {
     "title": "Vedrørende navneendring",
-    "description": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
+    "body": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
   },
   "severity": "warning"
 }
@@ -113,7 +113,7 @@ En alert med `severity` `"danger"`
   "type": "Alert",
   "textResourceBindings": {
     "title": "Vedrørende navneendring",
-    "description": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
+    "body": "Ved å bekrefte navneendring bekrefter du at du ønsker å endre navnet ditt."
   },
   "severity": "danger"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates the docs with the use of `body` instead of `description` for `textResourceBindings` for `Alert`. 


