### PR TITLE
Pin hugo to v0.133.1 for now

### DIFF
--- a/.github/workflows/hugo-verifications.yml
+++ b/.github/workflows/hugo-verifications.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.133.1'
 
       - name: Build docs
         run: hugo

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.124.1
+      HUGO_VERSION: 0.133.1
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
Avoid using latest since v0.134.0 released yesterday seems to have introduced a bug making link-checking fail