### PR TITLE
Update Azure Key Vault config provider code to use newer packages

### DIFF
--- a/content/altinn-studio/guides/maskinporten-app-integration/_index.en.md
+++ b/content/altinn-studio/guides/maskinporten-app-integration/_index.en.md
@@ -101,14 +101,15 @@ service with the appropriate configuration in the function `RegisterCustomAppSer
 services.AddMaskinportenHttpClient<SettingsJwkClientDefinition, AppClient>(config.GetSection("MaskinportenSettings"));
 ```
 
-Then we need to add the Azure Key Vault configuration provider to our host. Start by adding these package references:
+Then we need to add the Azure Key Vault configuration provider to our host.
+Start by adding these package references in the project file (`App.csproj`) - get the latest version from NuGet.org:
 
 {{< highlight csproj "linenos=false" >}}
-        <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
-        <PackageReference Include="Azure.Identity" Version="1.11.4" />
+<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
+<PackageReference Include="Azure.Identity" Version="1.11.4" />
 {{< / highlight >}}
 
-Then we can complete the configuration:
+Then we can complete the configuration by adding the Azure Key Vault configuration provider:
 
 {{< highlight csharp "linenos=false,hl_lines=1 8-30" >}}
 using Azure.Identity;

--- a/content/altinn-studio/guides/maskinporten-app-integration/_index.en.md
+++ b/content/altinn-studio/guides/maskinporten-app-integration/_index.en.md
@@ -101,7 +101,7 @@ service with the appropriate configuration in the function `RegisterCustomAppSer
 services.AddMaskinportenHttpClient<SettingsJwkClientDefinition, AppClient>(config.GetSection("MaskinportenSettings"));
 ```
 
-Then, we need to add the Azure Key Vault configuration provider to our host. Start by adding these package references:
+Then we need to add the Azure Key Vault configuration provider to our host. Start by adding these package references:
 
 {{< highlight csproj "linenos=false" >}}
         <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />


### PR DESCRIPTION
A user on Slack noted that the documentation makes use of a deprecated package for hooking up Azure KV as a configuration provider. We can't cleanup package dependencies right now (see https://github.com/Altinn/app-lib-dotnet/issues/647), but we can update the documentation so that users start using the new SDKs from Azure/MS. I avoided the `KeyVaultSettings` as it comes from a transitive depedency.

An alternative would be to enable the Azure KV configuration provider from Altinn.App.Api instead (`ConfigureAppWebHost`)