### PR TITLE
Updated /correspondence/getting-started/developer-guides/notifications/ page

### DIFF
--- a/content/correspondence/getting-started/developer-guides/notifications/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/notifications/_index.en.md
@@ -53,7 +53,7 @@ Keywords is a list of tokens which enable personalization in notifications. Thes
 | Value                 | Description                                                                                                                           | Extra                                                                                    |
 |-----------------------|-------------------------------------------------------------------------------------------------------------------------------------- |-------------------------------------------------------------------------------------------|
 | \$sendersName\$       | Will be supplied with the senders name. Either by the "MessageSender" attribute if it has value, or by a lookup in Altinn Register.   | Supported for all scenarios                                                               |
-| \$recipientName\$     | Will be supplied with the recipients name, which will be either det organizations name or a persons name                              | Is not supported when notifications is sent directly to an email adress or a phone number |
+| \$recipientName\$     | Will be supplied with the recipients name, which will be either det organizations name or a persons name                              | Supported for all scenarios                                                               |
 | \$recipientNumber\$   | If the recipient is a organization, it will be supplied with the organization number, otherwise it will be left empty                 | Is not supported when notifications is sent directly to an email adress or a phone number |
 
 ## Notification Templates

--- a/content/correspondence/getting-started/developer-guides/notifications/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/notifications/_index.en.md
@@ -50,11 +50,12 @@ A notification order is made by adding the following when initializing a message
 
 Keywords is a list of tokens which enable personalization in notifications. These will be automaticly supplied with text by Altinn.
 
-| Value                 | Description                                                                                                                           | Extra                                                                                    |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------- |-------------------------------------------------------------------------------------------|
-| \$sendersName\$       | Will be supplied with the senders name. Either by the "MessageSender" attribute if it has value, or by a lookup in Altinn Register.   | Supported for all scenarios                                                               |
-| \$recipientName\$     | Will be supplied with the recipients name, which will be either det organizations name or a persons name                              | Supported for all scenarios                                                               |
-| \$recipientNumber\$   | If the recipient is a organization, it will be supplied with the organization number, otherwise it will be left empty                 | Is not supported when notifications is sent directly to an email adress or a phone number |
+| Value                           | Description                                                                                                                           | Extra                                                                                     |
+|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------- |-------------------------------------------------------------------------------------------|
+| \$sendersName\$                 | Will be supplied with the senders name. Either by the "MessageSender" attribute if it has value, or by a lookup in Altinn Register.   | Supported for all scenarios                                                               |
+| \$correspondenceRecipientName\$ | Will be supplied with the correspondence recipient's name, which will be either the organization's name or a person's name            | Supported for all scenarios                                                               |
+| \$recipientName\$               | Will be supplied with the notification recipient's name, which will be either the organization's name or a person's name              | Is not supported when notifications is sent directly to an email adress or a phone number |
+| \$recipientNumber\$             | If the recipient is a organization, it will be supplied with the organization number, otherwise it will be left empty                 | Is not supported when notifications is sent directly to an email adress or a phone number |
 
 ## Notification Templates
 
@@ -69,11 +70,11 @@ Two types of notification templates are offered when using notifications through
 A generic Altinn text with the option to supplement with additional text. Currently supported languages are Norwegian, Nynorsk, and English.
 The language is chosen based on the language defined in the message.
 
-**Title:** You have received a message in Altinn {textToken}<br>
-**Content:** Hello \$recipientName\$, you have received a new message from \$sendersName\$. {textToken} Log in to Altinn to see this message.
+**Title:** A message has been received in Altinn {textToken}<br>
+**Content:** Hello. $correspondenceRecipientName$ has received a new message from $sendersName$. {textToken} Log in to Altinn to see this message.
 
-**Reminder Title:** Reminder - you have received a message in Altinn {textToken}<br>
-**Reminder Content:** Hello \$recipientName\$, this is a reminder that you have received a new message from \$sendersName\$. {textToken} Log in to Altinn to see this message.
+**Reminder Title:** Reminder - a message has been received in Altinn {textToken}<br>
+**Reminder Content:** Hello. This is a reminder that $correspondenceRecipientName$ has received a new message from $sendersName$. {textToken} Log in to Altinn to see this message.
 
 In the text, textToken will be replaced with the value given in, for example, "EmailSubject" for the title. SMS uses only the content, not the title.
 

--- a/content/correspondence/getting-started/developer-guides/notifications/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/notifications/_index.nb.md
@@ -48,11 +48,12 @@ En varslingsbestilling gjøres ved å legge til følgende når du initialiserer 
 ## Keyword støtte
 
 Keywords er en liste tokens som lar deg personalisere varslingene med for eksempel mottakers navn.
