### PR TITLE
Show TOC in right-hand-panel on all pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,8 +45,8 @@ style = "dracula"
 
 [markup.tableOfContents]
 startLevel = 2
-endLevel = 2
-ordered = false
+endLevel = 4
+ordered = true
 
 [blackfriday]
 fractions = false # disable automatic fraction rendering

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -588,3 +588,7 @@ input[type="search"] {
     font-weight: bold; 
     font-size: 2rem !important;
   }
+
+  #TableOfContents > ol > li > ol {
+    margin-left: 1.5rem;
+  }

--- a/themes/hugo-theme-altinn/layouts/partials/footer.html
+++ b/themes/hugo-theme-altinn/layouts/partials/footer.html
@@ -57,6 +57,10 @@
             {{- end -}}
         </section>
         </div> <!-- End col-sm-12 -->
+        <!-- Show page contents -->
+        <div class="col-sm-2" id="toc">
+          {{- partial "toc.html" . -}}
+          </div>
       </div> <!-- End row -->
     </div>
     </div> <!-- End container -->

--- a/themes/hugo-theme-altinn/layouts/partials/header.html
+++ b/themes/hugo-theme-altinn/layouts/partials/header.html
@@ -50,8 +50,10 @@
         <div class="col-12 last-modified">{{T "Last-Modified"}}{{ .Page.Lastmod | time.Format ":date_medium" }}</div>
       </div>
         <div class="row">
-            <div class="col-sm-12">
+            <div class="col-sm-2">
               {{- partialCached "menu.html" . -}}
+            </div>
+            <div class="col-sm-8">
 
         <script>
           {{ template "activeMenus" dict "page" . "value" (printf "$(\"li.dd-item a[href='%s']\").parent().addClass(\"active\");" .RelPermalink) }}
@@ -101,11 +103,6 @@
               </h1>
               <p class="a-leadText" id="leadText">{{.Description}}</p>
             {{- end -}}
-          {{- end -}}
-
-          {{- if .Params.toc -}}
-            <h2 class="toc-header">{{T "on-this-page"}}</h2>
-            {{- .TableOfContents -}}
           {{- end -}}
 
 {{- define "breadcrumb" -}}

--- a/themes/hugo-theme-altinn/layouts/partials/toc.html
+++ b/themes/hugo-theme-altinn/layouts/partials/toc.html
@@ -1,0 +1,4 @@
+<div id="tocpanel" class="inner-wrapper-sticky">
+    <h2 class="toc-header">{{T "on-this-page"}}</h2>
+    {{- .TableOfContents -}}
+</div>

--- a/themes/hugo-theme-altinn/static/css/theme.css
+++ b/themes/hugo-theme-altinn/static/css/theme.css
@@ -251,6 +251,38 @@ textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[typ
     }
 }
 
+/* TOC */
+#tocpanel {
+    background-color: transparent;
+    color: #000;
+    position: sticky;
+    top: 0;
+    width: 270px;
+    font-weight: normal;
+    font-size: 16px;
+    line-height: 27px;
+    -webkit-font-smoothing: antialiased;
+    will-change: min-height;
+    transition: all 0ms ease-out;
+}
+
+@media (min-width: 768px) {
+    #tocpanel {
+        top: 0;
+        position: sticky;
+        float: right;
+        width: 200px;
+        left: 0;
+    }
+}
+
+@media (max-width: 1200px) {
+    #tocpanel {
+        display: none;
+        width: 0;
+    }
+}
+
 /* SIDEBAR */
 #sidebar {
     background-color: transparent;
@@ -508,7 +540,8 @@ textarea:focus, input[type="email"]:focus, input[type="number"]:focus, input[typ
 
 @media only all and (min-width: 768px) {
     #body {
-        margin-left: 256px;
+        margin-left: 36px;
+        margin-right: 24px
     }
 }
 


### PR DESCRIPTION
Remove TOC logic from pages, and instead show TOC in a sidepanel on the right hand side.
This change uses the same TOC-functionality as before, but does not check for `toc` in the front matter.
TOC is now shown on the right-hand side for all pages.

Example:
<img width="1481" alt="Screenshot 2024-06-19 at 12 57 03" src="https://github.com/Altinn/altinn-studio-docs/assets/1636323/9dbc9a25-28be-4084-ad0c-87e569189c57">
