### PR TITLE
Updated resourceowner AuthorizedParties swagger with new scope requirement

### DIFF
--- a/static/swagger/altinn-platform-accessmanagement-v1-resourceowner.json
+++ b/static/swagger/altinn-platform-accessmanagement-v1-resourceowner.json
@@ -450,7 +450,7 @@
       },
       "AuthorizedPartiesSOAuth": {
         "type": "http",
-        "description": "Requires one of the following Scopes: [altinn:resourceowner/authorizedparties, altinn:resourceowner/authorizedparties.admin]",
+        "description": "Requires one of the following Scopes: [altinn:accessmanagement/authorizedparties.resourceowner, altinn:accessmanagement/authorizedparties.admin]",
         "scheme": "bearer",
         "bearerFormat": "JWT"
       }


### PR DESCRIPTION
Updated old scopes in swagger doc

from
```
altinn:resourceowner/authorizedparties
altinn:resourceowner/authorizedparties.admin
```

to 
```
altinn:accessmanagement/authorizedparties.resourceowner
altinn:accessmanagement/authorizedparties.admin
```