### PR TITLE
Bump Hugo to v0.124.0

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.121.2
+      HUGO_VERSION: 0.124.0
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Bump Hugo to v0.124.0

https://github.com/gohugoio/hugo/releases/tag/v0.124.0
