### PR TITLE
Improve information around available test-user login methods for the dev course

### DIFF
--- a/content/app/app-dev-course/modul3/_index.en.md
+++ b/content/app/app-dev-course/modul3/_index.en.md
@@ -94,7 +94,8 @@ It is in the format _{org}.apps.tt02.altinn.no/{org}/{app}_
 Unless you're already logged in with a user this link will bring you to Altinn's login page.
 Your organization should have access to a set of test users, use one of these to log in.
 
-Internal users in Digdir should use one of the test users found in [the test data set](https://pedia.altinn.cloud/testing/testdata/datasets/).
+Internal users in Digdir can use the "TestID" electronic ID, which lets you generate a random personal ID,
+or retrieve credentials from [the internal Altinn 3 testing dataset](https://pedia.altinn.cloud/altinn-3/testing/test-data/).
 
 **Test the different tracks and pages to confirm that the behaviour is as expected.**
 

--- a/content/app/app-dev-course/modul3/_index.nb.md
+++ b/content/app/app-dev-course/modul3/_index.nb.md
@@ -120,7 +120,9 @@ Den er på formatet `<org>.apps.tt02.altinn.no/<org>/<app>`.
 
 Med mindre du er logget inn med en bruker fra før av vil denne lenken ta deg til innloggingssiden til Altinn.
 Logg inn med en testbruker fra organisasjonen din eller benytt deg av [Tenors testdata](https://www.skatteetaten.no/skjema/testdata/).
- Er du intern i Digdir kan du logge inn med en testbruker fra [testdatasettet](https://pedia.altinn.cloud/testing/testdata/datasets/).
+ 
+Er du intern i Digdir kan du bruke "TestID" innloggings-metoden og generere en tilfeldig bruker,
+eller hente innloggings-detaljer for testbruker i [det interne Altinn 3 test-datasettet](https://pedia.altinn.cloud/altinn-3/testing/test-data/).
 
 ### Oppgaver
 
@@ -129,7 +131,7 @@ Logg inn med en testbruker fra organisasjonen din eller benytt deg av [Tenors te
 
 ### Nyttig dokumentasjon
 - [Tenor testdata](https://www.skatteetaten.no/skjema/testdata/)
-- [Digdir testdatasett](https://pedia.altinn.cloud/testing/testdata/datasets/)
+- [Digdir Altinn 3 testdatasett](https://pedia.altinn.cloud/altinn-3/testing/test-data/)
 
 {{% /expandlarge %}}
 


### PR DESCRIPTION
## Description

There are a couple of issues with the documentation around test users/logins for the dev course
* TestID is what I used during the course, so I figure that should be mentioned as an option? It seems to work for the test case of the course
* The link for testing dataset was dead, I'm guessing the correct link should be this: https://pedia.altinn.cloud/altinn-3/testing/test-data/

## Related Issue(s)
N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
