### PR TITLE
Fixed error in accesslist scopes

### DIFF
--- a/content/authorization/guides/manage-accesslist-api/_index.nb.md
+++ b/content/authorization/guides/manage-accesslist-api/_index.nb.md
@@ -16,9 +16,11 @@ I Altinn 3 håndteres denne funksjonaliteten av Ressursrettighetsregisteret (RRR
 
 Klienten må være definert i Maskinporten med følgende scopes:
 
-- `altinn:resourceregistry/access-list.read`
-- `altinn:resourceregistry/access-list.write`
+- `altinn:resourceregistry/accesslist.read`
+- `altinn:resourceregistry/accesslist.write`
 - `altinn:resourceregistry/resource.write`
+
+For å få tilgang til scopene i Samarbeidsportalen må det bestilles tilgang til scopene. Dette gjøres ved å ta kontakt per e-post på tjenesteeier@altinn.no
 
 [Full swagger-dokumentasjon](https://docs.altinn.studio/api/resourceregistry/spec/#/)
 


### PR DESCRIPTION
Removed '-' in from scopes in documentation which does not match the actual scopes in Samarbeidsportalen.
Also added sentence informing about access to scopes require email to servicedesk