### PR TITLE
edit guide for setting up as a Service Owner

### DIFF
--- a/content/correspondence/getting-started/service-owner/_index.en.md
+++ b/content/correspondence/getting-started/service-owner/_index.en.md
@@ -27,7 +27,7 @@ This step is only necessary for new enterprises that have not yet established th
 Perform steps 1 and 2 of the [Common Get started steps](../common-steps) if you have not already done so.
 
 ## 3. Register a Resource in Altinn Resource Registry {#register-a-resource-in-altinn-resource-registry}
-In order to send messages via Altinn Message, they must first be associated with a resource. 
+In order to send messages via Altinn Correspondence, they must first be associated with a resource. 
 A resource represents a specific function or set of functions used to manage access and rules for the correspondence. 
 Resources are registered via Altinn Studio and are used to define access rules and access lists, ensuring that only authorized users can perform specific actions.
 

--- a/content/correspondence/getting-started/service-owner/_index.en.md
+++ b/content/correspondence/getting-started/service-owner/_index.en.md
@@ -27,17 +27,17 @@ This step is only necessary for new enterprises that have not yet established th
 Perform steps 1 and 2 of the [Common Get started steps](../common-steps) if you have not already done so.
 
 ## 3. Register a Resource in Altinn Resource Registry {#register-a-resource-in-altinn-resource-registry}
+In order to send messages via Altinn Message, they must first be associated with a resource. 
+A resource represents a specific function or set of functions used to manage access and rules for the correspondence. 
+Resources are registered via Altinn Studio and are used to define access rules and access lists, ensuring that only authorized users can perform specific actions.
 
-All operations using Correspondence is associated with a resource/service/"tjenesteressurs". See [Resource Registry](../../../../authorization/what-do-you-get/resourceregistry/).
-Resources can be registered through Altinn Studio, and are used for access rules and access lists.
 Your policy must be configured in such a way that that they permit the actions:
-
-- "see" to see metadata about a message
-- "open" to open a message 
-- "send" to send a message
-- "subscribe" to register event subscriptions in Altinn Events
-
-To setup a resource that works quickly, you can use our [Postman collection](https://github.com/Altinn/altinn-correspondence/blob/main/altinn-correspondence-postman-collection.json) and run the requests "Create resource" and "Create resource policy" with a token that has the scope "altinn:resourceregistry/resource.write".
+1. Log in to Altinn Studio and navigate to the resource dashboard, See [Resource Registry](../../../../authorization/guides/create-resource-resource-admin/) for a detailed guide.
+2. Create a new resource, follow the guide and fill in the necessary information and details about the service.
+3. Set policy rules for the resource. Your policy must be configured in such a way that that they permit the actions:
+    - "read" meant for recipients to open and read a message
+    - "write" meant for senders to send a message
+    - "subscribe" to register event subscriptions in Altinn Events
 
 Here is an [example policy](ExamplePolicy.xml).
 

--- a/content/correspondence/getting-started/service-owner/_index.nb.md
+++ b/content/correspondence/getting-started/service-owner/_index.nb.md
@@ -28,20 +28,16 @@ Dette trinnet er bare nødvendig for nye virksomheter som ennå ikke har etabler
 Utfør steg 1 og 2 i [Felles kom i gang-steg](../common-steps) hvis du ikke allerede har gjort det.
 
 ## 3. Opprett ny ressurs {#register-a-resource-in-altinn-resource-registry}
-For at filer skal kunne sendes med Altinn Formidling, må de være tilknyttet en ressurs. 
-En ressurs representerer en spesifikk funksjon eller et sett av funksjoner som brukes til å administrere tilgang og regler for filoverføring. 
+For å kunne sende meldinger over med Altinn Melding, må de først være tilknyttet en ressurs. 
+En ressurs representerer en spesifikk funksjon eller et sett av funksjoner som brukes til å administrere tilgang og regler for overføring av meldinger. 
 Ressurser registreres via Altinn Studio og brukes til å definere tilgangsregler og tilgangslister, som sikrer at bare autoriserte brukere kan utføre bestemte handlinger.
 
-1. Logg inn på Altinn Studio og naviger til ressursdashboardet, Se [Ressursregister](../../../../authorization/what-do-you-get/resourceregistry/) for en detaljert veiledning.
+1. Logg inn på Altinn Studio og naviger til ressursdashboardet, Se [Ressursregister](../../../../authorization/guides/create-resource-resource-admin/) for en detaljert veiledning.
 2. Opprett ny ressurs, følg veiledningen og fyll inn nødvendig informasjon og detaljer om tjenesten.
-3. Angi tilgangsregler for ressursen.
-4. Tilgangsregler må for ressursen må konfigureres slik at de tillater følgende handlinger:
-    - "see" for å se metadata om en melding
-    - "open" for å åpne en melding
-    - "send" for å sende en melding
+3. Angi tilgangsregler for ressursen. Tilgangsregler må for ressursen må konfigureres slik at de tillater følgende handlinger:
+    - "read" ment for mottakere å åpne og lese en melding
+    - "write" ment for avsendere å sende en melding
     - "subscribe" for å registrere hendelsesabonnement i Altinn Events
-
-Alternativt, for å sette opp en ressurs som fungerer raskt, kan du bruke vår [Postman-samling](https://github.com/Altinn/altinn-correspondence/blob/main/altinn-correspondence-postman-collection.json) og kjøre forespørslene "Create resource" og "Create resource policy" med en token som har scopet "altinn:resourceregistry/resource.write".
 
 Her er en [eksempelpolicy](ExamplePolicy.xml).
 


### PR DESCRIPTION
Small fixes in Getting Started Guide

Change Open->Read and Send-> Write, as well as removing See policy. 

There were some differences in the english and norwegian guide, but these match now. 