### PR TITLE
fix: add published to details and overview, add notification to overview

### DIFF
--- a/static/swagger/altinn-correspondence-v1.json
+++ b/static/swagger/altinn-correspondence-v1.json
@@ -1141,6 +1141,10 @@
                     "IgnoreReservation": {
                         "type": "boolean",
                         "nullable": true
+                    },
+                    "published": {
+                        "type": "string",
+                        "format": "date-time"
                     }
                 },
                 "additionalProperties": false
@@ -1377,6 +1381,20 @@
                 },
                 "additionalProperties": false
             },
+            "CorrespondenceNotificationOverview": {
+                "type": "object",
+                "properties": {
+                    "notificationOrderId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "nullable": true
+                    },
+                    "isReminder": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false
+            },
             "CorrespondenceOverviewExt": {
                 "required": [
                     "correspondenceId",
@@ -1484,8 +1502,13 @@
                     "notifications": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/NotificationExt"
+                            "$ref": "#/components/schemas/CorrespondenceNotificationOverview"
                         },
+                        "nullable": true
+                    },
+                    "published" : {
+                        "type": "string",
+                        "format": "date-time",
                         "nullable": true
                     }
                 },


### PR DESCRIPTION
Following PR (https://github.com/Altinn/altinn-correspondence/pull/366), a new schema has been added along with the correct response for correspondence overview. 

A double checking has also been done for the schemas to ensure it is up to date with the current api. 