### PR TITLE
Update secret related documentation on how to use Azure Key Vault

### DIFF
--- a/content/altinn-studio/reference/configuration/secrets/_index.en.md
+++ b/content/altinn-studio/reference/configuration/secrets/_index.en.md
@@ -161,7 +161,7 @@ namespace Altinn.App.AppLogic
     await _secretsClient_.GetSecretAsync("secretId");
     ```
 
-#### Lokal mock
+#### Local mock
 
 To run your service locally without connecting to Azure Key Vault, you need to create a file named `secrets.json` under the _App_ folder. In the JSON structure, you can include dummy data for the secrets you need. If you have uploaded a secret in Key Vault with the name "secretId," the content of the JSON file will look like this:
 

--- a/content/altinn-studio/reference/configuration/secrets/_index.en.md
+++ b/content/altinn-studio/reference/configuration/secrets/_index.en.md
@@ -72,7 +72,7 @@ Configure();
 app.Run();
 ```
 
-Local mocking can be done with the use of [user secrets]('https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows).
+Local mocking can be done with the use of [user secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows).
 
 ```
 dotnet user-secrets init

--- a/content/altinn-studio/reference/configuration/secrets/_index.en.md
+++ b/content/altinn-studio/reference/configuration/secrets/_index.en.md
@@ -42,38 +42,59 @@ The last part of the file should look something like this after your changes are
 
 ## How to make use of secrets in your application
 
-The service `ISecret` is exposed to the application and can be dependency injected into the class in which you need to collect a secret.
+You can either add Azure Key Vault as a config provider and use the IOptions pattern to read secrets, or you can use the `ISecretsClient` service, which is exposed in the application and can be dependency injected into the class where you need to retrieve a secret.
 
-### Local mock
+### 1. Azure Key Vault as config provider (recommended)
+If this approach is chosen, you can use Azure Key Vault in the standard way via [IOptions-pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options).
 
-To run your service locally without connecting to the Azure Key vault you have to 
-create the file `secrets.json` under the folder _App_.
-In the json structure you can add dummy data for the secrets you need for your service.
-If you have uploaded a secret into the key vault with the name "secretId", the content should look like the following:
+There is a helper method to add Azure Key Vault in this way, which can be used in Program.cs.
 
-```json
+```cs
+if (!builder.Environment.IsDevelopment())
 {
-  "secretId": "local secret dummy data"
+    builder.AddAzureKeyVaultAsConfigProvider();
 }
 ```
 
-### Types of secrets
+Example:
+```cs
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+ConfigureServices(builder.Services, builder.Configuration);
+ConfigureWebHostBuilder(builder.WebHost);
 
-Secret - Stored as a string directly in the key vault. For ex. a base64 encoded certificate or a token.
-Key - key
-Certificate - certificate
+if (!builder.Environment.IsDevelopment())
+{
+    builder.AddAzureKeyVaultAsConfigProvider();
+}
 
-### Code example
+WebApplication app = builder.Build();
+Configure();
+app.Run();
+```
 
-In this section you can find an example of how to use a secret to populate a form field during instantiation.
+Local mocking can be done with the use of [user secrets]('https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows).
 
-The logic is implemented within `InstantiationHandler.cs`
+```
+dotnet user-secrets init
+dotnet user-secrets set "NetsPaymentSettings:SecretApiKey" "test-secret-key-used-for-documentation"
+```
+
+### 2. Using ISecretsClient
+
+If you do not wish to add Azure Key Vault as a config provider, you can alternatively use the `ISecretsClient` service, which is a wrapper around the retrieval of secrets from Azure Key Vault. This service offers methods for fetching individual secrets as needed.
+
+#### Code example
+
+In this section, you will find an example of how to use a secret to populate a form field during instantiation.
+
+The logic is implemented in `InstantiationHandler.cs`.
 
 ```cs
 using Altinn.App.Models;
 using Altinn.App.Services.Interface;
 using Altinn.App.Services.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
+using Altinn.App.Core.Internal.Secrets;
 using System.Threading.Tasks;
 
 namespace Altinn.App.AppLogic
@@ -82,18 +103,16 @@ namespace Altinn.App.AppLogic
     {
         private IProfile _profileService;
         private IRegister _registerService;
-        private ISecrets _secretsService;
+        private ISecretsClient _secretsClient;
 
         /// <summary>
         /// Set up access to profile and register services
         /// </summary>
-        /// <param name="profileService"></param>
-        /// <param name="registerService"></param>
-        public InstantiationHandler(IProfile profileService, IRegister registerService, ISecrets secretsService)
+        public InstantiationHandler(IProfile profileService, IRegister registerService, ISecretsClient secretsClient)
         {
             _profileService = profileService;
             _registerService = registerService;
-            _secretsService = secretsService;
+            _secretsClient = secretsClient;
         }
 
         /// <summary>
@@ -110,7 +129,7 @@ namespace Altinn.App.AppLogic
             if (data.GetType() == typeof(Skjema))
             {
                 Skjema model = (Skjema)data;
-                model.etatid = await _secretsService_.GetSecretAsync("secretId");
+                model.etatid = await _secretsClient.GetSecretAsync("secretId");
             }
             await Task.CompletedTask;
         }
@@ -118,54 +137,36 @@ namespace Altinn.App.AppLogic
 }
 ```
 
-1. The private variable for the service is included in the class
+1. The private variable for the service is included in the class.
 
     ```cs
-    private ISecrets _secretsService;
+    private ISecretsClient _secretsClient;
     ```
 
-2. The ISecrets service is dependency injected into the class, and the private variable assigned a value
+2. The ISecretsClient service is injected in the constructor and is assigned to the private variable.
 
     ```cs
-    public InstantiationHandler(IProfile profileService, IRegister registerService, ISecrets secretsService)
+    public InstantiationHandler(IProfile profileService, IRegister registerService, ISecretsClient secretsClient)
             {
                 _profileService = profileService;
                 _registerService = registerService;
-                _secretsService = secretsService;
+                _secretsClient = secretsClient;
             }
 
     ```
 
-3. In the method where you need the secret you call the service
-    `secretId` will be the name of our secret in KeyVault, or in our local mock. 
+3. How to get a specific secret using the name from Azure Key Vault and/or local mock.
 
     ```cs
-    await _secretsService_.GetSecretAsync("secretId");
+    await _secretsClient_.GetSecretAsync("secretId");
     ```
 
-4. If you try to build the solution now, it will fail. 
+#### Lokal mock
 
-    ISecrets will be missing where the InstantiationHandler is instantiated. Navigate to `App.cs`
-    and dependency inject the service into the constructor in App.
+To run your service locally without connecting to Azure Key Vault, you need to create a file named `secrets.json` under the _App_ folder. In the JSON structure, you can include dummy data for the secrets you need. If you have uploaded a secret in Key Vault with the name "secretId," the content of the JSON file will look like this:
 
-    The service must be added to the call where InstantiationHandler is instantiated as illustrated below.
-
-    ```cs
-    public App(
-        IAppResources appResourcesService,
-        ILogger<App> logger,
-        IData dataService,
-        IProcess processService,
-        IPDF pdfService,
-        IProfile profileService,
-        IRegister registerService,
-        IPrefill prefillService,
-        ISecrets secretsService
-        ) : base(appResourcesService, logger, dataService, processService, pdfService, prefillService)
-    {
-        _logger = logger;
-        _validationHandler = new ValidationHandler();
-        _calculationHandler = new CalculationHandler();
-        _instantiationHandler = new InstantiationHandler(profileService, registerService, secretsService);
-    }
-    ```
+```json
+{
+  "secretId": "dummy secret value"
+}
+```

--- a/content/altinn-studio/reference/configuration/secrets/_index.nb.md
+++ b/content/altinn-studio/reference/configuration/secrets/_index.nb.md
@@ -41,31 +41,52 @@ Siste del av filen skal se omtrent slik ut når du har gjort ferdig alle endring
 
 ![Steg 1](yaml.png)
 
+
 ## Hvordan benytte hemmeligheter i applikasjonen
 
-Servicen `ISecret` er eksponert i applikasjonen og kan dependency injectes
+Man kan enten legge til Azure Key Vault som en config provider og benytte IOptions-pattern for å lese ut hemmeligheter, eller så kan man benytte servicen `ISecretsClient` er eksponert i applikasjonen og kan dependency injectes
 i den klassen der du har behov for å hente ut en hemmelighet.
 
-### Lokal mock
+### 1. Azure Key Vault som config provider (anbefalt)
+Om denne fremgangsmåten velges kan man bruke Azure Key Vault på standard måte via [IOptions-pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options).
 
-For å kunne kjøre tjenesten din lokalt uten å koble seg til Azure Key vault
-må man opprette filen `secrets.json` under mappen _App_.
-I Json strukturen kan man legge inn dummydata for hemmelighetene man har behov for.
-Har man lastet opp en hemmelighet i Key Vault med navnet "secretId" vil innholdet i json-filen se slik ut
+Det finnes en hjelpemetode for å legge til Azure Key Vault på denne måten, som kan benyttes i program.cs.
 
-```json
+```cs
+if (!builder.Environment.IsDevelopment())
 {
-  "secretId": "local cecret dummy data"
+    builder.AddAzureKeyVaultAsConfigProvider();
 }
 ```
 
-### Type hemmeligheter
+Eksempel:
+```cs
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+ConfigureServices(builder.Services, builder.Configuration);
+ConfigureWebHostBuilder(builder.WebHost);
 
-Secret - lagres som en streng direkte i keyvault. F.eks et sertifikat som er base64 encoded eller et token.
-Key - Nøkkel
-Certificate - et sertifikat
+if (!builder.Environment.IsDevelopment())
+{
+    builder.AddAzureKeyVaultAsConfigProvider();
+}
 
-### Kodeeksempel
+WebApplication app = builder.Build();
+Configure();
+app.Run();
+```
+
+Lokal mocking kan gjøres ved hjelp av [user secrets]('https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows).
+
+```
+dotnet user-secrets init
+dotnet user-secrets set "NetsPaymentSettings:SecretApiKey" "test-secret-key-used-for-documentation"
+```
+
+### 2. Bruk av ISecretsClient
+
+Dersom man ikke ønsker å legge til Azure Key Vault som config provider så kan man alternativt benytte tjenesten ISecretsClient, som er en wrapper rundt uthenging av hemmeligheter fra Azure Key Vault. Her tilbys metoder for å hente ut en og en hemmelighet der de trengs.
+
+#### Kodeeksempel
 
 I denne seksjonen finner du et eksempel på hvordan man benytter en hemmelighet
 til å populere et skjemafelt under instansiering.
@@ -77,6 +98,7 @@ using Altinn.App.Models;
 using Altinn.App.Services.Interface;
 using Altinn.App.Services.Models.Validation;
 using Altinn.Platform.Storage.Interface.Models;
+using Altinn.App.Core.Internal.Secrets;
 using System.Threading.Tasks;
 
 namespace Altinn.App.AppLogic
@@ -85,18 +107,16 @@ namespace Altinn.App.AppLogic
     {
         private IProfile _profileService;
         private IRegister _registerService;
-        private ISecrets _secretsService;
+        private ISecretsClient _secretsClient;
 
         /// <summary>
         /// Set up access to profile and register services
         /// </summary>
-        /// <param name="profileService"></param>
-        /// <param name="registerService"></param>
-        public InstantiationHandler(IProfile profileService, IRegister registerService, ISecrets secretsService)
+        public InstantiationHandler(IProfile profileService, IRegister registerService, ISecretsClient secretsClient)
         {
             _profileService = profileService;
             _registerService = registerService;
-            _secretsService = secretsService;
+            _secretsClient = secretsClient;
         }
 
         /// <summary>
@@ -113,7 +133,7 @@ namespace Altinn.App.AppLogic
             if (data.GetType() == typeof(Skjema))
             {
                 Skjema model = (Skjema)data;
-                model.etatid = await _secretsService_.GetSecretAsync("secretId");
+                model.etatid = await _secretsClient.GetSecretAsync("secretId");
             }
             await Task.CompletedTask;
         }
@@ -124,17 +144,17 @@ namespace Altinn.App.AppLogic
 1. Den private variabelen for servicen inkluderes i klassen
 
     ```cs
-    private ISecrets _secretsService;
+    private ISecretsClient _secretsClient;
     ```
 
-2. ISecrets servicen dependency injectes inn i klassen. Og den private variabelen blir assignet en verdi.
+2. ISecretsClient servicen dependency injectes inn i klassen. Og den private variabelen blir assignet en verdi.
 
     ```cs
-    public InstantiationHandler(IProfile profileService, IRegister registerService, ISecrets secretsService)
+    public InstantiationHandler(IProfile profileService, IRegister registerService, ISecretsClient secretsClient)
             {
                 _profileService = profileService;
                 _registerService = registerService;
-                _secretsService = secretsService;
+                _secretsClient = secretsClient;
             }
 
     ```
@@ -143,32 +163,18 @@ namespace Altinn.App.AppLogic
     `secretId` vil være navnet på hemmeligheten i KeyVault evt. i lokal mock.
 
     ```cs
-    await _secretsService_.GetSecretAsync("secretId");
+    await _secretsClient_.GetSecretAsync("secretId");
     ```
 
-4. Dersom du prøver å bygge løsningen nå vil det feile.
+#### Lokal mock
 
-    ISecrets vil mangle der InstantiationHandler instansieres. Naviger til `App.cs`
-    og dependency inject servicen inn i konstruktøren til App.
+For å kunne kjøre tjenesten din lokalt uten å koble seg til Azure Key vault
+må man opprette filen `secrets.json` under mappen _App_.
+I Json strukturen kan man legge inn dummydata for hemmelighetene man har behov for.
+Har man lastet opp en hemmelighet i Key Vault med navnet "secretId" vil innholdet i json-filen se slik ut
 
-    Videre må tjenesten legges til i kallet der InstantiationHandler instansieres som vist nedenfor.
-
-    ```cs
-    public App(
-        IAppResources appResourcesService,
-        ILogger<App> logger,
-        IData dataService,
-        IProcess processService,
-        IPDF pdfService,
-        IProfile profileService,
-        IRegister registerService,
-        IPrefill prefillService,
-        ISecrets secretsService
-        ) : base(appResourcesService, logger, dataService, processService, pdfService, prefillService)
-    {
-        _logger = logger;
-        _validationHandler = new ValidationHandler();
-        _calculationHandler = new CalculationHandler();
-        _instantiationHandler = new InstantiationHandler(profileService, registerService, secretsService);
-    }
-    ```
+```json
+{
+  "secretId": "local cecret dummy data"
+}
+```

--- a/content/altinn-studio/reference/configuration/secrets/_index.nb.md
+++ b/content/altinn-studio/reference/configuration/secrets/_index.nb.md
@@ -75,7 +75,7 @@ Configure();
 app.Run();
 ```
 
-Lokal mocking kan gjøres ved hjelp av [user secrets]('https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows).
+Lokal mocking kan gjøres ved hjelp av [user secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows).
 
 ```
 dotnet user-secrets init

--- a/content/app/guides/payment/backend-configuration/_index.en.md
+++ b/content/app/guides/payment/backend-configuration/_index.en.md
@@ -172,16 +172,22 @@ void RegisterCustomAppServices(IServiceCollection services, IConfiguration confi
 ### 5. Add config to appsettings.json:
 
 1. [Get your secret key from nets.](https://developer.nexigroup.com/nexi-checkout/en-EU/docs/access-your-integration-keys/). Make sure you use the test key during development.
-2. Add your secret key to keyvault, with the variable name: `NetsPaymentSettings--SecretApiKey`. This way it will override `SecretApiKey` in `appsettings.json`.
-3. Add `NetsPaymentSettings` to your `appsettings.json`. Remember to set the correct `baseUrl` in production.
-```json
-{
-  "NetsPaymentSettings": {
-    "SecretApiKey": "In keyvault",
-    "BaseUrl": "https://test.api.dibspayment.eu/",
-    "TermsUrl": "https://www.yourwebsite.com/terms",
-    "ShowOrderSummary": true,
-    "ShowMerchantName": true
-  }
-}
-```
+2. Make your app ready for use of Azure Key Vault as a config provider, if this has not been done before. See relevant [documentation](../../../../altinn-studio/reference/configuration/secrets/).
+3. Add your secret key to keyvault, with the variable name: `NetsPaymentSettings--SecretApiKey`. This way it will override `SecretApiKey` in `appsettings.json`.
+4. Add `NetsPaymentSettings` to your `appsettings.json`. Remember to set the correct `baseUrl` in production.
+    ```json
+    {
+      "NetsPaymentSettings": {
+        "SecretApiKey": "In keyvault",
+        "BaseUrl": "https://test.api.dibspayment.eu/",
+        "TermsUrl": "https://www.yourwebsite.com/terms",
+        "ShowOrderSummary": true,
+        "ShowMerchantName": true
+      }
+    }
+    ```
+5. Local mocking of `SecretApiKey` can be done with the use of [user secrets]('https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows).
+   ```
+   dotnet user-secrets init
+   dotnet user-secrets set "NetsPaymentSettings:SecretApiKey" "test-secret-key-used-for-documentation"
+   ```

--- a/content/app/guides/payment/backend-configuration/_index.en.md
+++ b/content/app/guides/payment/backend-configuration/_index.en.md
@@ -172,7 +172,7 @@ void RegisterCustomAppServices(IServiceCollection services, IConfiguration confi
 ### 5. Add config to appsettings.json:
 
 1. [Get your secret key from nets.](https://developer.nexigroup.com/nexi-checkout/en-EU/docs/access-your-integration-keys/). Make sure you use the test key during development.
-2. Make your app ready for use of Azure Key Vault as a config provider, if this has not been done before. See relevant [documentation](../../../../altinn-studio/reference/configuration/secrets/).
+2. Make your app ready for use of Azure Key Vault as a config provider, if this has not been done before. See relevant [documentation](/altinn-studio/reference/configuration/secrets/).
 3. Add your secret key to keyvault, with the variable name: `NetsPaymentSettings--SecretApiKey`. This way it will override `SecretApiKey` in `appsettings.json`.
 4. Add `NetsPaymentSettings` to your `appsettings.json`. Remember to set the correct `baseUrl` in production.
     ```json
@@ -186,7 +186,7 @@ void RegisterCustomAppServices(IServiceCollection services, IConfiguration confi
       }
     }
     ```
-5. Local mocking of `SecretApiKey` can be done with the use of [user secrets]('https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows).
+5. Local mocking of `SecretApiKey` can be done with the use of [user secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows).
    ```
    dotnet user-secrets init
    dotnet user-secrets set "NetsPaymentSettings:SecretApiKey" "test-secret-key-used-for-documentation"

--- a/content/app/guides/payment/backend-configuration/_index.nb.md
+++ b/content/app/guides/payment/backend-configuration/_index.nb.md
@@ -171,7 +171,7 @@ void RegisterCustomAppServices(IServiceCollection services, IConfiguration confi
 ### 5. Legg til config i appSettings.json:
 
 1. [Hent din hemmelige nøkkel fra nets.](https://developer.nexigroup.com/nexi-checkout/en-EU/docs/access-your-integration-keys/). Pass på at du bruker testnøkkelen under utvikling.
-2. Gjør appen din klar for bruk av Azure Key Vault som konfigurasjonkilde, om dette ikke allerede er gjort tidligere. Se relevant [dokumentasjon](/altinn-studio/reference/configuration/secrets/).
+2. Gjør appen din klar for bruk av Azure Key Vault som konfigurasjonkilde, om dette ikke allerede er gjort tidligere. Se relevant [dokumentasjon](/nb/altinn-studio/reference/configuration/secrets/).
 3. Legg til din hemmelige nøkkel i keyvault, med variabelnavnet: `NetsPaymentSettings--SecretApiKey`. På denne måten vil den overstyre `SecretApiKey` i `appsettings.json`. 
 4. Legg til `NetsPaymentSettings` i din `appsettings.json`. Husk å sett riktig `baseUrl` i `appsettings.Production.json`.
     ```json

--- a/content/app/guides/payment/backend-configuration/_index.nb.md
+++ b/content/app/guides/payment/backend-configuration/_index.nb.md
@@ -170,17 +170,24 @@ void RegisterCustomAppServices(IServiceCollection services, IConfiguration confi
 
 ### 5. Legg til config i appSettings.json:
 
-1. [Hent din hemmelige nøkkel fra nets.](https://developer.nexigroup.com/nexi-checkout/en-EU/docs/access-your-integration-keys/). Pass på at du bruker testnøkkelen under utvikling. 
-2. Legg til din hemmelige nøkkel i keyvault, med variabelnavnet: `NetsPaymentSettings--SecretApiKey`. På denne måten vil den overstyre `SecretApiKey` i `appsettings.json`. 
-3. Legg til `NetsPaymentSettings` i din `appsettings.json`. Husk å sett riktig `baseUrl` i produksjon.
-```json
-{
-  "NetsPaymentSettings": {
-    "SecretApiKey": "In keyvault",
-    "BaseUrl": "https://test.api.dibspayment.eu/",
-    "TermsUrl": "https://www.yourwebsite.com/terms",
-    "ShowOrderSummary": true,
-    "ShowMerchantName": true
-  }
-}
-```
+1. [Hent din hemmelige nøkkel fra nets.](https://developer.nexigroup.com/nexi-checkout/en-EU/docs/access-your-integration-keys/). Pass på at du bruker testnøkkelen under utvikling.
+2. Gjør appen din klar for bruk av Azure Key Vault som konfigurasjonkilde, om dette ikke allerede er gjort tidligere. Se relevant [dokumentasjon](../../../../altinn-studio/reference/configuration/secrets/).
+3. Legg til din hemmelige nøkkel i keyvault, med variabelnavnet: `NetsPaymentSettings--SecretApiKey`. På denne måten vil den overstyre `SecretApiKey` i `appsettings.json`. 
+4. Legg til `NetsPaymentSettings` i din `appsettings.json`. Husk å sett riktig `baseUrl` i `appsettings.Production.json`.
+    ```json
+    {
+      "NetsPaymentSettings": 
+      {
+        "SecretApiKey": "In keyvault",
+        "BaseUrl": "https://test.api.dibspayment.eu/",
+        "TermsUrl": "https://www.yourwebsite.com/terms",
+        "ShowOrderSummary": true,
+        "ShowMerchantName": true
+      }
+    }
+    ```
+5. Lokal mocking av `SecretApiKey` kan gjøres ved hjelp av [user secrets]('https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows).
+   ```
+   dotnet user-secrets init
+   dotnet user-secrets set "NetsPaymentSettings:SecretApiKey" "test-secret-key-used-for-documentation"
+   ```

--- a/content/app/guides/payment/backend-configuration/_index.nb.md
+++ b/content/app/guides/payment/backend-configuration/_index.nb.md
@@ -171,7 +171,7 @@ void RegisterCustomAppServices(IServiceCollection services, IConfiguration confi
 ### 5. Legg til config i appSettings.json:
 
 1. [Hent din hemmelige nøkkel fra nets.](https://developer.nexigroup.com/nexi-checkout/en-EU/docs/access-your-integration-keys/). Pass på at du bruker testnøkkelen under utvikling.
-2. Gjør appen din klar for bruk av Azure Key Vault som konfigurasjonkilde, om dette ikke allerede er gjort tidligere. Se relevant [dokumentasjon](../../../../altinn-studio/reference/configuration/secrets/).
+2. Gjør appen din klar for bruk av Azure Key Vault som konfigurasjonkilde, om dette ikke allerede er gjort tidligere. Se relevant [dokumentasjon](/altinn-studio/reference/configuration/secrets/).
 3. Legg til din hemmelige nøkkel i keyvault, med variabelnavnet: `NetsPaymentSettings--SecretApiKey`. På denne måten vil den overstyre `SecretApiKey` i `appsettings.json`. 
 4. Legg til `NetsPaymentSettings` i din `appsettings.json`. Husk å sett riktig `baseUrl` i `appsettings.Production.json`.
     ```json
@@ -186,7 +186,7 @@ void RegisterCustomAppServices(IServiceCollection services, IConfiguration confi
       }
     }
     ```
-5. Lokal mocking av `SecretApiKey` kan gjøres ved hjelp av [user secrets]('https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows).
+5. Lokal mocking av `SecretApiKey` kan gjøres ved hjelp av [user secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows).
    ```
    dotnet user-secrets init
    dotnet user-secrets set "NetsPaymentSettings:SecretApiKey" "test-secret-key-used-for-documentation"


### PR DESCRIPTION
Update secret related documentation on how to use Azure Key Vault as a configuration provider. Also includes some adjustments to payment docs.

Strongly related to https://github.com/Altinn/app-lib-dotnet/pull/704