### PR TITLE
Add plural form for order endpoints in API reference for Notifications API

### DIFF
--- a/content/notifications/reference/api/endpoints/cancel-notification-order/_index.en.md
+++ b/content/notifications/reference/api/endpoints/cancel-notification-order/_index.en.md
@@ -9,7 +9,7 @@ toc: true
 
 ## Endpoint
 
-PUT /order/{id}/cancel
+PUT /orders/{id}/cancel
 
 {id} represents the ID of the notification order to retrieve notifications for.
 

--- a/content/notifications/reference/api/endpoints/cancel-notification-order/_index.nb.md
+++ b/content/notifications/reference/api/endpoints/cancel-notification-order/_index.nb.md
@@ -9,7 +9,7 @@ toc: true
 
 ## Endpoint
 
-PUT /order/{id}/cancel
+PUT /orders/{id}/cancel
 
 {id} represents the ID of the notification order to retrieve notifications for.
 

--- a/content/notifications/reference/api/endpoints/get-email-notifications/_index.en.md
+++ b/content/notifications/reference/api/endpoints/get-email-notifications/_index.en.md
@@ -9,7 +9,7 @@ toc: true
 
 ## Endpoint
 
-GET /order/{id}/notifications/email
+GET /orders/{id}/notifications/email
 
 {id} represents the ID of the notification order to retrieve notifications for.
 

--- a/content/notifications/reference/api/endpoints/get-email-notifications/_index.nb.md
+++ b/content/notifications/reference/api/endpoints/get-email-notifications/_index.nb.md
@@ -9,7 +9,7 @@ toc: true
 
 ## Endpoint
 
-GET /order/{id}/notifications/email
+GET /orders/{id}/notifications/email
 
 {id} represents the ID of the notification order to retrieve notifications for.
 

--- a/content/notifications/reference/api/endpoints/get-notification-order-by-id/_index.en.md
+++ b/content/notifications/reference/api/endpoints/get-notification-order-by-id/_index.en.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Endpoint
 
-GET /order/{id}
+GET /orders/{id}
 
 {id} represents the ID of the notification order to retrieve details for.
 

--- a/content/notifications/reference/api/endpoints/get-notification-order-by-id/_index.nb.md
+++ b/content/notifications/reference/api/endpoints/get-notification-order-by-id/_index.nb.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Endpoint
 
-GET /order/{id}
+GET /orders/{id}
 
 {id} represents the ID of the notification order to retrieve details for.
 

--- a/content/notifications/reference/api/endpoints/get-notification-order-status/_index.en.md
+++ b/content/notifications/reference/api/endpoints/get-notification-order-status/_index.en.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Endpoint
 
-GET /order/{id}/status
+GET /orders/{id}/status
 
 {id} represents the ID of the notification order to retrieve status for.
 

--- a/content/notifications/reference/api/endpoints/get-notification-order-status/_index.nb.md
+++ b/content/notifications/reference/api/endpoints/get-notification-order-status/_index.nb.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Endpoint
 
-GET /order/{id}/status
+GET /orders/{id}/status
 
 {id} represents the ID of the notification order to retrieve status for.
 

--- a/content/notifications/reference/api/endpoints/get-sms-notifications/_index.en.md
+++ b/content/notifications/reference/api/endpoints/get-sms-notifications/_index.en.md
@@ -9,7 +9,7 @@ toc: true
 
 ## Endpoint
 
-GET /order/{id}/notifications/sms
+GET /orders/{id}/notifications/sms
 
 {id} represents the ID of the notification order to retrieve notifications for.
 

--- a/content/notifications/reference/api/endpoints/get-sms-notifications/_index.nb.md
+++ b/content/notifications/reference/api/endpoints/get-sms-notifications/_index.nb.md
@@ -9,7 +9,7 @@ toc: true
 
 ## Endpoint
 
-GET /order/{id}/notifications/sms
+GET /orders/{id}/notifications/sms
 
 {id} represents the ID of the notification order to retrieve notifications for.
 


### PR DESCRIPTION
Det er mismatch mellom denne docs'en og docs'en i OpenAPI/Swagger. Får naturligvis 404 dersom det brukes _order_, og dersom man følger docs fra Swagger blir det riktig.