### PR TITLE
english intro course titles

### DIFF
--- a/content/altinn-studio/getting-started/app-dev-course/modul1/_index.en.md
+++ b/content/altinn-studio/getting-started/app-dev-course/modul1/_index.en.md
@@ -1,5 +1,5 @@
 ---
-title: Create the Service
+title: "Module 1: Create the Service"
 description: In this module, we will create a form service in Altinn Studio
 weight: 10
 toc: true

--- a/content/altinn-studio/getting-started/app-dev-course/modul2/_index.en.md
+++ b/content/altinn-studio/getting-started/app-dev-course/modul2/_index.en.md
@@ -1,5 +1,5 @@
 ---
-title: Customize the Data Model
+title: "Module 2: Customize the Data Model"
 description: In this module, we will customize the data model for the service
 weight: 20
 toc: true

--- a/content/altinn-studio/getting-started/app-dev-course/modul3/_index.en.md
+++ b/content/altinn-studio/getting-started/app-dev-course/modul3/_index.en.md
@@ -1,7 +1,6 @@
 ---
-title: Create Form
+title: "Module 3: Create Form"
 description: Create the first version of the form
-linktitle: Create Form
 tags: [apps, training, form]
 weight: 30
 ---

--- a/content/altinn-studio/getting-started/app-dev-course/modul4/_index.en.md
+++ b/content/altinn-studio/getting-started/app-dev-course/modul4/_index.en.md
@@ -1,5 +1,5 @@
 ---
-title: Create Info Page
+title: "Module 4: Create Info Page"
 description: Create an info page that is shown to the user when they start the service
 tags: [apps, training, form, pages]
 weight: 40

--- a/content/altinn-studio/getting-started/app-dev-course/modul5/_index.en.md
+++ b/content/altinn-studio/getting-started/app-dev-course/modul5/_index.en.md
@@ -1,5 +1,5 @@
 ---
-title: Publish the Service
+title: "Module 5: Publish the Service"
 description: Publish the service to a test environment
 tags: [apps, training, form, deploy, test]
 weight: 50

--- a/content/altinn-studio/getting-started/app-dev-course/modul6/_index.en.md
+++ b/content/altinn-studio/getting-started/app-dev-course/modul6/_index.en.md
@@ -1,8 +1,8 @@
 ---
-title: Add code lists
+title: "Module 6: Add code lists"
 description: Not translated.
 tags: [apps, training, form, pages]
-weight: 40
+weight: 60
 toc: true
 ---
 


### PR DESCRIPTION
Added "Module" + module number as prefix to english translations of intro course and fixed ordering of codelists module in english translation.