### PR TITLE
Fix access-management resource owner swagger example

### DIFF
--- a/static/swagger/altinn-platform-accessmanagement-v1-resourceowner.json
+++ b/static/swagger/altinn-platform-accessmanagement-v1-resourceowner.json
@@ -327,7 +327,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "example": "[\"app_org_appname\",\"someresourceid\"]"
+              "example": ["app_org_appname", "someresourceid"]
             }
           },
           "authorizedRoles": {


### PR DESCRIPTION
Fixed error in generated json example