### PR TITLE
Better ToC

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -33,6 +33,9 @@ ignoreErrors = ["error-remote-getjson"]
 [markup.goldmark]
 duplicateResourceFiles = true
 
+[markup.goldmark.parser]
+autoHeadingIDType = "github-ascii"
+
 [markup.goldmark.parser.attribute]
 block = true
 title = true
@@ -45,7 +48,7 @@ style = "dracula"
 
 [markup.tableOfContents]
 startLevel = 2
-endLevel = 2
+endLevel = 5
 ordered = false
 
 [blackfriday]

--- a/config.toml
+++ b/config.toml
@@ -34,7 +34,7 @@ ignoreErrors = ["error-remote-getjson"]
 duplicateResourceFiles = true
 
 [markup.goldmark.parser]
-autoHeadingIDType = "github-ascii"
+autoHeadingIDType = "github"
 
 [markup.goldmark.parser.attribute]
 block = true

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -67,10 +67,13 @@ $(document).ready(function() {
      */
     function expandHashTarget() {
         const id = (window.location.hash || '#').substring(1);
-        const element = document.getElementById(id);
-        if (element && element.classList.contains('adocs-expand')) {
-            $(element).find('a[aria-expanded="false"]').click();
-            element.scrollIntoView();
+        if (id != null && id.length > 0) {
+            const element = document.getElementById(id);
+            if (element && element.classList.contains('adocs-expand')) {
+                $(element).find('a[aria-expanded="false"]').click();
+                element.
+                scrollIntoView();
+            }
         }
     }
     window.addEventListener('hashchange', expandHashTarget, false);

--- a/themes/hugo-theme-altinn/layouts/partials/footer.html
+++ b/themes/hugo-theme-altinn/layouts/partials/footer.html
@@ -85,7 +85,8 @@
     <script src="{{"js/stickysidebar/sticky-sidebar.js" | relURL}}"></script>
 
     <style>
-      #TableOfContents > ul > li {margin-top: 1em !important; list-style-type:none; list-style-position:inside;}
+      #TableOfContents {overflow: visible;}
+      #TableOfContents > ul > li {margin-top: 0.8em !important; list-style-type:none; list-style-position:inside;}
       #TableOfContents li li {margin-left: 0.4em; list-style-type:circle;}
       #TableOfContents li li:has(a.text-active) {list-style-type:disc;}
       #TableOfContents a {border-bottom: 2px solid transparent;}
@@ -97,9 +98,13 @@
         static init() {
           if(document.querySelector('#TableOfContents')) {
             this.tocLinks = document.querySelectorAll('#TableOfContents a');
-            this.tocLinks.forEach(link => link.classList.add('transition', 'duration-200'))
             this.headers = Array.from(this.tocLinks).map(link => {
-              return document.querySelector(`#${CSS.escape(link.href.split('#')[1])}`);
+              var s = link.href.split('#')[1];
+              s = s.replace("%C3%A6", "æ");
+              s = s.replace("%C3%B8", "ø");
+              s = s.replace("%C3%A5", "å");
+
+              return document.getElementById(s);
             })
             this.ticking = false;
             window.addEventListener('scroll', (e) => {

--- a/themes/hugo-theme-altinn/layouts/partials/footer.html
+++ b/themes/hugo-theme-altinn/layouts/partials/footer.html
@@ -40,7 +40,7 @@
                   {{- end -}}
               </div>
               */}}
-
+              
             </div><!-- End adocs-content -->
 
             {{- if and (or .IsPage .IsSection) .Site.Params.editURL -}}
@@ -57,6 +57,12 @@
             {{- end -}}
         </section>
         </div> <!-- End col-sm-12 -->
+        <div class="col-md-2 d-none d-md-block">
+          <div class="toc-container">
+            <!--span class="toc-header">{{T "on-this-page"}}</span-->
+            {{- .TableOfContents -}}
+          </div>
+        </div>
       </div> <!-- End row -->
     </div>
     </div> <!-- End container -->
@@ -78,7 +84,59 @@
     <script src="{{"js/stickysidebar/ResizeSensor.js" | relURL}}"></script>
     <script src="{{"js/stickysidebar/sticky-sidebar.js" | relURL}}"></script>
 
+    <style>
+      #TableOfContents > ul > li {margin-top: 1em !important; list-style-type:none; list-style-position:inside;}
+      #TableOfContents li li {margin-left: 0.4em; list-style-type:circle;}
+      #TableOfContents li li:has(a.text-active) {list-style-type:disc;}
+      #TableOfContents a {border-bottom: 2px solid transparent;}
+      #TableOfContents a.text-active, #TableOfContents a:hover {border-bottom: 2px solid #1EAEF7;}
+    </style>
     <script>
+      // Thanks https://dakotaleemartinez.com/tutorials/how-to-add-active-highlight-to-table-of-contents/
+      class Scroller {
+        static init() {
+          if(document.querySelector('#TableOfContents')) {
+            this.tocLinks = document.querySelectorAll('#TableOfContents a');
+            this.tocLinks.forEach(link => link.classList.add('transition', 'duration-200'))
+            this.headers = Array.from(this.tocLinks).map(link => {
+              return document.querySelector(`#${CSS.escape(link.href.split('#')[1])}`);
+            })
+            this.ticking = false;
+            window.addEventListener('scroll', (e) => {
+              this.onScroll()
+            })
+          }
+        }
+
+        static onScroll() {
+          if(!this.ticking) {
+            requestAnimationFrame(this.update.bind(this));
+            this.ticking = true;
+          }
+        }
+
+        static update() {
+          this.activeHeader ||= this.headers[0];
+          let activeIndex = this.headers.findIndex((header) => {
+            if (header != null) {
+              return header.getBoundingClientRect().top > 180;
+            }
+          });
+          if(activeIndex == -1) {
+            activeIndex = this.headers.length - 1;
+          } else if(activeIndex > 0) {
+            activeIndex--;
+          }
+          let active = this.headers[activeIndex];
+          if(active !== this.activeHeader) {
+            this.activeHeader = active;
+            this.tocLinks.forEach(link => link.classList.remove('text-active'));
+            this.tocLinks[activeIndex].classList.add('text-active');
+          }
+          this.ticking = false;
+        }
+      }
+
       var a = new StickySidebar('#sidebar', {
         topSpacing: 20,
         bottomSpacing: 60,
@@ -86,10 +144,22 @@
         innerWrapperSelector: '.sidebar__inner',
         minWidth: 768
       });
+      if (document.getElementById("TableOfContents")) {
+        var a = new StickySidebar('.toc-container', {
+          topSpacing: 20,
+          bottomSpacing: 60,
+          containerSelector: '.adocs-scrollcontainer',
+          innerWrapperSelector: '#TableOfContents',
+          minWidth: 768
+        });
+      }
     </script>
     <link href="{{"mermaid/mermaid.css" | relURL}}" type="text/css" rel="stylesheet"/>
     <script src="{{"mermaid/mermaid.js" | relURL}}"></script>
-    <script>mermaid.initialize({startOnLoad:true});</script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function(e) { Scroller.init();});
+      mermaid.initialize({startOnLoad:true});
+    </script>
 
     {{- partial "custom-footer.html" . -}}
   </body>

--- a/themes/hugo-theme-altinn/layouts/partials/footer.html
+++ b/themes/hugo-theme-altinn/layouts/partials/footer.html
@@ -100,9 +100,9 @@
             this.tocLinks = document.querySelectorAll('#TableOfContents a');
             this.headers = Array.from(this.tocLinks).map(link => {
               var s = link.href.split('#')[1];
-              s = s.replace("%C3%A6", "æ");
-              s = s.replace("%C3%B8", "ø");
-              s = s.replace("%C3%A5", "å");
+              s = s.replace(/%C3%A6/g, "æ");
+              s = s.replace(/%C3%B8/g, "ø");
+              s = s.replace(/%C3%A5/g, "å");
 
               return document.getElementById(s);
             })

--- a/themes/hugo-theme-altinn/layouts/partials/header.html
+++ b/themes/hugo-theme-altinn/layouts/partials/header.html
@@ -47,12 +47,11 @@
     <div class="container pt-2 pt-md-3 pt-lg-5">      
       <div class="adocs-scrollcontainer">
         <div class="row">
-        <div class="col-12 last-modified">{{T "Last-Modified"}}{{ .Page.Lastmod | time.Format ":date_medium" }}</div>
-      </div>
+          <div class="col-sm-12 col-md-10 last-modified">{{T "Last-Modified"}}{{ .Page.Lastmod | time.Format ":date_medium" }}</div>
+        </div>
         <div class="row">
-            <div class="col-sm-12">
+          <div class="col-sm-12 col-md-10">
               {{- partialCached "menu.html" . -}}
-
         <script>
           {{ template "activeMenus" dict "page" . "value" (printf "$(\"li.dd-item a[href='%s']\").parent().addClass(\"active\");" .RelPermalink) }}
         </script>
@@ -101,11 +100,6 @@
               </h1>
               <p class="a-leadText" id="leadText">{{.Description}}</p>
             {{- end -}}
-          {{- end -}}
-
-          {{- if .Params.toc -}}
-            <h2 class="toc-header">{{T "on-this-page"}}</h2>
-            {{- .TableOfContents -}}
           {{- end -}}
 
 {{- define "breadcrumb" -}}


### PR DESCRIPTION
- Automatic ToC to the right, showing all heading levels and page structure
- ToC highlights when scrolling page
   - Changed hash-links to `gitHub-ascii` (to make this work with Norwegian)
- Always there, always clickable


<img width="1445" alt="image" src="https://github.com/Altinn/altinn-studio-docs/assets/6088624/3b240d95-df1f-475c-af7e-9b00ce6b521f">
