### PR TITLE
Fix styling of expandsmall shortcode to allow formatting of header

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -519,7 +519,7 @@ figure {
 /* Code title */
 
 h2 code, h3 code, h4 code {
-    color:unset;
+    color: unset;
     background: none;
     border: none;
 }
@@ -528,8 +528,19 @@ h4 code {
     font-weight: bold;
 }
 
+.expandsmall-header code + .copy-to-clipboard,
 h2 code + .copy-to-clipboard,
 h3 code + .copy-to-clipboard,
 h4 code + .copy-to-clipboard {
 display: none;
+}
+
+.expandsmall-header code {
+    color: unset;
+    background: none;
+    border: none;
+    border-radius: none;
+    padding: 0;
+    font-size: 88%;
+    vertical-align:baseline;
 }

--- a/themes/hugo-theme-altinn/layouts/shortcodes/expandsmall.html
+++ b/themes/hugo-theme-altinn/layouts/shortcodes/expandsmall.html
@@ -13,7 +13,9 @@
 			<i class="ai ai-expand ai-sm"><span class="sr-only">Vis/skjul innhold</span></i>
 			</span>
 			{{- with .Get "header" -}}
-				{{- . -}}
+				<div class="expandsmall-header">
+					{{- . | markdownify -}}
+				</div>
 			{{- else -}}
 				expand-default
 			{{- end -}}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Markdownify header in expandsmall shortcode
- Add CSS styling to format code in expandsmall header

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
