### PR TITLE
Add language support to product toggle

### DIFF
--- a/layouts/partials/product-switcher.html
+++ b/layouts/partials/product-switcher.html
@@ -13,19 +13,25 @@
         </p>
       </a>
       <a aria-hidden="true" class="dropdown-item" href="{{ with .Site.GetPage `/authorization`}}{{.RelPermalink}}{{end}}">
-        <p class="product-item">
-          Authorization
-        </p>
+        {{- if eq .Language.Lang "en" -}}
+        <p class="product-item">Authorization</p>
+        {{- else if eq .Language.Lang "nb" -}}
+        <p class="product-item">Autorisasjon</p>
+        {{- end -}}
       </a>
       <a aria-hidden="true" class="dropdown-item" href="{{ with .Site.GetPage `/broker`}}{{.RelPermalink}}{{end}}">
-        <p class="product-item">
-          Broker
-        </p>
+        {{- if eq .Language.Lang "en" -}}
+        <p class="product-item">Broker</p>
+        {{- else if eq .Language.Lang "nb" -}}
+        <p class="product-item">Formidling</p>
+        {{- end -}}
       </a>
       <a aria-hidden="true" class="dropdown-item" href="{{ with .Site.GetPage `/correspondence`}}{{.RelPermalink}}{{end}}">
-        <p class="product-item">
-          Correspondence
-        </p>
+        {{- if eq .Language.Lang "en" -}}
+        <p class="product-item">Correspondence</p>
+        {{- else if eq .Language.Lang "nb" -}}
+        <p class="product-item">Melding</p>
+        {{- end -}}
       </a>
   </div>
   


### PR DESCRIPTION
When products have different names in different languages, the product toggle should reflect this.
