### PR TITLE
Which account to use for Application Insights and KeyStore

### DIFF
--- a/content/app/guides/access-management/apps/_index.en.md
+++ b/content/app/guides/access-management/apps/_index.en.md
@@ -1,21 +1,28 @@
 ---
 title: Apps infrastructure access
 linktitle: Apps
-description: How to request access to Altinn Apps infrastructure.
-toc: false
+description: How to request access to app logs and secrets.
+toc: true
 weight: 200
 ---
 
-## Access to logs and secrets
-
+## Roles
 There are two different roles that give access to the runtime environments in Altinn Apps.
-
-- _Developer_ : grants access to _Application Insights_ where logs for the applications owned by the service owner are stored.
-- _Operations_ : grants access to _Key Vault_ which is used to manage the secrets used by applications.
 
 There are two variants of each role: one for test (TT02) and one for production (prod).
 A user can be assigned one or more roles.
 
+### Developer
+The role Developer grants access to
+[Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)
+where logs for the applications owned by the service owner are stored.
+
+### Operations
+The role Operations grants access to [Key Vault](https://learn.microsoft.com/nb-NO/azure/key-vault/general/basic-concepts)
+which is used to manage the secrets used by applications.
+
+
+## Creating a ticket
 The following roles can be requested assigned to a user by the service owner:
 
 - Test Developer
@@ -33,4 +40,8 @@ To create a ticket requesting a new role for you user click the tab _"Support"_ 
 * Finally, specify the desired roles along with the contact information of the user who the roles should be granted to.
 
 When the user has been assigned the requested roles logs and/or secrets can be accessed through [Microsoft Azure Portal](https://portal.azure.com).
-For login you use the same accountas for the self-service portal: 'username@ai-dev.brreg.no'.
+
+For login you use the same account as for the self-service portal:
+
+- `username@ai-dev.no` (most people)
+- `username@ai-dev.brreg.no` (a few still uses this)

--- a/content/app/guides/access-management/apps/_index.nb.md
+++ b/content/app/guides/access-management/apps/_index.nb.md
@@ -1,20 +1,28 @@
 ---
 title: Apps infrastruktur tilganger
 linktitle: Apps
-description: Hvordan bestille tilganger til Altinn Apps infrastruktur.
-toc: false
+description: Hvordan bestille tilganger til app logger og hemmeligheter.
+toc: true
 weight: 200
 ---
 
-## Tilgang til logger og hemmeligheter
-
+## Roller
 Det er definert to forskjellige typer roller for tilgang i driftsmiljøene i Altinn Apps.
 
-- _Developer_ gir tilgang til _Application Insights_ der applikasjonslogger samles for tjenesteeier sine applikasjoner i miljøet.
-- _Operations_ gir tilgang til _Key Vault_ for å laste opp hemmeligheter som sertifikater, passord og api-nøkler.
+Disse rollene er videre delt opp i tilgang til test (TT02) og produksjon (prod).
+En bruker kan tildeles en eller flere roller.
 
-Disse rollene er videre delt opp i tilgang til test (TT02) og produksjon (prod). En bruker kan tildeles en eller flere roller.
+### Developer
+Rollen Developer gir tilgang til
+[Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)
+der applikasjonslogger samles for tjenesteeier sine applikasjoner i miljøet.
 
+### Operations
+Rollen Operations gir tilgang til [Key Vault](https://learn.microsoft.com/nb-NO/azure/key-vault/general/basic-concepts)
+for å laste opp hemmeligheter som sertifikater, passord og api-nøkler.
+
+
+## Bestilling
 Tjenesteeiere kan bestille følgende tilganger for sine ressurser i miljøene TT02 og produksjon:
 
 - Test Developer
@@ -22,7 +30,7 @@ Tjenesteeiere kan bestille følgende tilganger for sine ressurser i miljøene TT
 - Prod Developer
 - Prod Operations
 
-For å få aksess til disse rollene må autoriserte bestillere hos Tjenesteeier, bestille dette på vår [Selvbetjeningsportal](https://www.altinndigital.no/oversikt).
+For å få tilgang til disse rollene må autoriserte bestillere hos Tjenesteeier, bestille dette på vår [Selvbetjeningsportal](https://www.altinndigital.no/oversikt).
 Portalen beskriver også hvordan man oppretter en ny bruker hvis man ikke har dette fra før av.
 
 For å opprette en ny sak for å søke om tilgang trykker man først på fanen _Support_ og så _Ny sak_ i menyen til venstre.
@@ -31,4 +39,8 @@ For å opprette en ny sak for å søke om tilgang trykker man først på fanen _
 * Til slutt fylles kontaktinformasjon for brukeren ut, samt hvilke roller hen skal ha tilgang til.
 
 Når rollene har blitt tildelt kan logger og/eller hemmeligheter aksesseres via [Microsoft Azure Portal](https://portal.azure.com).
-Innlogging gjøres med samme konto som til Selvbetjeningsportalen: 'brukernavn@ai-dev.brreg.no'.
+
+Innlogging gjøres med samme konto som til Selvbetjeningsportalen:
+
+- `brukernavn@ai-dev.no` (de fleste)
+- `brukernavn@ai-dev.brreg.no` (noen få benytter fortsatt denne)


### PR DESCRIPTION
The documentation did not describe which account to use for Application Insights and KeyStore management. The support/order-form asks for an email-address, but that is not the user name. It's not obvious to outsiders, that the ADFS login for the self-service portal, and the Endra ID login for Azure-portal, are synced/the same. Espesially given the experience that the Altinn2-RemoteDesktop (Entra ID) login is not linked to the self-service portal.

This PR adds information about the account domain to use for Altinn 3 app insight and keystore.