### PR TITLE
testing alternative search engine

### DIFF
--- a/.github/workflows/hugo-verifications.yml
+++ b/.github/workflows/hugo-verifications.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Build docs
         run: hugo
 
+      - name: Build pagefind search indexes
+        run: npx -y pagefind --site ./public
+
       - name: Verify links
         uses: untitaker/hyperlink@0.1.27
         with:

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -56,6 +56,8 @@ jobs:
           hugo \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - name: Build pagefind search indexes
+        run: npx -y pagefind --site ./public
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/README.md
+++ b/README.md
@@ -18,32 +18,90 @@ git clone https://github.com/altinn/altinn-studio-docs
 
 ```shell
 cd altinn-studio-docs
+```
+
+### "Render" to disk
+```shell
+./hugo server --renderToDisk
+```
+
+
+### or in memory
+```shell
 ./hugo server --navigateToChanged
 ```
 
-Which will result in output similar to:
+> Render to disk is required for `pagefind` search to work locally.
+
+_More information about Hugo is [available here](https://gohugo.io/)_
+
+
+In either render mode, you should see output similar to:
 
 ```cmd
 Start building sites …
-                   | EN  | NB
+                  | EN  | NB   
 -------------------+-----+------
-  Pages            | 527 | 180
-  Paginator pages  |  40 |   3
-  Non-page files   | 558 | 219
-  Static files     | 236 | 236
-  Processed images |   0 |   0
-  Aliases          | 143 |   9
-  Sitemaps         |   2 |   1
-  Cleaned          |   0 |   0
+  Pages            | 770 | 357  
+  Paginator pages  |  44 |   6  
+  Non-page files   | 940 | 491  
+  Static files     | 228 | 228  
+  Processed images |   0 |   0  
+  Aliases          | 217 |  71  
+  Sitemaps         |   2 |   1  
+  Cleaned          |   0 |   0 
 
-Built in 8390 ms
+Built in 1367 ms
 Watching for changes in C:\repos\altinn-studio-docs\{content,layouts,static,themes}
 Watching for config changes in C:\repos\altinn-studio-docs\config.toml
 Environment: "development"
-Serving pages from memory
+Serving pages from disk
 Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
 Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
 Press Ctrl+C to stop
 ```
 
 The solution is now running locally at http://localhost:1313
+
+
+## NEW! Update pagefind search index
+
+To update the `pagefind` search index files, run the following command at the root of your local git repository:
+
+```shell
+npx -y pagefind --site ./public
+```
+
+Output:
+```shell
+Running Pagefind v1.0.3 (Extended)
+Running from: "./altinn-studio-docs"
+Source:       "public"
+Output:       "public/pagefind"
+
+[Walking source directory]
+Found 1462 files matching **/*.{html}
+
+[Parsing files]
+Did not find a data-pagefind-body element on the site.
+↳ Indexing all <body> elements on the site.
+5 pages found without an <html> element. 
+Pages without an outer <html> element will not be processed by default. 
+If adding this element is not possible, use the root selector config to target a different root element.
+
+[Reading languages]
+Discovered 3 languages: nb, en, unknown
+1 page found without an html lang attribute. 
+Merging these pages with the en language, as that is the main language on this site. 
+Run Pagefind with --verbose for more information.
+
+[Building search indexes]
+Total: 
+  Indexed 2 languages
+  Indexed 1177 pages
+  Indexed 30014 words
+  Indexed 0 filters
+  Indexed 0 sorts
+
+Finished in 10.810 seconds
+```

--- a/layouts/partials/landing-pages/frontpage.html
+++ b/layouts/partials/landing-pages/frontpage.html
@@ -12,6 +12,9 @@
     <link href="{{"css/horsey.css" | relURL}}" rel="stylesheet">
     <link href="{{"css/fortawesome.css" | relURL}}" rel="stylesheet">
     <link href="{{"css/designsystem.css" | relURL}}" rel="stylesheet">
+
+    <link href="{{"pagefind/pagefind-ui.css" | relURL}}" rel="stylesheet">
+
     {{- with .Site.Params.themeStyle -}}
     <link href="{{(printf "css/%s.css" .) | relURL}}" rel="stylesheet">
     {{- else -}}
@@ -21,6 +24,10 @@
       <link href="{{(printf "css/theme-%s.css" .) | relURL}}" rel="stylesheet">
     {{- end -}}
     <script src="{{"js/jquery-2.x.min.js" | relURL}}"></script>
+
+    <script src="{{"pagefind/pagefind-ui.js" | relURL}}"></script>
+    
+
     {{- partial "custom-head.html" . -}}
 
     <style>

--- a/layouts/partials/landing-pages/frontpage.html
+++ b/layouts/partials/landing-pages/frontpage.html
@@ -12,9 +12,8 @@
     <link href="{{"css/horsey.css" | relURL}}" rel="stylesheet">
     <link href="{{"css/fortawesome.css" | relURL}}" rel="stylesheet">
     <link href="{{"css/designsystem.css" | relURL}}" rel="stylesheet">
-
     <link href="{{"pagefind/pagefind-ui.css" | relURL}}" rel="stylesheet">
-
+    
     {{- with .Site.Params.themeStyle -}}
     <link href="{{(printf "css/%s.css" .) | relURL}}" rel="stylesheet">
     {{- else -}}
@@ -22,7 +21,8 @@
     {{- end -}}
     {{- with .Site.Params.themeVariant -}}
       <link href="{{(printf "css/theme-%s.css" .) | relURL}}" rel="stylesheet">
-    {{- end -}}
+    {{- end -}}    
+
     <script src="{{"js/jquery-2.x.min.js" | relURL}}"></script>
 
     <script src="{{"pagefind/pagefind-ui.js" | relURL}}"></script>

--- a/themes/hugo-theme-altinn/exampleSite/layouts/partials/topbar.html
+++ b/themes/hugo-theme-altinn/exampleSite/layouts/partials/topbar.html
@@ -18,7 +18,7 @@
             <span class="sr-only">Til forsiden</span>
           </a>
 
-          <button class="navbar-toggler d-md-none" type="button"><span class="sr-only">Vis/skjul meny</span></button>
+          <button class="navbar-toggler d-md-none" type="button"><span class="sr-only">Show/hide meny Vis/skjul meny</span></button>
           <div class="collapse navbar-toggleable-sm a-globalNav-main" id="exCollapsingNavbar2">
             <ul id="exCollapsingNavbar">
               <li class="d-md-none">

--- a/themes/hugo-theme-altinn/layouts/partials/footer.html
+++ b/themes/hugo-theme-altinn/layouts/partials/footer.html
@@ -2,7 +2,7 @@
                 </div>
               </div>
               {{/*
-              <div id="navigation">
+              <div id="navigation" data-pagefind-weight="0.3">
                   <!-- Next prev page -->
                   {{- $currentNode := . -}}
                   {{- template "menu-nextprev" dict "menu" .Site.Home "currentnode" $currentNode -}}

--- a/themes/hugo-theme-altinn/layouts/partials/header.html
+++ b/themes/hugo-theme-altinn/layouts/partials/header.html
@@ -18,6 +18,10 @@
     <link href="{{"css/horsey.css" | relURL}}" rel="stylesheet">
     <link href="{{"css/fortawesome.css" | relURL}}" rel="stylesheet">
     <link href="{{"css/designsystem.css" | relURL}}" rel="stylesheet">
+
+
+    <link href="{{"pagefind/pagefind-ui.css" | relURL}}" rel="stylesheet">
+
     {{- with .Site.Params.themeStyle -}}
     <link href="{{(printf "css/%s.css" .) | relURL}}" rel="stylesheet">
     {{- else -}}
@@ -26,6 +30,7 @@
     {{- with .Site.Params.themeVariant -}}
       <link href="{{(printf "css/theme-%s.css" .) | relURL}}" rel="stylesheet">
     {{- end -}}
+
 
     <script src="{{"js/jquery-2.x.min.js" | relURL}}"></script>
 
@@ -73,7 +78,7 @@
                 <span id="sidebar-toggle-span" class="adocs-sidebarToggle">
                   <a href="#" id="sidebar-toggle" data-sidebar-toggle="">
                     <i class="fa fa-bars"></i>
-                    <span class="sr-only">Vis/skjul meny</span>
+                    <span class="sr-only">Show/hide menu Vis/skjul meny</span>
                   </a>
                 </span>
                 <span class="links">

--- a/themes/hugo-theme-altinn/layouts/partials/header.html
+++ b/themes/hugo-theme-altinn/layouts/partials/header.html
@@ -29,6 +29,8 @@
 
     <script src="{{"js/jquery-2.x.min.js" | relURL}}"></script>
 
+    <script src="{{"pagefind/pagefind-ui.js" | relURL}}"></script>
+
     {{- partial "custom-head.html" . -}}
 
     <style>
@@ -54,6 +56,14 @@
           {{ template "activeMenus" dict "page" . "value" (printf "$(\"li.dd-item a[href='%s']\").parent().addClass(\"active\");" .RelPermalink) }}
         </script>
         <section id="body">
+          <div id="search"></div>
+          <script>
+              window.addEventListener('DOMContentLoaded', (event) => {
+                  new PagefindUI({ element: "#search", showSubResults: true });
+              });
+          </script>
+
+
           <div id="content" class="adocs-content js-moveChildrenTo">
         <div id="overlay"></div>
         <div class="a-text">

--- a/themes/hugo-theme-altinn/static/css/theme.css
+++ b/themes/hugo-theme-altinn/static/css/theme.css
@@ -1732,9 +1732,13 @@ a code + .copy-to-clipboard {
 }
 
 body {
-  --pagefind-ui-primary: #44aaf3;
-  --pagefind-ui-text: #eeeeee;
-  --pagefind-ui-background: #152028;
+  --pagefind-ui-primary: #6499be;
+  --pagefind-ui-text: #363333;
+  --pagefind-ui-background: #ffffff;
   --pagefind-ui-border: #152028;
   --pagefind-ui-tag: #152028;
+}
+
+.pagefind-ui__results {
+    background: rgb(255, 255, 240);
 }

--- a/themes/hugo-theme-altinn/static/css/theme.css
+++ b/themes/hugo-theme-altinn/static/css/theme.css
@@ -1730,3 +1730,11 @@ a code {
 a code + .copy-to-clipboard {
     display: none;
 }
+
+body {
+  --pagefind-ui-primary: #44aaf3;
+  --pagefind-ui-text: #eeeeee;
+  --pagefind-ui-background: #152028;
+  --pagefind-ui-border: #152028;
+  --pagefind-ui-tag: #152028;
+}


### PR DESCRIPTION
## Description
In connection with processing our documentation files as a training data set for the Digdir Assistant Slack bot, we have identified the need for more fine grained control over search ranking. `pagefind` is an open source library written in Rust and providing local file based search indexing without the need for a backend server.

Please help us evaluate the quality of the ranking of query results for the content that you know needs improving!

Information about `pagefind`: https://pagefind.app/

Specifically, weighting content: https://pagefind.app/docs/weighting/

## Verification
- [x] Local run instructions added
- [x] Github actions for updating search indexes added and tested

