### PR TITLE
add documentation of how to opt-in for automatic tracks migration

### DIFF
--- a/content/community/changelog/app-frontend/v4/_index.en.md
+++ b/content/community/changelog/app-frontend/v4/_index.en.md
@@ -160,6 +160,9 @@ Unless the user changes this setting, they will be prompted with the following p
 Showing and hiding pages using [tracks](/app/development/ux/pages/tracks/) (calculate page order) is no longer supported.
 This also means that the trigger `calculatePageOrder` no longer has any effect and should be removed from any components where it is used.
 Instead, you should use dynamic expressions on the `hidden` property of a layout page to determine whether pages should be visible or hidden.
+
+To opt-in for an automatic AI-generated Pull Request to help you migrate from the old tracks feature, see the [Opt-in to Altinn AI for tracks migration](/community/changelog/app-frontend/v4/migrating-from-v3/#opt-in-to-altinn-ai-for-tracks-migration).
+
 See the [documentation on dynamic expressions](/app/development/logic/expressions/#showhide-entire-pages) for more information.
 
 ## Data model schema validation works for more data models
@@ -568,12 +571,12 @@ Where `showValidations` contains a set of validation types to check; this can be
 - `All`
 
 This causes validations to become visible immediately when they occur.
-Because of this, you may want to make sure that any custom validation code you have written does not produce a validation error when the field is empty, 
+Because of this, you may want to make sure that any custom validation code you have written does not produce a validation error when the field is empty,
 as this will cause the validation to be shown immediately when the user enters the page.
 If leaving the field empty is invalid, please mark the field as required instead of validating that with custom code.
 
-**Note**: `"showValidations": ["AllExceptRequired"]` is the default value if the property is not set. 
-Meaning that all validations except for `Required` valdiations will be shown immediately. 
+**Note**: `"showValidations": ["AllExceptRequired"]` is the default value if the property is not set.
+Meaning that all validations except for `Required` valdiations will be shown immediately.
 This also includes any custom validations implemented in the backend which previously needed `"triggers": ["validation"]` to be set on the component.
 To avoid showing certain types of validations immediately, you can override the `showValidations` property on the component.
 

--- a/content/community/changelog/app-frontend/v4/migrating-from-v3/_index.en.md
+++ b/content/community/changelog/app-frontend/v4/migrating-from-v3/_index.en.md
@@ -3,7 +3,7 @@ title: Migration from v3
 description: How to migrate from App-frontend v3 to v4
 weight: 50
 toc: true
----
+--- 
 
 ## Introduction
 
@@ -136,3 +136,40 @@ In addition to changing the version, you should also remove the links to the thi
       }
     ```
 4. Fix any [breaking changes](/community/changelog/app-frontend/v4) affecting your app, including upgrading the nuget packages to version 8.0.
+
+## Opt-in to Altinn AI for tracks migration
+
+In v3, `IPageOrder` and `calculatePageOrder`, so called tracks, could be used to define custom page order based on input 
+from the user. This functionality has been removed in v4, and the page order is now determined by the layout configuration 
+with the `hidden` property. To get pages to show/hide based on selections in the UI, you can use `hidden` together with 
+dynamic expressions. This is a somewhat different approach to a dynamic page order, and you may find it beneficial to get
+some help with the migration.
+
+You can opt-in for an automatic AI-generated Pull Request to help you migrate from the old tracks feature, as the new 
+way of handling page order is also available in v3. When you have opted-in for the AI-generated Pull Request, our 
+Altinn Ai Bot will create a Pull Request in your repository with a suggested migration from tracks to dynamic expressions.
+This PR will be generated in a nightly run.
+
+Steps to opt-in on a single repository:
+1. In gitea, go to the repository where you want to opt-in for the AI-generated Pull Request.
+2. Go to the Settings tab.
+3. Go to the Collaboration section.
+4. Add "altinn_sa_ai (Altinn AI [Bot])"
+5. Sit back and relax, and let the Altinn Ai do the work for you. The PR will be created in a nightly run if the bot finds any tracks in your repository.
+
+
+If you want to opt-in for all repositories in your organization, you can do this on a service owner level.
+Steps to opt-in on a service owner level:
+1. In gitea, go to your organization: `https://altinn.studio/repos/<orgname>`
+2. Go to the Teams tab.
+3. Click the "Devs" team.
+4. Add "altinn_sa_ai (Altinn AI [Bot])" to the team
+5. Sit back and relax, and let the Altinn Ai do the work for you. A PR will be created in a nightly run in any repository the bot finds the tracks implementation.
+
+
+{{% notice warning %}}
+**Note**: Because the dynamic expression way of handling page order differs slightly from the tracks implementation,
+the migrated result might not be a 100% match to the original behavior. The AI is not perfect at migrating the 
+code, and you should always review and test the changes made in the Pull Request before merging it. 
+{{% /notice %}}
+

--- a/content/community/changelog/app-frontend/v4/migrating-from-v3/_index.en.md
+++ b/content/community/changelog/app-frontend/v4/migrating-from-v3/_index.en.md
@@ -173,3 +173,8 @@ the migrated result might not be a 100% match to the original behavior. The AI i
 code, and you should always review and test the changes made in the Pull Request before merging it. 
 {{% /notice %}}
 
+The AI used is for this bot is Azure OpenAI. It is a dedicated model hosted on Digdir's internal Azure.
+The model used is `gpt-4-1106-preview`. The bot only uploads C# classes that have implemented the `IPageOrder` interface
+from your repository to the AI model.   
+
+ 

--- a/content/community/changelog/app-frontend/v4/migrating-from-v3/_index.en.md
+++ b/content/community/changelog/app-frontend/v4/migrating-from-v3/_index.en.md
@@ -173,8 +173,9 @@ the migrated result might not be a 100% match to the original behavior. The AI i
 code, and you should always review and test the changes made in the Pull Request before merging it. 
 {{% /notice %}}
 
-The AI used is for this bot is Azure OpenAI. It is a dedicated model hosted on Digdir's internal Azure.
-The model used is `gpt-4-1106-preview`. The bot only uploads C# classes that have implemented the `IPageOrder` interface
-from your repository to the AI model.   
+The generative AI model used for this bot is 'gpt-4-1106-preview' from OpenAI, hosted as a dedicated instance on Digdir's
+internal Azure subscription. Information provided to the model is limited to a relevant subset of your repository,
+in this case the C# classes that implement the `IPageOrder` interface. Note that this information is not made available 
+to any third party for training purposes.
 
  


### PR DESCRIPTION
This PR documents how a service owner can opt-in to get automatic tracks migration pull requests generated for their repositories. 