### PR TITLE
chore: update organisation logo documentation with size parameter

### DIFF
--- a/content/app/development/ux/organisation-logo/_index.en.md
+++ b/content/app/development/ux/organisation-logo/_index.en.md
@@ -62,6 +62,16 @@ Specifies where the source of the logo should be fetched from. It has two valid 
 Specifies whether the service owner's name should be displayed next to the logo. Retrieves the service owner's name 
 directly from altinn-orgs.json if appOwner is not defined in the text resource files.
 
+#### size
+
+For some logos, the default size of the logo might not always fit. The size can be specified with the `size` property.
+It has three valid values:
+
+- `"small"`
+- `"medium"` 
+- `"large"`
+
+The size defaults to `"small"` if not specified.
 
 ## Design guidelines for app owner logo
 #### Size and scale:

--- a/content/app/development/ux/organisation-logo/_index.nb.md
+++ b/content/app/development/ux/organisation-logo/_index.nb.md
@@ -75,6 +75,16 @@ Spesifiserer om tjenesteeiers navn skal skrives ut ved siden av logoen. Henter n
 direkte fra `altinn-orgs.json` dersom `appOwner` ikke er definert i tekstressursfilene
 
 
+#### size
+
+For noen logoer passer ikke alltid standardstørrelsen til logoen. Størrelsen kan spesifiseres ved hjelp av `size`-egenskapen.
+Den har tre gyldige verdier:
+
+- `"small"`
+- `"medium"`
+- `"large"`
+
+Størrelsen er som standard satt til `"small"` hvis den ikke er spesifisert.
 
 ## Designretningslinjer for app-eier logo
 


### PR DESCRIPTION
Documents the use of the `size` parameter in settings for organisation logo.