### PR TITLE
Make common component properties available to web content crawlers

### DIFF
--- a/layouts/shortcodes/common-defs-expandlarge.html
+++ b/layouts/shortcodes/common-defs-expandlarge.html
@@ -23,7 +23,7 @@
 				</a>
 			</div>
 			<div id="expandable-{{with $title}}{{.}}{{else}}expand-default{{end}}" 
-						class="a-collapseContent" role="tabpanel" hidden="until-found">
+						class="a-collapseContent-searchable" role="tabpanel" hidden="until-found">
 				<div class="a-collapseContent-inside">
 					<a name="#{{$title}}"></a>
 					{{- template "list-descriptions" (dict "property" $def "propName" $title) -}}
@@ -32,3 +32,17 @@
 		</div>
 	{{- end -}}
 {{- end -}}
+
+
+<script lang="javascript">
+	// if (!('onbeforematch' in document.body)) {
+	// 	// fallback to original behavior
+  //   document.addEventListener('DOMContentLoaded', (event) => {
+  //       let divs = document.querySelectorAll('div.a-collapseContent-searchable');
+  //       divs.forEach((div) => {
+  //           div.classList.remove('a-collapseContent-searchable');
+  //           div.classList.add('a-collapseContent');
+  //       });
+  //   });
+	// }
+</script>

--- a/layouts/shortcodes/common-defs-expandlarge.html
+++ b/layouts/shortcodes/common-defs-expandlarge.html
@@ -22,7 +22,8 @@
 					{{end}}
 				</a>
 			</div>
-			<div id="expandable-{{with $title}}{{.}}{{else}}expand-default{{end}}" class="a-collapseContent collapse" role="tabpanel">
+			<div id="expandable-{{with $title}}{{.}}{{else}}expand-default{{end}}" 
+						class="a-collapseContent" role="tabpanel" hidden="until-found">
 				<div class="a-collapseContent-inside">
 					<a name="#{{$title}}"></a>
 					{{- template "list-descriptions" (dict "property" $def "propName" $title) -}}

--- a/themes/hugo-theme-altinn/static/css/designsystem.css
+++ b/themes/hugo-theme-altinn/static/css/designsystem.css
@@ -275,6 +275,31 @@ template {
 [hidden] {
   display: none !important; }
 
+.a-collapseContent.collapse {
+  display: block;
+  content-visibility: hidden;
+}
+
+.a-collapseContent[hidden=until-found] {
+    display: block !important;
+    content-visibility: hidden;
+} 
+
+.a-collapseContent.collapsing[hidden=until-found] {
+  display: block !important;
+  content-visibility: visible;
+} 
+
+.a-collapseContent.collapse.show {
+  display: block;
+  content-visibility: visible;
+}
+
+.a-collapseContent.collapse.show[hidden=until-found] {
+  display: block;
+  content-visibility: visible;
+}
+
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
   margin-bottom: 6px;

--- a/themes/hugo-theme-altinn/static/css/designsystem.css
+++ b/themes/hugo-theme-altinn/static/css/designsystem.css
@@ -275,27 +275,27 @@ template {
 [hidden] {
   display: none !important; }
 
-.a-collapseContent.collapse {
+.a-collapseContent-searchable.collapse {
   display: block;
   content-visibility: hidden;
 }
 
-.a-collapseContent[hidden=until-found] {
+.a-collapseContent-searchable[hidden=until-found] {
     display: block !important;
     content-visibility: hidden;
 } 
 
-.a-collapseContent.collapsing[hidden=until-found] {
+.a-collapseContent-searchable.collapsing[hidden=until-found] {
   display: block !important;
   content-visibility: visible;
 } 
 
-.a-collapseContent.collapse.show {
+.a-collapseContent-searchable.collapse.show {
   display: block;
   content-visibility: visible;
 }
 
-.a-collapseContent.collapse.show[hidden=until-found] {
+.a-collapseContent-searchable.collapse.show[hidden=until-found] {
   display: block;
   content-visibility: visible;
 }


### PR DESCRIPTION
- improve SEO
- find-in-page will find content in all accordians that have not be manually collapsed


Related to: #1656 
This fix applies **only** to the accordian configuration on the [Common Component Properties](https://docs.altinn.studio/app/development/ux/components/commondefs/) page. If it works well, we should consider modifying all accordians accordingly.