### PR TITLE
Add docs for how to configure payment receipt pdf data type.

### DIFF
--- a/content/app/guides/payment/backend-configuration/_index.en.md
+++ b/content/app/guides/payment/backend-configuration/_index.en.md
@@ -4,9 +4,9 @@ description: Set up your backend to handle payment.
 weight: 1
 ---
 
-### 1. Create a data type to store payment information:
+### 1. Create two data types to store payment information:
 
-This data type is used to store information and status about the payment. Put it in the `dataTypes` array in `App/config/applicationmetadata.json`. ID can be set to something else, but it must match the ID entered in `paymentDataType` in the process step, as shown in step 2.
+This data type is used to store information and status about the payment. Put it in the `dataTypes` array in `App/config/applicationmetadata.json`.
 
 ```json
 {
@@ -19,6 +19,20 @@ This data type is used to store information and status about the payment. Put it
 }
 ```
 
+This data type is used to store the PDF-receipt for the payment. Configure it next to the other data type.
+
+```json
+{
+    "id": "paymentReceiptPdf",
+    "allowedContentTypes": [
+        "application/pdf"
+    ],
+    "maxCount": 1,
+    "minCount": 0,
+}
+```
+
+ The IDs can be set to something else, but they must match the IDs entered in `paymentDataType` and `paymentReceiptPdfDataType` in the process step, as shown in step 2.
 
 ### 2. Extend the app process with payment task:
 
@@ -62,6 +76,7 @@ Payment uses three user actions. If the Altinn user interface is used by the app
           </altinn:actions>
           <altinn:paymentConfig>
             <altinn:paymentDataType>paymentInformation</altinn:paymentDataType>
+            <altinn:paymentReceiptPdfDataType>paymentReceiptPdf</altinn:paymentReceiptPdfDataType>
           </altinn:paymentConfig>
         </altinn:taskExtension>
       </bpmn:extensionElements>
@@ -86,7 +101,7 @@ Payment uses three user actions. If the Altinn user interface is used by the app
       <bpmn:incoming>Flow_g1_end</bpmn:incoming>
     </bpmn:endEvent>
 ```
-The value of this node: `<altinn:paymentDataType>paymentInformation</altinn:paymentDataType>` must match the ID of the data type you configured in the previous step.
+The value of this node: `<altinn:paymentDataType>paymentInformation</altinn:paymentDataType>` must match the ID of the data type you configured in the previous step. Same for the pdf-receipt data type.
 
 ### 3. Ensure correct authorization for payment process task:
 

--- a/content/app/guides/payment/backend-configuration/_index.nb.md
+++ b/content/app/guides/payment/backend-configuration/_index.nb.md
@@ -4,9 +4,9 @@ description: Sett opp din backend til å håndtere betaling.
 weight: 1
 ---
 
-### 1. Opprett en datatype for å lagre betalingsinformasjon:
+### 1. Opprett to datatyper for å lagre betalingsinformasjon:
 
-Denne datatypen benyttes av betalingssteget for å lagre informasjon og status om betalingen. Legg den i `App/config/applicationmetadata.json` sin `dataTypes` array. ID kan settes til noe annet, men det må matche ID-en som legges inn i `paymentDataType` i prossessteget, som vist i punkt 2.
+Denne datatypen benyttes av betalingssteget for å lagre informasjon og status om betalingen. Legg den i `App/config/applicationmetadata.json` sin `dataTypes` array. 
 
 ```json
 {
@@ -18,6 +18,21 @@ Denne datatypen benyttes av betalingssteget for å lagre informasjon og status o
     "minCount": 0,
 }
 ```
+
+Denne datatypen benyttes for å lagre PDF-kvittering for betalingen. Legg den inn samme sted.
+
+```json
+{
+    "id": "paymentReceiptPdf",
+    "allowedContentTypes": [
+        "application/pdf"
+    ],
+    "maxCount": 1,
+    "minCount": 0,
+}
+```
+
+ID-ene kan settes til noe annet, men det må matche ID-ene som legges inn i `paymentDataType` og `paymentReceiptPdfDataType` i prossessteget, som vist i punkt 2.
 
 ### 2. Utvid app prossesen med payment task:
 
@@ -61,6 +76,7 @@ Betaling benytter tre user actions. Dersom Altinn brukergrensesnittet brukes av 
           </altinn:actions>
           <altinn:paymentConfig>
             <altinn:paymentDataType>paymentInformation</altinn:paymentDataType>
+            <altinn:paymentReceiptPdfDataType>paymentReceiptPdf</altinn:paymentReceiptPdfDataType>
           </altinn:paymentConfig>
         </altinn:taskExtension>
       </bpmn:extensionElements>
@@ -85,7 +101,7 @@ Betaling benytter tre user actions. Dersom Altinn brukergrensesnittet brukes av 
       <bpmn:incoming>Flow_g1_end</bpmn:incoming>
     </bpmn:endEvent>
 ```
-NB: Verdien til denne noden: `<altinn:paymentDataType>paymentInformation</altinn:paymentDataType>` må matche ID-en til datatypen du konfigurerte i forrige steg.
+NB: Verdien til denne noden: `<altinn:paymentDataType>paymentInformation</altinn:paymentDataType>` må matche ID-en til datatypen du konfigurerte i forrige steg. Det samme gjelder datatypen for pdf-kvittering.
 
 ### 3. Gi tilganger til den som skal betale:
 


### PR DESCRIPTION
We were using the wrong data type for the payment receipt PDF.

See https://github.com/Altinn/app-lib-dotnet/pull/697
