### PR TITLE
fix: remove accidental |-character in soft validation documentation

### DIFF
--- a/content/app/development/logic/validation/_index.en.md
+++ b/content/app/development/logic/validation/_index.en.md
@@ -552,7 +552,7 @@ and `validateRow` only runs validation on the row the user is trying to save. Ex
   "data": {
     "layout": [
       {
-        "id": "demo-gruppe",|
+        "id": "demo-gruppe",
         "type": "Group",
         "children": [
             "..."


### PR DESCRIPTION
Removes a |-character that was accidentally added in #1378 