### PR TITLE
Changes to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,11 @@ Guidelines for Reviewers:
 1.	Focus on the Code, Not the Person: The goal is to elevate the quality of the code, not to showcase your expertise. Be constructive in your feedback.
 2.	Adhere to Established Standards: Stick to coding conventions and practices that are accepted within the team. Deviations must be justified.
 3.	Understand the Purpose: Make sure to understand the rationale behind the code you're reviewing. Go through any associated documentation or task definitions.
-4.	Clarify Importance: Distinguish between critical issues and lesser suggestions. Make it clear what needs to be amended before the code can be merged.
-5.	Invite Discussion: Ask questions like, "Have you considered isolating this logic into a separate method?" rather than giving direct instructions.
+If something is unclear, ask the author to clarify and/or add comments to the code.
+4.	Be direct and polite: Avoid wrapping your opinions in questions, like "Have you considered isolating this logic into a separate method?". Instead, be
+direct and point out your difference in opinion: "I think this logic would be easier to follow if isolated into a separate method".
+5.	Clarify Importance: Distinguish between critical issues and lesser suggestions. Make it clear what needs to change before the code can be merged, and
+respect the author's right to make the final decision about the rest.
 
 Guidelines for Authors:
 1.	Self-Check: Review your own code to catch simple errors before requesting a review.

--- a/content/community/changelog/app-frontend/stricter-schema/_index.en.md
+++ b/content/community/changelog/app-frontend/stricter-schema/_index.en.md
@@ -6,7 +6,7 @@ toc: true
 ---
 
 # What?
-During the start of September 2023 upgraded the layout JsonSchema used by Altinn 3 apps to verify the layout files.
+During the start of September 2023 we upgraded the layout JsonSchema used by Altinn 3 apps to verify the layout files.
 This change made the JsonSchema stricter and might have caused your app to display an increased amount of validation
 errors (usually yellow lines) when developing locally in Visual Studio Code (or similar IDEs).
 


### PR DESCRIPTION
## Description
We were reminded about `CONTRIBUTING.md` today, [and I commented](https://altinndevops.slack.com/archives/C045EB3JA9X/p1695027440677159) about my difference in opinion about framing ones own opinion as questions to the author. I prefer the direct, but polite (possibly more Scandinavian?) approach of just putting your opinion out there.

This might be controversial, but I dislike rhetorical questions in code review, and I believe reviewers should strive to only ask questions to the author when they _do not know the answer themselves_. At the more extreme end of the asking-questions-in-code-reviews spectrum lies a manipulation tactic where the author might be made to feel stupid ("why didn't you think of doing _x_?").

Also, sneaking in an entirely unrelated change where I forgot a "we" 😇

## Related links
- https://news.ycombinator.com/item?id=21475937 (an opposing opion, with discussions)
- https://google.github.io/eng-practices/review/reviewer/comments.html (CL = "change list" ~= "pull request")