### PR TITLE
`dotnet` version bumped from 7 to 8 for NuGet automation

### DIFF
--- a/content/community/contributing/handbook/back-end/nuget-package/_index.md
+++ b/content/community/contributing/handbook/back-end/nuget-package/_index.md
@@ -139,12 +139,14 @@ package generation and publishing.
             with:
               fetch-depth: 0
 
-          - name: Install dotnet8
+          - name: Install dotnet
             uses: actions/setup-dotnet@v3
             with:
               dotnet-version: 8.0.x
           - name: Install deps
-            run:  dotnet restore
+            run: |
+              cd src/Altinn.Common.AccessTokenClient
+              dotnet restore
           - name: Build AccessTokenClient
             if: startsWith(github.ref, 'refs/tags/Altinn.Common.AccessTokenClient-')
             run: |

--- a/content/community/contributing/handbook/back-end/nuget-package/_index.md
+++ b/content/community/contributing/handbook/back-end/nuget-package/_index.md
@@ -139,10 +139,10 @@ package generation and publishing.
             with:
               fetch-depth: 0
 
-          - name: Install dotnet6
+          - name: Install dotnet8
             uses: actions/setup-dotnet@v3
             with:
-              dotnet-version: 7.0.x
+              dotnet-version: 8.0.x
           - name: Install deps
             run:  dotnet restore
           - name: Build AccessTokenClient


### PR DESCRIPTION
This PR is the result of this PR discussion: https://github.com/Altinn/altinn-platform/pull/670#discussion_r1484201664

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] All tests run green
