### PR TITLE
testing typesense search UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,74 @@ Press Ctrl+C to stop
 ```
 
 The solution is now running locally at http://localhost:1313
+
+
+## Updating the search index
+
+```shell
+pipenv run python -m src.index
+```
+
+
+config
+```python
+config = '{
+  "index_name": "altinn-studio-docs",
+  "scrape_start_urls": false,
+  "start_urls": [
+    {
+      "url": "https://docs.altinn.studio"
+    }
+  ],
+  "stop_urls": [
+    "https://docs.altinn.studio/app/app-dev-course",
+    "https://docs.altinn.studio/app/development/ux/components/commondefs",
+    "https://docs.altinn.studio/authentication",
+    "https://docs.altinn.studio/authorization",
+    "https://docs.altinn.studio/community/changelog",
+    "https://docs.altinn.studio/app/launched-apps",
+    "https://docs.altinn.studio/tags",
+    "https://docs.altinn.studio/api",
+    "https://docs.altinn.studio/community",
+    "https://docs.altinn.studio/security",
+    "https://docs.altinn.studio/technology",
+    
+
+    "https://docs.altinn.studio/nb/app/app-dev-course",
+    "https://docs.altinn.studio/nb/app/development/ux/components/commondefs",
+    "https://docs.altinn.studio/nb/authentication",
+    "https://docs.altinn.studio/nb/authorization",
+    "https://docs.altinn.studio/nb/community/changelog",
+    "https://docs.altinn.studio/nb/app/launched-apps",
+    "https://docs.altinn.studio/nb/app",
+    "https://docs.altinn.studio/nb/tags",
+    "https://docs.altinn.studio/nb/api",
+    "https://docs.altinn.studio/nb/community",
+    "https://docs.altinn.studio/nb/security",
+    "https://docs.altinn.studio/nb/technology"
+
+  ],
+  "sitemap_urls": [
+    "https://docs.altinn.studio/en/sitemap.xml"
+  ],
+  "selectors": {
+    "default": {
+      "lvl0": {
+        "selector": "#breadcrumbs .links a",
+        "global": true,
+        "default_value": "Documentation"
+      },
+      "lvl1": "#body-inner h1",
+      "lvl2": "#body-inner h2",
+      "lvl3": "#body-inner h3",
+      "lvl4": "#body-inner h4",
+      "text": "#body-inner p,#body-inner il,#body-inner td:last-child"
+    }
+  },
+  "selectors_exclude": [".hash-link"],
+  "custom_settings": {
+    "attributesForFaceting": ["language"],
+    "separatorsToIndex": "_"
+  }
+}'
+```

--- a/themes/hugo-theme-altinn/layouts/partials/header.html
+++ b/themes/hugo-theme-altinn/layouts/partials/header.html
@@ -32,6 +32,7 @@
     <script src="{{"js/jquery-2.x.min.js" | relURL}}"></script>
     <!-- Typesense Docsearch -->
     <script src="https://cdn.jsdelivr.net/npm/typesense-docsearch.js@3.4"></script>
+    <link rel="preconnect" href="https://altinn-typesense-api.azurewebsites.net" crossorigin />
 
     {{- partial "custom-head.html" . -}}
 
@@ -57,6 +58,7 @@
         <script>
           {{ template "activeMenus" dict "page" . "value" (printf "$(\"li.dd-item a[href='%s']\").parent().addClass(\"active\");" .RelPermalink) }}
         </script>
+
         <section id="body">
           <div id="typesense-searchbar"></div>
           <script>
@@ -74,6 +76,7 @@
               typesenseSearchParameters: { // Optional.
                 //filter_by: 'version_tag:=0.21.0' // Useful when you have versioned docs
               },
+
             });
           </script>
 

--- a/themes/hugo-theme-altinn/layouts/partials/header.html
+++ b/themes/hugo-theme-altinn/layouts/partials/header.html
@@ -18,6 +18,8 @@
     <link href="{{"css/horsey.css" | relURL}}" rel="stylesheet">
     <link href="{{"css/fortawesome.css" | relURL}}" rel="stylesheet">
     <link href="{{"css/designsystem.css" | relURL}}" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/typesense-docsearch-css@0.3.0" rel="stylesheet" >
+
     {{- with .Site.Params.themeStyle -}}
     <link href="{{(printf "css/%s.css" .) | relURL}}" rel="stylesheet">
     {{- else -}}
@@ -28,6 +30,8 @@
     {{- end -}}
 
     <script src="{{"js/jquery-2.x.min.js" | relURL}}"></script>
+    <!-- Typesense Docsearch -->
+    <script src="https://cdn.jsdelivr.net/npm/typesense-docsearch.js@3.4"></script>
 
     {{- partial "custom-head.html" . -}}
 
@@ -54,6 +58,25 @@
           {{ template "activeMenus" dict "page" . "value" (printf "$(\"li.dd-item a[href='%s']\").parent().addClass(\"active\");" .RelPermalink) }}
         </script>
         <section id="body">
+          <div id="typesense-searchbar"></div>
+          <script>
+            docsearch({
+              container: '#typesense-searchbar',
+              typesenseCollectionName: 'altinn-studio-docs', // Should match the collection name you mention in the docsearch scraper config.js
+              typesenseServerConfig: { 
+                nodes: [{
+                  host: 'altinn-typesense-api.azurewebsites.net', // For Typesense Cloud use xxx.a1.typesense.net
+                  port: '443',      // For Typesense Cloud use 443
+                  protocol: 'https'   // For Typesense Cloud use https
+                }],
+                apiKey: 'xyx', // Use API Key with only Search permissions
+              },
+              typesenseSearchParameters: { // Optional.
+                //filter_by: 'version_tag:=0.21.0' // Useful when you have versioned docs
+              },
+            });
+          </script>
+
           <div id="content" class="adocs-content js-moveChildrenTo">
         <div id="overlay"></div>
         <div class="a-text">

--- a/themes/hugo-theme-altinn/layouts/partials/header.html
+++ b/themes/hugo-theme-altinn/layouts/partials/header.html
@@ -75,6 +75,12 @@
               },
               typesenseSearchParameters: { // Optional.
                 //filter_by: 'version_tag:=0.21.0' // Useful when you have versioned docs
+                query_by: 'content,embedding',
+                prioritize_exact_match: false,
+                sort_by: "_text_match:desc",
+                drop_tokens_threshold: 5,
+                group_limit: 4,
+                limit: 14,
               },
 
             });

--- a/themes/hugo-theme-altinn/static/css/theme.css
+++ b/themes/hugo-theme-altinn/static/css/theme.css
@@ -240,6 +240,16 @@ textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[typ
 .searchbox input:-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
 }
+#typesense-searchbar {
+    margin-bottom: unset;
+    background-color: unset;
+    border: unset;
+}
+input#docsearch-input {
+    margin-bottom: unset;
+    background-color: unset;
+    border: unset;
+}
 
 /* SIDEBAR TOGGLE */ 
 #sidebar-toggle-span {

--- a/themes/hugo-theme-altinn/static/css/theme.css
+++ b/themes/hugo-theme-altinn/static/css/theme.css
@@ -250,7 +250,10 @@ input#docsearch-input {
     background-color: unset;
     border: unset;
 }
+.DocSearch-Footer {
+    display: none;
 
+}
 /* SIDEBAR TOGGLE */ 
 #sidebar-toggle-span {
     display: none;


### PR DESCRIPTION
This PR is for testing the user experience of typesense.

There are a lot of configuration options that affect how the crawler parsers the HTML and which url paths it indexes. Fortunately, there are thousands of example configurations published here:

https://github.com/algolia/docsearch-configs/blob/master/configs/


For now, I crawled docs.altinn.studio by running the crawler locally for now. Will create a separate PR for the scheduled job to crawl automatically after each PR in the docs repo is merged to master branch.

