### PR TITLE
fix: add documentation for the new layout-set based receipt

### DIFF
--- a/content/app/development/configuration/process/customize/_index.en.md
+++ b/content/app/development/configuration/process/customize/_index.en.md
@@ -10,12 +10,14 @@ An application wil have a process which the user of the application follows.
 Depending of the type of step the user is in, different views are presented.
 This page explains the different views and how they can be customized.
 
-## Data 
+## Data
+
 In this process task a form which the user can fill in data.
 The form can be edited using the [UI editor](/app/getting-started) or by changing `FormLayout.json` manually.
 
 ## Confirmation
-In this process task some standard texts are presented and the user can choose to *confirm* to go forward.
+
+In this process task some standard texts are presented and the user can choose to _confirm_ to go forward.
 
 These texts can be overridden by manually adding each defined text keys in the apps text resources. More information about how this is done can be found [here](../../../ux/texts).
 In the following section we will present an overview of the different texts that can be customized.
@@ -24,16 +26,16 @@ In the following section we will present an overview of the different texts that
 
 ### Customize texts
 
-| Text # (see image above)  | Text key            |
-| ------------------------- | ------------------- |
-| 1                         | confirm.title       |
-| 2                         | confirm.sender      |
-| 3                         | confirm.body        |
-| 4                         | confirm.answers     |
-| 5                         | confirm.attachments |
-| 6                         | confirm.button_text |
+| Text # (see image above) | Text key            |
+| ------------------------ | ------------------- |
+| 1                        | confirm.title       |
+| 2                        | confirm.sender      |
+| 3                        | confirm.body        |
+| 4                        | confirm.answers     |
+| 5                        | confirm.attachments |
+| 6                        | confirm.button_text |
 
-Example of custom texts in the file  `resources.nb.json`:
+Example of custom texts in the file `resources.nb.json`:
 
 ```json
 {
@@ -76,23 +78,19 @@ An example setup of the `layout-sets.json` where `Task_1` is a data step, and `T
 
 ```json
 {
-    "sets": [
-      {
-        "id": "simple",
-        "dataType": "simple",
-        "tasks": [
-          "Task_1"
-        ]
-      },
-      {
-        "id": "custom-confirmation",
-        "dataType": "simple",
-        "tasks": [
-          "Task_2"
-        ]
-      }
-    ]
-  }
+  "sets": [
+    {
+      "id": "simple",
+      "dataType": "simple",
+      "tasks": ["Task_1"]
+    },
+    {
+      "id": "custom-confirmation",
+      "dataType": "simple",
+      "tasks": ["Task_2"]
+    }
+  ]
+}
 ```
 
 Notice that the layout-set configuration for `Task_2` references the data model used in `Task_1`.
