### PR TITLE
Broken links

### DIFF
--- a/content/api/guides/appownerintegration/receivingdata/_index.md
+++ b/content/api/guides/appownerintegration/receivingdata/_index.md
@@ -52,18 +52,18 @@ Prosessen overordnet
 Utvikling av applikasjon er dekket i Guide for applikasjonsutvikling
 Aktivering av publisering av hendelser fra applikasjon er beskrevet i guide.
 
-Krav til webhook for mottak av events finner du [her](/)
+Krav til webhook for mottak av events finner du [her](/events/subscribe-to-events/developer-guides/setup-subscription/#request)
 
 Tjenesteeier må ha registert en integrasjon i Maskinporten. 
 
-Opprettelse av integrasjon er beskrevet i Guide her.
+Opprettelse av integrasjon er beskrevet i Guide [her](/api/authentication/maskinporten/#tilgang-som-tjenesteeier).
 
 ## Detaljert teknisk prosess
 
 
 ### Tjenesteeiersystem mottar Event fra Altinn Events
 
-Første steget i prosessen er at mottaksendepunkt mottar informasjon om Event fra Applikasjon kjørende i Altinn. Dette forutsetter at [abonnement er satt opp](/events/subscribe-to-events/).
+Første steget i prosessen er at mottaksendepunkt mottar informasjon om Event fra Applikasjon kjørende i Altinn. Dette forutsetter at [abonnement er satt opp](/events/subscribe-to-events/developer-guides/setup-subscription/).
 
 ```
 {


### PR DESCRIPTION
Some updated links

## Description
Another user found some missing, broken and wrong links in this documentation. Found some of the correct links (i think.. please double check). Might add more later when i've found them.

Other missing links include:
- https://docs.altinn.studio/api/guides/appownerintegration/receivingdata/#overordnet-prosess-sluttbruker - Wrong link on number 5
- https://docs.altinn.studio/api/guides/appownerintegration/receivingdata/#instansiering-av-tjeneste - Missing link on how TE can instantiate an app possible links: (https://docs.altinn.studio/nb/api/apps/instances/#create-instance) || (https://docs.altinn.studio/nb/app/development/logic/instantiation/#eksempel-2---instansiering-kun-tillatt-for-applikasjonseier)