### PR TITLE
Removal of filter description for repeating groups

### DIFF
--- a/content/app/development/ux/fields/grouping/repeating/dynamics/_index.en.md
+++ b/content/app/development/ux/fields/grouping/repeating/dynamics/_index.en.md
@@ -18,31 +18,3 @@ hide a row when the firstName within the data model is equal to "John".
 }
 ```
 You can read more about [expressions here](/app/development/logic/expressions).
-
-## Filter (deprecated)
-
-{{%notice warning%}}
-This functionality will be deprecated and you should use `hiddenRow` with expressions instead. Read more above.
-{{% /notice %}}
-
-Support to filter elements in group, so that only the elements matching the defined criteria are displayed.
-E.g. in a group displaying work experience, only display the elements where the workplace was Oslo.
-List of criteria is based on values of one or more fields in the group, on the format:
-
-```json
-"edit": {
-  "filter": [
-    { "key": "<felt i datamodell>", "value": "<ønsket verdi>" }
-  ]
-}
-```
-
-If there are multiple criteria, all must match for the element to be displayed.
-
-If there is only one result, this is displayed automatically in editing-mode. If there are multiple elements in the group that match the filter, these will be displayed.
-Other elements in the group will be hidden. `filter` can be combined with the `mode`-parameter.
-
-{{%notice warning%}}
-If you combine `"mode": "showAll"` with `"filter"`, it will not be possible to add more elements to the group. This is because with "showAll" only the editing area is displayed,
-and as long as the filter does not match, the element will not be displayed.
-{{% /notice %}}

--- a/content/app/development/ux/fields/grouping/repeating/dynamics/_index.nb.md
+++ b/content/app/development/ux/fields/grouping/repeating/dynamics/_index.nb.md
@@ -18,32 +18,3 @@ vi kan skjule en rad dersom fornavn i datamodellen er lik "John".
 }
 ```
 Du kan lese mer om [dynamiske utrykk her](/app/development/logic/expressions).
-
-## Filter (utgår)
-
-{{%notice warning%}}
-Denne funksjonaliteten vil bli avviklet. Vennligst bruk `hiddenRow` med dynamiske utrykk istedenfor. Se ovenfor.
-{{% /notice %}}
-
-
-Støtte for å filtrere elementene i gruppen, slik at kun de elementene som matcher de definerte kriteriene vises.
-F.eks. i en gruppe som viser arbeidserfaring, vis kun de elementene der arbeidssted var Oslo.
-Liste med kriterier er basert på verdi av ett eller flere felter i gruppen, på formen
-
-```json
-"edit": {
-  "filter": [
-    { "key": "<felt i datamodell>", "value": "<ønsket verdi>" }
-  ]
-}
-```
-
-Dersom det er flere kriterier, må alle matche for at elementet skal vises.
-
-Om det kun er ett resultat, vises dette automatsk i redigerings-modus. Om det er flere elementer i gruppen som matcher filteret, vil disse vises.
-Andre elementer i gruppen skjules. `filter` kan kombineres med `mode`-parameter.
-
-{{%notice warning%}}
-Om man kombinerer `"mode": "showAll"` med `"filter"`, vil det ikke fungere å legge til nye elementer i gruppen. Dette er fordi man med "showAll" kun
-viser redigerings-flaten, og så lenge filteret ikke matcher, vil ikke elementet vises.
-{{% /notice %}}


### PR DESCRIPTION
We no longer supports `filter` for repeating groups (except for start/stop functionality in likert). This PR removed the description of filter in rep.groups. 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