-| Verdi                 | Beskrivelse                                                                                                                            | Ekstra                                                                               |
-|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------- |--------------------------------------------------------------------------------------|
-| \$sendersName\$       | Blir byttet ut med avsenders navn. Enten "MessageSender" om attributten har en verdi, eller basert på ett oppslag i Altinn Register.   | Støttes for alle scenarioer                                                          |
-| \$recipientName\$     | Blir byttet ut med mottakers navn. Dette vil være enten organisasjonsnavn eller personens navn.                                        | Støttes for alle scenarioer                                                          |
-| \$recipientNumber\$   | Dersom mottaker er en organisasjon vises Organisasjonsnummer. Dersom mottaker er en privatperson vises ingenting                       | Støttes ikke dersom varsel blir sendt direkte til e-post adresse eller telefonnummer |
+| Verdi                           | Beskrivelse                                                                                                                            | Ekstra                                                                               |
+|---------------------------------|--------------------------------------------------------------------------------------------------------------------------------------- |--------------------------------------------------------------------------------------|
+| \$sendersName\$                 | Blir byttet ut med avsenders navn. Enten "MessageSender" om attributten har en verdi, eller basert på ett oppslag i Altinn Register.   | Støttes for alle scenarioer                                                          |
+| \$correspondenceRecipientName\$ | Blir byttet ut med melding mottakers navn. Dette vil være enten organisasjonsnavn eller personens navn.                                | Støttes for alle scenarioer                                                          |
+| \$recipientName\$               | Blir byttet ut med varsling mottakers navn. Dette vil være enten organisasjonsnavn eller personens navn.                               | Støttes ikke dersom varsel blir sendt direkte til e-post adresse eller telefonnummer |
+| \$recipientNumber\$             | Dersom mottaker er en organisasjon vises Organisasjonsnummer. Dersom mottaker er en privatperson vises ingenting                       | Støttes ikke dersom varsel blir sendt direkte til e-post adresse eller telefonnummer |
 
 ## Varslingsmaler
 
@@ -66,11 +67,11 @@ Det tilbys to typer varslingsmaler når du bruker varsling gjennom Meldings-API`
 
 - En generisk Altinn-tekst med mulighet for å supplere med ekstra tekst. Foreløpig støttede språk er norsk, nynorsk og engelsk. Språk velges basert på språket definert i meldingen
 
-**Tittel:** Du har mottatt en melding i Altinn {textToken}<br>
-**Innhold:** Hei \$recipientName\$, du har mottatt en ny melding fra \$sendersName\$. {textToken} Logg deg inn i Altinn for å se denne meldingen.
+**Tittel:** En melding har blitt mottatt i Altinn {textToken}<br>
+**Innhold:** Hei. $correspondenceRecipientName$ har mottatt en ny melding fra $sendersName$. {textToken}Logg deg inn i Altinn for å se denne meldingen.
 
-**Revarsel tittel:** Påminnelse - du har mottatt en melding i Altinn {textToken}<br>
-**Revarsel innhold:** Hei \$recipientName\$, dette er en påminnelse om at du har mottatt en ny melding fra \$sendersName\$. {textToken} Logg deg inn i Altinn for å se denne meldingen.
+**Revarsel tittel:** Påminnelse - en melding har blitt mottatt i Altinn {textToken}<br>
+**Revarsel innhold:** Hei. Dette er en påminnelse om at $correspondenceRecipientName$ har mottatt en ny melding fra $sendersName$. {textToken}Logg deg inn i Altinn for å se denne meldingen.
 
 I teksten vil textToken bli byttet ut med verdien gitt i for eksempel "EmailSubject" for tittelen. SMS bruker kun innholdet, ikke tittelen.
 \$recipientName\$ vil bli byttet ut med mottakers navn. Dette vil være enten organisasjonsnavn eller personens navn.

--- a/content/correspondence/getting-started/developer-guides/notifications/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/notifications/_index.nb.md
@@ -51,7 +51,7 @@ Keywords er en liste tokens som lar deg personalisere varslingene med for eksemp
 | Verdi                 | Beskrivelse                                                                                                                            | Ekstra                                                                               |
 |-----------------------|--------------------------------------------------------------------------------------------------------------------------------------- |--------------------------------------------------------------------------------------|
 | \$sendersName\$       | Blir byttet ut med avsenders navn. Enten "MessageSender" om attributten har en verdi, eller basert på ett oppslag i Altinn Register.   | Støttes for alle scenarioer                                                          |
-| \$recipientName\$     | Blir byttet ut med mottakers navn. Dette vil være enten organisasjonsnavn eller personens navn.                                        | Støttes ikke dersom varsel blir sendt direkte til e-post adresse eller telefonnummer |
+| \$recipientName\$     | Blir byttet ut med mottakers navn. Dette vil være enten organisasjonsnavn eller personens navn.                                        | Støttes for alle scenarioer                                                          |
 | \$recipientNumber\$   | Dersom mottaker er en organisasjon vises Organisasjonsnummer. Dersom mottaker er en privatperson vises ingenting                       | Støttes ikke dersom varsel blir sendt direkte til e-post adresse eller telefonnummer |
 
 ## Varslingsmaler


### PR DESCRIPTION
This PR changes information for keyword support on the notification page for corrospondence. The keyword $recipientName$ is now supported for all scenarioes. Both the english and norwiegan page have been updated.

