### PR TITLE
fix wrong naming in Broker terminology

### DIFF
--- a/content/broker/_index.en.md
+++ b/content/broker/_index.en.md
@@ -13,8 +13,8 @@ weight: 1
 ## What you get with Altinn Broker
 An overview and description of the key functionalities and features of Altinn Broker.
 
-### End-to-end file transfer
-Altinn Formidling offers end-to-end file transfer, from creation, sending, receiving to tracking file transfers. This ensures that all parts of the messaging flow are handled efficiently and securely.
+### End-to-end file transfers
+Altinn Formidling offers end-to-end file transfers, from creation, sending, receiving to tracking file transfers. This ensures that all parts of the messaging flow are handled efficiently and securely.
 
 ### Support for large payloads
 A unique feature of Altinn Broker is its ability to handle large data volumes (payloads). We aim to support very large payloads in the near future. This is the solution for those who need to transfer large amounts of information efficiently and securely.

--- a/content/broker/_index.en.md
+++ b/content/broker/_index.en.md
@@ -13,8 +13,8 @@ weight: 1
 ## What you get with Altinn Broker
 An overview and description of the key functionalities and features of Altinn Broker.
 
-### End-to-end message exchange
-Altinn Formidling offers end-to-end message exchange, from creation, sending, receiving to tracking messages. This ensures that all parts of the messaging flow are handled efficiently and securely.
+### End-to-end file transfer
+Altinn Formidling offers end-to-end file transfer, from creation, sending, receiving to tracking file transfers. This ensures that all parts of the messaging flow are handled efficiently and securely.
 
 ### Support for large payloads
 A unique feature of Altinn Broker is its ability to handle large data volumes (payloads). We aim to support very large payloads in the near future. This is the solution for those who need to transfer large amounts of information efficiently and securely.
