### PR TITLE
Update norw "streng" to eng "string"

### DIFF
--- a/content/app/development/logic/expressions/_index.en.md
+++ b/content/app/development/logic/expressions/_index.en.md
@@ -138,9 +138,9 @@ Dynamic expressions are currently available for use in these properties, as defi
 | [Repeating groups](../../ux/fields/grouping/repeating)                                                                                 | `edit.deleteButton`           | [Boolean](#boolean-values) | ✅       | ❌      |  
 | [Repeating groups](../../ux/fields/grouping/repeating)                                                                                 | `edit.alertOnDelete`          | [Boolean](#boolean-values) | ✅       | ❌      |  
 | [Repeating groups](../../ux/fields/grouping/repeating)                                                                                 | `edit.saveAndNextButton`      | [Boolean](#boolean-values) | ✅       | ❌      |  
-| [RadioButtons](../../ux/components/radiobuttons), [Checkboxes](../../ux/components/checkbox), [Dropdown](../../ux/components/dropdown) | `source.label`                | [Streng](#strings)         | ✅       | ❌      |
-| [RadioButtons](../../ux/components/radiobuttons), [Checkboxes](../../ux/components/checkbox), [Dropdown](../../ux/components/dropdown) | `source.description`          | [Streng](#strings)         | ✅       | ❌      |
-| [RadioButtons](../../ux/components/radiobuttons), [Checkboxes](../../ux/components/checkbox), [Dropdown](../../ux/components/dropdown) | `source.helpText`             | [Streng](#strings)         | ✅       | ❌      |
+| [RadioButtons](../../ux/components/radiobuttons), [Checkboxes](../../ux/components/checkbox), [Dropdown](../../ux/components/dropdown) | `source.label`                | [String](#strings)         | ✅       | ❌      |
+| [RadioButtons](../../ux/components/radiobuttons), [Checkboxes](../../ux/components/checkbox), [Dropdown](../../ux/components/dropdown) | `source.description`          | [String](#strings)         | ✅       | ❌      |
+| [RadioButtons](../../ux/components/radiobuttons), [Checkboxes](../../ux/components/checkbox), [Dropdown](../../ux/components/dropdown) | `source.helpText`             | [String](#strings)         | ✅       | ❌      |
 | All                                                                                                                                    | `textResourceBindings.[*]` \* | [String](#strings)         | ✅       | ❌      |                                                   
 
 \* = The values that can be overridden with textResourceBindings vary from component to component, but will work wherever


### PR DESCRIPTION
Some properties in the table of the English documentation had the Norwegian name "streng" for "string".
This is now fixed.

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