@@ -165,6 +163,7 @@ The end result:
 For a complete setup of this feature see our [example app.](https://altinn.studio/repos/ttd/custom-view-confirm)
 
 ## Feedback
+
 This is a process step where the application owner can validate the filled data to generate a feedback before the data is archived.
 
 In the following section we will present an overview of the different texts that can be customized.
@@ -173,12 +172,12 @@ In the following section we will present an overview of the different texts that
 
 ### Customize texts
 
-| Text # (see image above)  | Text key          |
-| ------------------------- | ----------------- |
-| 1                         | feedback.title    |
-| 2                         | feedback.body     |
+| Text # (see image above) | Text key       |
+| ------------------------ | -------------- |
+| 1                        | feedback.title |
+| 2                        | feedback.body  |
 
-Example of custom texts in the file  `resources.nb.json`:
+Example of custom texts in the file `resources.nb.json`:
 
 ```json
 {
@@ -192,6 +191,7 @@ Example of custom texts in the file  `resources.nb.json`:
 ```
 
 ## Receipt
+
 In this process task the process will be ended and some standard texts are shown.
 
 These texts can be overridden by manually adding each defined text key in the app's text resources. More information about how this is done can be found [here](../../../ux/texts).
@@ -202,16 +202,15 @@ If the actual recipient of the form is a different organization than the organiz
 
 ![Receipt view](receipt-step.png "Texts that can be customized in the receipt view")
 
-| Text # (see image above)  | Text key                |
-|---------------------------|-------------------------|
-| 1                         | receipt.receipt         |
-| 2                         | receipt.title           |
-| 3                         | receipt.subtitle        |
-| 4                         | receipt.body            |
-| 5                         | receipt.title_submitted |
+| Text # (see image above) | Text key                |
+| ------------------------ | ----------------------- |
+| 1                        | receipt.receipt         |
+| 2                        | receipt.title           |
+| 3                        | receipt.subtitle        |
+| 4                        | receipt.body            |
+| 5                        | receipt.title_submitted |
 
-
-Example of custom texts in the file  `resources.nb.json`:
+Example of custom texts in the file `resources.nb.json`:
 
 ```json
 {
@@ -244,31 +243,87 @@ This results in the following view:
 
 ### Custom form layout
 
-{{%notice warning%}}
-This is a temporary approach for customizing the receipt page just as any other pages in the form. When support for layout-sets is available in Altinn Studio it will be possible to customize the receipt page in the same way as the confirmation page.
-{{%/notice%}}
+A custom receipt view can now be created in the same way as all other form pages. The functionality will also
+soon be available in Altinn Studio.
 
-A custom receipt can be made in the same way as any other form page. The functionality will also be available in Altinn
-Studio shortly.
+To create a custom receipt view, you create a new layout set. This layout set works exactly like
+all other page types. Within the layout set, you can create a layouts folder and here define all the pages you want to
+include in the receipt view (Yes, the receipt view supports multiple pages!). Inside the layout set, you must also create
+a `Settings.json`, where you can define the order of the pages in the receipt view.
 
-Build the layout as usual and refer to the filename of the layout in `setting.json` with the key `receiptLayoutName`.
-See below example where the layout file `receipt.json` is referred to.
+For the app to understand that this layout set should be used as a receipt view, you must refer to the name of the layout set
+in `layout-sets.json`. Add a new layout set with `id` that refers to the name of your layout set, and add
+the key value `"CustomReceipt"` in the `tasks` array of the layout set. In addition, you can specify which data model
+should be available in the receipt view by adding the key `dataType` with the name of the data model you want to support.
+
+Here is a complete example where we have a layout set named custom-receipt that will be used as a receipt view:
+
+{{<content-version-selector classes="border-box">}}
+{{<content-version-container version-label="Folder structure">}}
+
+```
+|- App/
+  |- ui/
+    |- layout-sets.json
+    |- custom-receipt/
+      |- layouts/
+        |- page1.json
+        |- page2.json
+      |- Settings.json
+```
+
+{{</content-version-container>}}
+{{</content-version-selector>}}
+
+{{<content-version-selector classes="border-box">}}
+{{<content-version-container version-label="Code">}}
+
+{{<code-title>}}
+App/ui/layout-sets.json
+{{</code-title>}}
+
+```json {hl_lines=[4,6]}
+{
+  "sets": [
+    {
+      "id": "custom-receipt",
+      "dataType": "fields",
+      "tasks": ["CustomReceipt"]
+    }
+  ]
+}
+```
+
+{{</content-version-container>}}
+{{</content-version-selector>}}
+
+{{<content-version-selector classes="border-box">}}
+{{<content-version-container version-label="Code">}}
+
+{{<code-title>}}
+App/ui/custom-receipt/Settings.json
+{{</code-title>}}
 
 ```json
 {
   "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
   "pages": {
-    "order": [
-      "page1",
-      "page2",
-      "page3"
-    ]
-  },
-  "receiptLayoutName": "receipt"
+    "order": ["page1", "page2"]
+  }
 }
 ```
 
-Example of a customized layout file for the receipt.
+{{</content-version-container>}}
+{{</content-version-selector>}}
+
+Example of a custom layout for the receipt:
+
+{{<content-version-selector classes="border-box">}}
+{{<content-version-container version-label="Code">}}
+
+{{<code-title>}}
+App/ui/custom-receipt/layouts/page1.json
+{{</code-title>}}
 
 ```json
 {
@@ -315,7 +370,7 @@ Example of a customized layout file for the receipt.
       {
         "id": "ReceiptInstanceInformation",
         "type": "InstanceInformation",
-        "elements":{
+        "elements": {
           "dateSent": false
         }
       },
@@ -338,6 +393,9 @@ Example of a customized layout file for the receipt.
 }
 ```
 
+{{</content-version-container>}}
+{{</content-version-selector>}}
+
 Resulting receipt in the application:
 
 ![Custom receipt](custom-receipt.png "Custom receipt")
@@ -351,13 +409,13 @@ In the following section we will present an overview of the different texts that
 
 ![Simple receipt view](simple-receipt-step.png "Texts that can be customized in the simple receipt view")
 
-| Text # (see image above)  | Text key                |
-|---------------------------|-------------------------|
-| 1                         | receipt.receipt         |
-| 2                         | receipt.title           |
-| 3                         | receipt.body_simple     |
+| Text # (see image above) | Text key            |
+| ------------------------ | ------------------- |
+| 1                        | receipt.receipt     |
+| 2                        | receipt.title       |
+| 3                        | receipt.body_simple |
 
-Example of custom texts in the file  `resources.nb.json`:
+Example of custom texts in the file `resources.nb.json`:
 
 ```json
 {

--- a/content/app/development/configuration/process/customize/_index.nb.md
+++ b/content/app/development/configuration/process/customize/_index.nb.md
@@ -5,16 +5,18 @@ description: Hvordan tilpasse visninger i forskjellige steg av en prosess.
 toc: true
 ---
 
-En applikasjon vil ha en prosess som brukeren av applikasjonen vil følge. 
-Avhengig av hvilken type steg brukeren er i, vil forskjellige ting vises. 
+En applikasjon vil ha en prosess som brukeren av applikasjonen vil følge.
+Avhengig av hvilken type steg brukeren er i, vil forskjellige ting vises.
 Denne siden vil forklare hvordan visningen til de forskjellige stegene kan tilpasses.
 
 ## Data (tilsvarer utfyllingssteg i Altinn II)
+
 I denne prosess-task-typen vises skjema som kan fylles ut.  
 Skjema kan redigeres ved bruk av [UI editoren](/nb/app/getting-started) eller ved å endre `FormLayout.json` direkte.
 
 ## Bekreftelse (Confirmation)
-I denne prosess-task-typen vises noen standard-tekster, og bruker kan velge å *bekrefte* for å gå videre.
+
+I denne prosess-task-typen vises noen standard-tekster, og bruker kan velge å _bekrefte_ for å gå videre.
 
 Tekstene kan overstyres, ved at man legger inn tekstnøkkel som hører til hver tekst i språkfilene for appen. Info
 om hvordan dette gjøres finner du [her](../../../ux/texts). Se under for oversikt over de forskjellige tekstnøklene som kan
@@ -32,7 +34,6 @@ overstyres.
 | 4                         | confirm.answers     |
 | 5                         | confirm.attachments |
 | 6                         | confirm.button_text |
-
 
 Eksempel på overstyrte tekster i filen `resources.nb.json`:
 
@@ -74,23 +75,19 @@ Eksempel oppsett av `layout-sets.json` hvor `Task_1` er et datasteg, og `Task_2`
 
 ```json
 {
-    "sets": [
-      {
-        "id": "simple",
-        "dataType": "simple",
-        "tasks": [
-          "Task_1"
-        ]
-      },
-      {
-        "id": "custom-confirmation",
-        "dataType": "simple",
-        "tasks": [
-          "Task_2"
-        ]
-      }
-    ]
-  }
+  "sets": [
+    {
+      "id": "simple",
+      "dataType": "simple",
+      "tasks": ["Task_1"]
+    },
+    {
+      "id": "custom-confirmation",
+      "dataType": "simple",
+      "tasks": ["Task_2"]
+    }
+  ]
+}
 ```
 
 Legg merke til at konfigurasjonen for settet til `Task_2` referer til data typen til `Task_1`.
@@ -163,6 +160,7 @@ Sluttresultatet i appen:
 For et komplett oppsett av denne muligheten kan du se vår [eksempel applikasjon.](https://altinn.studio/repos/ttd/custom-view-confirm)
 
 ## Tilbakemelding (Feedback)
+
 Dette er et prosesssteg hvor applikasjonseier vil sjekke utfylte data for å generere en tilbakemelding før alle data kan arkiveres.
 
 Tekstene på siden kan overstyres ved at man legger inn tekstnøkler som hører til hver tekst i språkfilene for appen. Info om hvordan dette gjøres finner du [her](../../../ux/texts). Se under for oversikt over de forskjellige tekstnøklene som kan overstyres.
@@ -171,10 +169,10 @@ Tekstene på siden kan overstyres ved at man legger inn tekstnøkler som hører 
 
 ### Overstyre tekster
 
-| Tekst nr. (se bilde over) | Tekstnøkkel       |
-| ------------------------- | ----------------- |
-| 1                         | feedback.title    |
-| 2                         | feedback.body     |
+| Tekst nr. (se bilde over) | Tekstnøkkel    |
+| ------------------------- | -------------- |
+| 1                         | feedback.title |
+| 2                         | feedback.body  |
 
 Eksempel på overstyrte tekster i filen `resources.nb.json`:
 
@@ -190,7 +188,8 @@ Eksempel på overstyrte tekster i filen `resources.nb.json`:
 ```
 
 ## Kvittering (Receipt)
-I denne prosess-task-typen er prosessen ferdig og noen standardtekster vises. 
+
+I denne prosess-task-typen er prosessen ferdig og noen standardtekster vises.
 
 Tekstene kan overstyres, ved at man legger inn tekstnøkkel som hører til hver tekst i språkfilene for appen. Info om hvordan dette gjøres finner du [her](../../../ux/texts).
 
@@ -201,13 +200,12 @@ Dersom den reelle mottakeren av skjemaet er en annen organisasjon enn organisasj
 ![Kvitterings-visningen](receipt-step.png "Tekster som kan endres/overstyres i kvitterings-visningen")
 
 | Tekst nr. (se bilde over) | Tekstnøkkel             |
-|---------------------------|-------------------------|
+| ------------------------- | ----------------------- |
 | 1                         | receipt.receipt         |
 | 2                         | receipt.title           |
 | 3                         | receipt.subtitle        |
 | 4                         | receipt.body            |
 | 5                         | receipt.title_submitted |
-
 
 Eksempel på overstyrte tekster i filen `resources.nb.json`:
 
@@ -242,29 +240,87 @@ Dette resulterer i følgende visning:
 
 ### Custom form layout
 
-{{%notice warning%}}
-Dette er en midlertidig fremgangsmåte for å fleksibelt bygge kvitteringssiden på samme måte som andre skjemasider. Når støtte for layout-sets blir tilgjengelig i Altinn Studio vil tilpasning av kvittering skje på tilsvarende måte som for bekreftelsessiden.
-{{%/notice%}}
+En egendefinert kvitteringsvisning kan nå lages på samme måte som alle andre skjemasider. Funksjonaliteten vil også
+innen kort tid bli tilgjengelig i Altinn Studio.
 
-En egendefinert kvitteringsside kan nå lages på samme måte som alle andre skjemasider. Funksjonaliteten vil også innen kort tid bli tilgjengelig i Altinn Studio. 
+For å lage en egendefinert kvitteringsvisning lager du en ny sidegruppe (layout set). Denne sidegruppen fungerer helt likt
+som alle andre sidetyper. Innenfor sidegruppen kan du opprette en mappe `layouts` og her definere alle sider du ønsker at
+skal inngå i kvitteringsvisningen (Ja, kvitteringsvisning støtter flere sider!). Inne i sidegruppen må du også lage
+`Settings.json`, hvor du kan definere rekkefølgen på sidene i kvitteringsvisningen.
 
-Bygg layoutfilen på vanlig måte og referer til navnet på denne layoutfilen i `settings.json` med nøkkelen `receiptLayoutName`. Se eksempelet under for en layout med filnavnet `kvittering.json`.
+For at appen skal forstå at denne sidegruppen skal brukes som kvitteringsvisning må du referere til navnet på sidegruppen
+i `layout-sets.json`. Legg til en ny sidegruppe med `id` som referer til navnet på sidegruppen din, og legg til
+nøkkelverdien `"CustomReceipt"` i `tasks`-arrayet til sidegruppen. I tillegg kan du spesifisere hvilken datamodell som
+skal være tilgjengelig i kvitteringsvisningen ved å legge til nøkkelen `dataType` med navnet på datamodellen du vil støtte.
+
+Her er et fullt eksempel hvor vi har en sidegruppe med navnet `custom-receipt` som skal brukes som kvitteringsvisning:
+
+{{<content-version-selector classes="border-box">}}
+{{<content-version-container version-label="Mappestruktur">}}
+
+```
+|- App/
+  |- ui/
+    |- layout-sets.json
+    |- custom-receipt/
+      |- layouts/
+        |- side1.json
+        |- side2.json
+      |- Settings.json
+```
+
+{{</content-version-container>}}
+{{</content-version-selector>}}
+
+{{<content-version-selector classes="border-box">}}
+{{<content-version-container version-label="Kode">}}
+
+{{<code-title>}}
+App/ui/layout-sets.json
+{{</code-title>}}
+
+```json {hl_lines=[4,6]}
+{
+  "sets": [
+    {
+      "id": "custom-receipt",
+      "dataType": "fields",
+      "tasks": ["CustomReceipt"]
+    }
+  ]
+}
+```
+
+{{</content-version-container>}}
+{{</content-version-selector>}}
+
+{{<content-version-selector classes="border-box">}}
+{{<content-version-container version-label="Kode">}}
+
+{{<code-title>}}
+App/ui/custom-receipt/Settings.json
+{{</code-title>}}
 
 ```json
 {
   "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
   "pages": {
-    "order": [
-      "side1",
-      "side2",
-      "side3"
-    ]
-  },
-  "receiptLayoutName": "kvittering"
+    "order": ["side1", "side2"]
+  }
 }
 ```
 
+{{</content-version-container>}}
+{{</content-version-selector>}}
+
 Eksempel på en egendefinert layoutfil for kvittering:
+
+{{<content-version-selector classes="border-box">}}
+{{<content-version-container version-label="Kode">}}
+
+{{<code-title>}}
+App/ui/custom-receipt/layouts/side1.json
+{{</code-title>}}
 
 ```json
 {
@@ -311,7 +367,7 @@ Eksempel på en egendefinert layoutfil for kvittering:
       {
         "id": "ReceiptInstanceInformation",
         "type": "InstanceInformation",
-        "elements":{
+        "elements": {
           "dateSent": false
         }
       },
@@ -334,6 +390,9 @@ Eksempel på en egendefinert layoutfil for kvittering:
 }
 ```
 
+{{</content-version-container>}}
+{{</content-version-selector>}}
+
 Sluttresultatet i appen:
 
 ![Custom kvitteringsvisning](custom-receipt.png "Custom kvitteringsvisning")
@@ -347,11 +406,11 @@ Følgende avsnitt viser en oversikt over hvilke tekster som kan tilpasses.
 
 ![Enkel kvitteringsvisning](simple-receipt-step.png "Tekster som kan endres/overstyres i kvitteringsvisningen")
 
-| Tekst # (se bilde over)   | Tekstnøkkel             |
-|---------------------------|-------------------------|
-| 1                         | receipt.receipt         |
-| 2                         | receipt.title           |
-| 3                         | receipt.body_simple     |
+| Tekst # (se bilde over) | Tekstnøkkel         |
+| ----------------------- | ------------------- |
+| 1                       | receipt.receipt     |
+| 2                       | receipt.title       |
+| 3                       | receipt.body_simple |
 
 Eksempel på overstyrte tekster i filen `resources.nb.json`:
 

--- a/content/community/changelog/app-frontend/v4/_index.en.md
+++ b/content/community/changelog/app-frontend/v4/_index.en.md
@@ -38,6 +38,84 @@ This entails a slightly different folder structure in the `ui` folder of your ap
 This used to be optional, but as of v4 it is required, even for apps with only a single data step.
 See the [documentation on layout sets](/app/development/ux/pages/layout-sets) for more information.
 
+## Defining a custom receipt is now done with a layout set
+
+{{% notice info %}}
+This change was introduced in `v4.0.0-rc3`. It was not present in `v4.0.0-rc1` or `v4.0.0-rc2`. In these previous versions,
+a custom receipt was not supported.
+{{% /notice %}}
+A custom receipt view can now be created in the same way as all other form pages.
+
+To create a custom receipt view, you create a new layout set. This layout set works exactly like
+all other page types. Within the layout set, you can create a layouts folder and here define all the pages you want to
+include in the receipt view (Yes, the receipt view supports multiple pages!). Inside the layout set, you must also create
+a `Settings.json`, where you can define the order of the pages in the receipt view.
+
+For the app to understand that this layout set should be used as a receipt view, you must refer to the name of the layout set
+in `layout-sets.json`. Add a new layout set with `id` that refers to the name of your layout set, and add
+the key value `"CustomReceipt"` in the `tasks` array of the layout set. In addition, you can specify which data model
+should be available in the receipt view by adding the key `dataType` with the name of the data model you want to support.
+
+Here is a complete example where we have a layout set named custom-receipt that will be used as a receipt view:
+
+{{<content-version-selector classes="border-box">}}
+{{<content-version-container version-label="Folder structure">}}
+
+```
+|- App/
+  |- ui/
+    |- layout-sets.json
+    |- custom-receipt/
+      |- layouts/
+        |- page1.json
+        |- page2.json
+      |- Settings.json
+```
+
+{{</content-version-container>}}
+{{</content-version-selector>}}
+
+{{<content-version-selector classes="border-box">}}
+{{<content-version-container version-label="Code">}}
+
+{{<code-title>}}
+App/ui/layout-sets.json
+{{</code-title>}}
+
+```json {hl_lines=[4,6]}
+{
+  "sets": [
+    {
+      "id": "custom-receipt",
+      "dataType": "fields",
+      "tasks": ["CustomReceipt"]
+    }
+  ]
+}
+```
+
+{{</content-version-container>}}
+{{</content-version-selector>}}
+
+{{<content-version-selector classes="border-box">}}
+{{<content-version-container version-label="Code">}}
+
+{{<code-title>}}
+App/ui/custom-receipt/Settings.json
+{{</code-title>}}
+
+```json
+{
+  "$schema": "https://altinncdn.no/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": ["page1", "page2"]
+  }
+}
+```
+
+{{</content-version-container>}}
+{{</content-version-selector>}}
+
 ## AddressComponent has been renamed to Address
 
 {{% notice info %}}
@@ -223,7 +301,7 @@ Example of old to new config:
   type; `"RepeatingGroup"`
 - `"maxCount"` is no longer required to create a repeating group, but is still able to be used to restrict the maximum
   number of addable rows.
-- `edit.filter` is no longer supported, but the same functionality (or better) can be achieved by using the 
+- `edit.filter` is no longer supported, but the same functionality (or better) can be achieved by using the
   existing `hiddenRow` property with [expressions](/app/development/logic/expressions).
 
 Example of old to new config:
@@ -374,7 +452,7 @@ This functions more or less the same as before, but the configuration has been c
 
 This change also has the advantage that the need for `*FIXED*` validations no longer exists, as a
 `IFormDataValidator` in your custom backend code can now control when it should run, and when it runs all its validation
-messages are treated as one *group*. This means that if you have a validation that checks the value of *another field*,
+messages are treated as one _group_. This means that if you have a validation that checks the value of _another field_,
 or multiple fields at once, the validation message will disappear in frontend when the validation message is no longer
 added to the list of validation messages in the backend - even if another component than the validation message target
 was the one that changed.


### PR DESCRIPTION
## Description
This PR adds documentation of how to use the new layout-set based way of configuring custom receipt pages. 

## Related Issue(s)
- Altinn/app-frontend-react#1468

