### PR TITLE
Guidance on moving/migrating a personal application to an organization for module 3 of the dev course

### DIFF
--- a/content/app/app-dev-course/modul3/_index.en.md
+++ b/content/app/app-dev-course/modul3/_index.en.md
@@ -9,7 +9,7 @@ weight: 20
  This module requires that you are part of an [organization](/app/getting-started/create-user/#join-an-organization) with an enabled test environment for Altinn Apps. If this is not the case, move on to the [next module](../modul4/). 
  <br><br>
  If you have a personal application registered that you would like to move to an organization, 
- [you can ask for access to an organization by asking an administrator or the service desk](https://docs.altinn.studio/app/getting-started/create-user/#join-an-organization).
+ [you can ask for access to an organization by asking an administrator or the service desk](/app/getting-started/create-user/#join-an-organization).
 
  When you have access to an organization with enabled test environments, the application can be moved by following these steps:
  1. Move the repository for the application in Gitea to your organization via the "Settings" menu on the Gitea-page.

--- a/content/app/app-dev-course/modul3/_index.en.md
+++ b/content/app/app-dev-course/modul3/_index.en.md
@@ -6,7 +6,14 @@ tags: [apps, training, build, deploy, test ]
 weight: 20
 ---
 {{% notice warning %}}
- This module requires that you are part of an [organization](/app/getting-started/create-user/#join-an-organization) with an enabled test environment for Altinn Apps. If this is not the case, move on to the [next module](../modul4/).
+ This module requires that you are part of an [organization](/app/getting-started/create-user/#join-an-organization) with an enabled test environment for Altinn Apps. If this is not the case, move on to the [next module](../modul4/). 
+ <br><br>
+ If you have a personal application registered that you would like to move to an organization, 
+ [you can ask for access to an organization by asking an administrator or the service desk](https://docs.altinn.studio/app/getting-started/create-user/#join-an-organization).
+
+ When you have access to an organization with enabled test environments, the application can be moved by following these steps:
+ 1. Move the repository for the application in Gitea to your organization via the "Settings" menu on the Gitea-page.
+ 2. Update the `id` and `org`-fields in the `App/config/applicationmetadata.json`-file, so that they refer to the new organization 
 {{% /notice %}}
 
 

--- a/content/app/app-dev-course/modul3/_index.nb.md
+++ b/content/app/app-dev-course/modul3/_index.nb.md
@@ -8,6 +8,13 @@ weight: 20
 
 {{% notice warning %}}
  Denne modulen krever at du er medlem av en organisasjon som har et etablert testmiljø for Altinn Apps. Dersom dette ikke er tilfellet kan du gå videre til [neste modul](../modul4/).
+ <br><br>
+ Hvis du har en personlig applikasjon som du vil flytte til en organisasjon, 
+ [så kan du spørre en administrator eller service desk](https://docs.altinn.studio/nb/app/getting-started/create-user/#bli-del-av-en-organisasjon).
+
+ Når du har tilgang til en organisasjon som har etablert testmiljø så kan du flytte applikasjonen til organisasjonen slik:
+ 1. Flytt repository for applikasjonen i Gitea til organisasjonen via "Instillinger" på Gitea-siden
+ 2. Oppdater `id` og `org`-feltene i `App/config/applicationmetadata.json`-filen til å peke på organisasjonen 
 {{% /notice %}}
 
 I denne modulen skal du bygge og publisere applikasjonen til [Altinns testmiljø (TT02)](https://tt02.altinn.no/) og verifisere at alt fungerer som forventet også der.

--- a/content/app/app-dev-course/modul3/_index.nb.md
+++ b/content/app/app-dev-course/modul3/_index.nb.md
@@ -10,7 +10,7 @@ weight: 20
  Denne modulen krever at du er medlem av en organisasjon som har et etablert testmiljø for Altinn Apps. Dersom dette ikke er tilfellet kan du gå videre til [neste modul](../modul4/).
  <br><br>
  Hvis du har en personlig applikasjon som du vil flytte til en organisasjon, 
- [så kan du spørre en administrator eller service desk](https://docs.altinn.studio/nb/app/getting-started/create-user/#bli-del-av-en-organisasjon).
+ [så kan du spørre en administrator eller service desk](/nb/app/getting-started/create-user/#bli-del-av-en-organisasjon).
 
  Når du har tilgang til en organisasjon som har etablert testmiljø så kan du flytte applikasjonen til organisasjonen slik:
  1. Flytt repository for applikasjonen i Gitea til organisasjonen via "Instillinger" på Gitea-siden


### PR DESCRIPTION
## Description
When I worked my way through the dev course, I had initially created a personal application (not tied to an org),
@tjololo told me I could move the app to the test-org with access to tt02 by moving the repository and updating the application metadata.

This PRs adds to the module 3 warning notice, giving users the option to proceed with the module by moving the personal application into an org.

## Related Issue(s)
N/A

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
