### PR TITLE
Suggest PAT as credential for cloning Altinn repos

### DIFF
--- a/content/app/getting-started/local-dev/_index.en.md
+++ b/content/app/getting-started/local-dev/_index.en.md
@@ -22,6 +22,12 @@ During application development, you will need to work both in Altinn Studio and 
     ```cmd
     $ git clone https://altinn.studio/repos/<org>/<app-name>.git
     ```
+    -  If you have logged into Altinn Studio without creating a password (e.g. using Github login),
+    you can [create a personal access token in Gitea](https://altinn.studio/repos/user/settings/applications)
+    that can be used as a password when cloning:
+    ```cmd
+    $ git clone https://<brukernavn>:<access-token>@altinn.studio/repos/<org>/<app-name>.git
+    ```
     - You should see an output in the terminal similar to this:
     ```cmd
     Cloning into 'app-name'...

--- a/content/app/getting-started/local-dev/_index.nb.md
+++ b/content/app/getting-started/local-dev/_index.nb.md
@@ -24,6 +24,12 @@ Her er en oversikt over hvordan du kommer i gang med lokal utvikling.
     ```cmd
     $ git clone https://altinn.studio/repos/<org>/<app-name>.git
     ```
+    -  Hvis du har logget inn i Altinn Studio uten å lage passord (f. eks. Github login),
+    så kan du [lage et personlig access token i Gitea](https://altinn.studio/repos/user/settings/applications)
+    som kan brukes som passord ved kloning:
+    ```cmd
+    $ git clone https://<brukernavn>:<access-token>@altinn.studio/repos/<org>/<app-name>.git
+    ```
     - I terminalen skal du se en output som likner dette
     ```cmd
     Cloning into 'app-name'...


### PR DESCRIPTION

## Description
Working through the developer course in the docs as a newbie, it wasn't obvious how I should clone the repo for my app
* I've registered using my Github user (so I haven't made a password)
* SSH keys are disabled in Gitea AFAICT

This PR suggests that a PAT can be used as password when cloning the repository. Not sure if there are other ways?

## Related Issue(s)
N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
