### PR TITLE
Removed altinn:authorization:pdp from docs as no longer used

### DIFF
--- a/content/authorization/modules/pdp/_index.md
+++ b/content/authorization/modules/pdp/_index.md
@@ -33,7 +33,7 @@ Url for API is
 - TT02: https://platform.tt02.altinn.no/authorization/api/v1/authorize
 - Production: https://platform.altinn.no/authorization/api/v1/authorize
 
-**It is required to have access to a scope altinn:authorization:pdp and a API key for this access. Contact Altinn to get this.**
+**It is required to have an API key for this access. Contact Altinn to get this.**
 
 Api Key need to be sent as "Ocp-Apim-Subscription-Key" header.
 

--- a/content/broker/user-guides/get-started/common-steps/_index.en.md
+++ b/content/broker/user-guides/get-started/common-steps/_index.en.md
@@ -27,7 +27,6 @@ If you do not already possess an API Key for the Maskinporten Client(s) you inte
 
 Register your Maskinporten client(s) to authenticate with the Broker API, assigning them relevant scopes:
 
-- `altinn:authorization:pdp` - Required for all broker API clients for authorization access.
 - `altinn:broker.write` - For clients sending files.
 - `altinn:broker.read` - For clients receiving files.
 

--- a/content/broker/user-guides/get-started/common-steps/_index.nb.md
+++ b/content/broker/user-guides/get-started/common-steps/_index.nb.md
@@ -27,7 +27,6 @@ Hvis du ikke allerede har en API-nøkkel for Maskinporten-klient(er) du har tenk
 
 Registrer Maskinporten-klienten(e) din for å autentisere mot Broker-API-en, tildel dem relevante omfang:
 
-- `altinn:authorization:pdp` - Påkrevd for alle Broker-API-klienter for autorisasjonsadgang.
 - `altinn:broker.write` - For klienter som sender filer.
 - `altinn:broker.read` - For klienter som mottar filer.
 


### PR DESCRIPTION
altinn:authorization:pdp was removed so we rewrote to use our own Maskinporten client with altinn:authorization/authorize.admin instead.