@@ -23,10 +23,10 @@ A unique feature of Altinn Broker is its ability to handle large data volumes (p
 Users have access to all functionalities through both a user-friendly interface (GUI) and via APIs. This provides you with the flexibility to integrate Altinn Formidling into your own systems, allowing you to automate your processes.
 
 ### Notifications and tracking
-The system supports detailed notification and tracking mechanisms. This includes notifications in accordance with the E-Government Regulation, ensuring that you are always updated on the status of your messages. The tracking provides a complete overview of the messaging flow, including delivery status and confirmations.
+The system supports detailed notification and tracking mechanisms. This includes notifications in accordance with the E-Government Regulation, ensuring that you are always updated on the status of your transfers. The tracking provides a complete overview of the messaging flow, including delivery status and confirmations.
 
 ### High degree of auditability and detailed access control
-Altinn Broker offers a high degree of auditability, meaning that all events and processes are logged carefully for verification. The system also supports refined and detailed access control, ensuring that only authorized users can access specific messages or functionalities.
+Altinn Broker offers a high degree of auditability, meaning that all events and processes are logged carefully for verification. The system also supports refined and detailed access control, ensuring that only authorized users can access specific transfers or functionalities.
 
 ### Support for various file formats
 The solution is flexible and supports both structured and unstructured files. This customization allows for adaptation to a wide range of use cases and data formats.

--- a/content/broker/_index.nb.md
+++ b/content/broker/_index.nb.md
@@ -12,8 +12,8 @@ weight: 1
 ## Hva du får med Altinn Formidling 
 Overordnet oversikt og bekrivelse av nøkkelfunksjonalitetene og egenskapene til Altinn Formidling 
 
-### Ende-til-ende meldingsutveksling
-Altinn Formidling tilbyr ende-til-ende meldingsutveksling, fra opprettelse, sending, mottak til sporing av meldinger. Dette sikrer at alle deler av meldingsflyten håndteres effektivt og sikkert. 
+### Ende-til-ende filoverføringer
+Altinn Formidling tilbyr ende-til-ende filoverføringer, fra opprettelse, sending, mottak til sporing av fileoverføringer. Dette sikrer at alle deler av overføringsflyten håndteres effektivt og sikkert. 
  
 ### Støtte for store payloads
 Et særegent trekk ved Altinn Formidling er evne til å håndtere store datamengder (payloads). Vi har ambisjoner om å støtte svært store payloads i nær fremtid. Dette er løsningen for deg som trenger å overføre store mengder informasjon effektivt og sikkert. 
@@ -22,10 +22,10 @@ Et særegent trekk ved Altinn Formidling er evne til å håndtere store datameng
 Brukere får tilgang til alle funksjoner både gjennom et brukervennlig grensesnitt (GUI) og via API-er. Dette gir deg fleksibilitet til å integrere Altinn Formidling i egne systemer, slik at du kan automatisere dine prosesser. 
 
 ### Varsling og sporing
-Systemet støtter detaljerte varslings- og sporingsmekanismer. Dette inkluderer varslinger i tråd med eForvaltningsforskriften, som sikrer at du alltid er oppdatert på statusen til deres meldinger. Sporingen gir full oversikt over meldingsflyten, inkludert leveringsstatus og bekreftelser. 
+Systemet støtter detaljerte varslings- og sporingsmekanismer. Dette inkluderer varslinger i tråd med eForvaltningsforskriften, som sikrer at du alltid er oppdatert på statusen til deres overføringer. Sporingen gir full oversikt over overføringsflyten, inkludert leveringsstatus og bekreftelser. 
 
 ### Høy grad av notoritet og detaljert tilgangsstyring
-Altinn Formidling tilbyr en høy grad av notoritet, noe som betyr at alle hendelser og prosesser loggføres nøye for etterprøvbarhet. Systemet støtter også spisset og detaljert tilgangsstyring, slik at du kan være trygg på at kun autoriserte brukere får tilgang til spesifikke meldinger eller funksjoner. 
+Altinn Formidling tilbyr en høy grad av notoritet, noe som betyr at alle hendelser og prosesser loggføres nøye for etterprøvbarhet. Systemet støtter også spisset og detaljert tilgangsstyring, slik at du kan være trygg på at kun autoriserte brukere får tilgang til spesifikke filoverføringer eller funksjoner. 
 
 ### Støtte for ulike filformater 
 Løsningen er fleksibel og støtter både strukturerte og ustrukturerte filer. Dette gjør det mulig å tilpasse løsningen til en rekke forskjellige bruksområder og dataformater. 

--- a/content/broker/reference/terminology/_index.en.md
+++ b/content/broker/reference/terminology/_index.en.md
@@ -1,14 +1,14 @@
 ---
 title: Terminology
 linktitle: Terminology
-description: Altinn 3 Terminology
+description: Terminology for Altinn 3 Broker
 tags: []
 toc: false
 weight: 10
 ---
 
 The following table gives brief descriptions of the main terms used to describe
-Altinn 3 Correspondence. Also see https://docs.altinn.studio/technology/terms/ and <https://data.norge.no/concepts>.
+Altinn 3 Broker. Also see https://docs.altinn.studio/technology/terms/ and <https://data.norge.no/concepts>.
 
 | **Term**                       | **Explanation**                                                                                                                                                                                                                                          |
 |--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -70,6 +70,6 @@ A longer list of terms. kept as a comment until further:
 -->
 
 Notes: 
-* In the context of Altinn Correspondence, the terms _Data Provider_ and _Sender_ may be assumed to mean the same.
-* In the context of Altinn Correspondence, the terms _Data Consumer_ and _Recipient_ may be assumed to mean the same.
+* In the context of Altinn Broker, the terms _Data Provider_ and _Sender_ may be assumed to mean the same.
+* In the context of Altinn Broker, the terms _Data Consumer_ and _Recipient_ may be assumed to mean the same.
   <!-- are used interchangeably. -->

--- a/content/broker/reference/terminology/_index.nb.md
+++ b/content/broker/reference/terminology/_index.nb.md
@@ -1,13 +1,13 @@
 ---
 title: Begreper
 linktitle: Begreper
-description: Begrepsapparat for Altinn 3 Melding
+description: Begrepsapparat for Altinn 3 Formidling
 tags: []
 toc: false
 weight: 10
 ---
 
-Her følger en tabell som gir korte beskrivelser av hovedbegrepene som brukes for å beskrive Altinn 3 Melding. 
+Her følger en tabell som gir korte beskrivelser av hovedbegrepene som brukes for å beskrive Altinn 3 Formidling. 
 Se også https://docs.altinn.studio/technology/terms/ og <https://data.norge.no/concepts>.
 
 | **Begrep**                       | **Forklaring**                                                                                                                                                                                                                                          |
@@ -36,7 +36,7 @@ Se også https://docs.altinn.studio/technology/terms/ og <https://data.norge.no/
 
 
 Merk: 
-* I kontekst av Altinn Melding, benyttes begrepene _datatilbyder_ og _avsender_ om det samme.
-* I kontekst av Altinn Melding, benyttes begrepene _datakonsument_ og _mottaker_ om det samme.
+* I kontekst av Altinn Formidling, benyttes begrepene _datatilbyder_ og _avsender_ om det samme.
+* I kontekst av Altinn Formidling, benyttes begrepene _datakonsument_ og _mottaker_ om det samme.
   <!-- are used interchangeably. -->
 

--- a/content/correspondence/reference/capabilities/_index.nb.md
+++ b/content/correspondence/reference/capabilities/_index.nb.md
@@ -18,7 +18,7 @@ TBD
 
 
 ## Overordnede brukerbehov
-For å se hvilke egenskaper som kreves av Altinn Formidlingsløsningen, starter vi med å vurdere brukernes behov. 
+For å se hvilke egenskaper som kreves av Altinn Meldingsløsningen, starter vi med å vurdere brukernes behov. 
 Følgende diagram uttrykker de overordnede brukerbehovene for hvert verdistrømsteg.
 
 Figur: TBD

--- a/content/correspondence/reference/solution-architecture/_index.nb.md
+++ b/content/correspondence/reference/solution-architecture/_index.nb.md
@@ -9,7 +9,7 @@ weight: 40
 
 ## Overordnet løsningsarkitektur
 
-Følgende figur gir en oversikt over de vikigste byggeklossene i overordnet løsningsarktitektur for Altinn 3 Formidling.
+Følgende figur gir en oversikt over de vikigste byggeklossene i overordnet løsningsarktitektur for Altinn 3 Melding.
 
 ![Byggeklosser i Altinn 3 Melding - overordnet løsningsarkitektur](altinn3-correspondence-solution-overview-nb.png "Byggeklosser i Altinn 3 Melding - overordnet løsningsarkitektur")
 


### PR DESCRIPTION
Broker had references to Correspondence, which should be Broker