### PR TITLE
Shortcode and styling for code block title

### DIFF
--- a/layouts/shortcodes/code-title.html
+++ b/layouts/shortcodes/code-title.html
@@ -1,0 +1,3 @@
+<div class="code-title">
+    <code>{{- .Inner -}}</code>
+</div>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -482,3 +482,26 @@ figure {
     height: fit-content;
     /* margin-right: 15px; */
 }
+
+.code-title {
+    position: relative;
+    top: 30px;
+    background-color:#222;
+    padding: 15px;
+    padding-top: 0px;
+    margin-top: -30px;
+    border: 0;
+    border-radius: 7px;
+    box-shadow: 5px 0 5px rgba(68, 68, 68, 0.6);
+}
+
+.code-title code {
+    background-color:#222;
+    color: #707880;
+    border: 0;
+    font-size: 75%;
+}
+
+.code-title .copy-to-clipboard {
+    display: none;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Shortcode code-title that adds code formatting with class .code-title to content
- Styling of .code-title

The shortcode is added just before a code block. The result is a slightly lighter field at the top of the block where the title within the shortcode (e.g. file name) is displayed.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
