### PR TITLE
Fix urls to POST & GET systemregister system

### DIFF
--- a/content/authentication/guides/systemauthentication-for-systemproviders/_index.md
+++ b/content/authentication/guides/systemauthentication-for-systemproviders/_index.md
@@ -122,13 +122,13 @@ The example shows the system registered for the demo application SmartCloud in t
 URL to register
 
 ```http
-POST https://platform.tt02.altinn.no/authentication/api/v1/systemregister/system/vendor/
+POST https://platform.tt02.altinn.no/authentication/api/v1/systemregister/vendor/
 ```
 
 URL to update this system (ID must be changed for other systems)
 
 ```http
-POST https://platform.tt02.altinn.no/authentication/api/v1/systemregister/system/vendor/91825827_smartcloud
+POST https://platform.tt02.altinn.no/authentication/api/v1/systemregister/vendor/91825827_smartcloud
 ```
 
 For production, change the domain to **platform.altinn.no**

--- a/content/authentication/guides/systemauthentication-for-systemproviders/_index.nb.md
+++ b/content/authentication/guides/systemauthentication-for-systemproviders/_index.nb.md
@@ -123,13 +123,13 @@ Eksempelet viser systemet som er registrert for demoapplikasjonen SmartCloud i T
 Url for å regsistrere
 
 ```http
-POST https://platform.tt02.altinn.no/authentication/api/v1/systemregister/system/vendor/
+POST https://platform.tt02.altinn.no/authentication/api/v1/systemregister/vendor/
 ```
 
 Url for å opppdatere dette systemet (ID må endres for andre system)
 
 ```http
-POST https://platform.tt02.altinn.no/authentication/api/v1/systemregister/system/vendor/91825827_smartcloud
+POST https://platform.tt02.altinn.no/authentication/api/v1/systemregister/vendor/91825827_smartcloud
 ```
 
 For produksjon endres domenet til **platform.altinn.no**


### PR DESCRIPTION
Urls toPOST & GET systemregister system has been changed, but documentation us not up to date for the new routes.