### PR TITLE
fix(Accordion): Document headingLevel option

### DIFF
--- a/content/app/development/ux/components/accordion/_index.en.md
+++ b/content/app/development/ux/components/accordion/_index.en.md
@@ -14,6 +14,7 @@ description: A component that allows you to group content into collapsible secti
 {
   "id": "accordion",
   "type": "Accordion",
+  "headingLevel": 2,
   "children": ["paragraph", "paragraph-2"]
 },
 {
@@ -42,3 +43,6 @@ Then specify which other components you want to be able to collapse by adding th
 The following types can be added to an Accordion: 
 - `Paragraph`
 - `Button`
+
+## Options
+- `headingLevel`: The level of the heading element of the `Accordion`. Can be any of the values `2 | 3 | 4 | 5 | 6`. Defaults to `2`.

--- a/content/app/development/ux/components/accordion/_index.nb.md
+++ b/content/app/development/ux/components/accordion/_index.nb.md
@@ -14,6 +14,7 @@ description: En komponent som lar deg gruppere innhold i sammenleggbare seksjone
 {
   "id": "accordion",
   "type": "Accordion",
+  "headingLevel": 2,
   "children": ["paragraph", "paragraph-2"]
 },
 {
@@ -44,3 +45,6 @@ legge til deres ID-er til `Accordion`-komponenten sin `children`-egenskap.
 Følgende typer kan legges til en `Accordion`:
 - `Paragraph`
 - `Button`
+
+## Egenskaper
+- `headingLevel`: Nivået på overskriftelementet til `Accordion`. Kan være en av disse verdiene `2 | 3 | 4 | 5 | 6`. Standardverdien er `2`.


### PR DESCRIPTION
Documents the property `headingLevel` for the `Accordion` component.