### PR TITLE
added link to how to administrate deployment access

### DIFF
--- a/content/app/deployment/_index.en.md
+++ b/content/app/deployment/_index.en.md
@@ -21,6 +21,9 @@ This routine just needs to be followed once. When the cluster is set up, the sol
 ## Deployment of app
 
 Deploy of an application to production is done in [the same way as for test environments](/app/testing/deploy).
+The user that will deploy an application to production must be a member of the `Deploy-Production` group in Altinn Studio.
+Access to groups in Altinn Studio is administrated by each organization in Altinn Studio.
+[Read more about access in Altinn Studio](../guides/access-management/studio/).
 
 ## Order "About form"-page on altinn.no
 

--- a/content/app/deployment/_index.nb.md
+++ b/content/app/deployment/_index.nb.md
@@ -19,6 +19,9 @@ Denne rutinen trenger bare å følges en gang. Når clusteret er satt opp, er l�
 ## Produksjonssette en app
 
 Produksjonssetting av applikasjonen gjøres på [samme måte som for testmiljøer](/nb/app/testing/deploy).
+Den som skal produksjonssette app'en må være medlem av gruppen `Deploy-Production` for sin organisasjon i Altinn Studio.
+Tilgang til grupper i Altinn Studio administreres av hver enkelt organisasjon i Altinn Studio.
+[Les mer om tilganger i Altinn Studio](../guides/access-management/studio/).
 
 ## Bestille Om skjema-side
 


### PR DESCRIPTION
See title. Based on feedback, updated deployment (to prod) docs to include link to information on how to get access to deploy to different environments.