### PR TITLE
docs: fix broken links

### DIFF
--- a/content/app/getting-started/create-app/settings/_index.en.md
+++ b/content/app/getting-started/create-app/settings/_index.en.md
@@ -23,8 +23,8 @@ This section allows you to modify basic settings for the application.
 ## Access Rules
 Access in an app is governed by a _Policy_ file located within the app. This file is based on the XACML standard. We have developed a tool to make it easier to add and edit access rules.
 
-Learn more about how to set this up [here](https://docs.altinn.studio/app/development/configuration/authorization/). 
-We have also written a [guide for authorization rules](https://docs.altinn.studio/app/development/configuration/authorization/guidelines_authorization/) 
+Learn more about how to set this up [here](../../../development/configuration/authorization/). 
+We have also written a [guide for authorization rules](../../../development/configuration/authorization/guidelines_authorization/) 
 that may be useful to review before getting started.
 
 ## Tools for Access Rules

--- a/content/app/getting-started/create-app/settings/_index.en.md
+++ b/content/app/getting-started/create-app/settings/_index.en.md
@@ -23,8 +23,8 @@ This section allows you to modify basic settings for the application.
 ## Access Rules
 Access in an app is governed by a _Policy_ file located within the app. This file is based on the XACML standard. We have developed a tool to make it easier to add and edit access rules.
 
-Learn more about how to set this up [here](https://docs.altinn.studio/en/app/development/configuration/authorization/). 
-We have also written a [guide for authorization rules](https://docs.altinn.studio/en/app/development/configuration/authorization/guidelines_authorization/) 
+Learn more about how to set this up [here](https://docs.altinn.studio/app/development/configuration/authorization/). 
+We have also written a [guide for authorization rules](https://docs.altinn.studio/app/development/configuration/authorization/guidelines_authorization/) 
 that may be useful to review before getting started.
 
 ## Tools for Access Rules

--- a/content/app/getting-started/create-app/settings/_index.nb.md
+++ b/content/app/getting-started/create-app/settings/_index.nb.md
@@ -24,8 +24,8 @@ Her kan du endre enkle innstillinger for applikasjonen.
 Tilganger i en app styres av en _Policy_-fil som ligger i appen. Denne filen baserer seg på XACML standarden. Vi har utviklet
 et verktøy for å gjøre det enklere å legge til og redigere tilgangsregler.
 
-Les mer om hvordan dette settes opp [her](https://docs.altinn.studio/nb/app/development/configuration/authorization/). Vi
-har også skrevet en [veiledning for autorisasjonsregler](https://docs.altinn.studio/nb/app/development/configuration/authorization/guidelines_authorization/)
+Les mer om hvordan dette settes opp [her](../../../development/configuration/authorization/). Vi
+har også skrevet en [veiledning for autorisasjonsregler](../../../development/configuration/authorization/guidelines_authorization/)
 som kan være nyttig å lese gjennom før man setter i gang.
 
 ## Verktøy for tilgangsregler


### PR DESCRIPTION
## Description

A couple links containing "/en/" were not working.

