### PR TITLE
docs: remove depricated steps in copy app guide

### DIFF
--- a/content/altinn-studio/guides/development/copy-app/_index.en.md
+++ b/content/altinn-studio/guides/development/copy-app/_index.en.md
@@ -22,11 +22,4 @@ If you don't have permissions you should talk to your organizations administrato
     _The name can not be changed after the application has been published._
 4. Create the copy by clicking "**Kopier app**".
 5. When the application has been copied you will be redirected to the copied app.
-6. In order for the copied app to work there is some changes in the source code. These changes has automatically been added as a pull request against your repository. To navigate to the repo click the profile-icon in the top right corner and choose "**Åpne repository**" ![Open repository](open-repository.png "Open repository")
-7. Navigate to the tab "**Pull requests**" and the that the changes under the pull request named "Auto-generated: Final changes for cloning app.". ![Pull request](pull-request-summary.png "Pull-request-summary")
-8. Look through the pull request and make sure that the changes matches the new name of your application.
-9. If everything is in order the pull request can be merged by clicking "**Merge pull request**".
-10. The final step needed is to ensure that all changes are reflected in your user account in Studio. Navigate to the tab with your new app and click on the hamburger menu to the right of "Share your changes." Select "Local changes" from the menu.
-11. Click "Delete local changes" at the bottom of the dialog that appears.
-12. Enter the name of the app to confirm, and click the "Delete my changes" button. Wait for the dialog to disappear and for a confirmation that the deletion was successful.
-13. Voila! You are now ready to develop on the copied app.
+6. Voila! You are now ready to develop on the copied app.

--- a/content/altinn-studio/guides/development/copy-app/_index.nb.md
+++ b/content/altinn-studio/guides/development/copy-app/_index.nb.md
@@ -21,12 +21,4 @@ Dersom du mangler skrivetilgang må du ta kontakt med personen som har administr
     _Navnet kan **ikke** endres etter at appen er publisert._
 4. Opprett kopien ved å klikke "**Lag kopi**".
 5. Når applikasjonen har blitt kopiert vil du bli sendt til din nye applikasjon.
-6. For at den kopierte applikasjonen skal være klar til å brukes trengs det en liten endring i koden. Denne endringen har automatisk blitt lagt inn som en pull request mot repositoriet ditt. For å navigere til repo klikk på profil-ikonet i høyre hjørne og velg "Åpne repository". ![Åpne repository](open-repository.png "Åpne repository")
-7. Naviger så til fanen "**Pull requests**" og se at det ligger klar en pull request med navnet "Auto-generated: Final changes for cloning app.". ![Pull request visning](pull-request-summary.png "Pull-request-summary")
-
-8. Klikk deg inn på denne og se over at endringene stemmer overens med det nye navnet på applikasjonen din.
-9. Om alt ser greit ut så kan endringen merges ved å klikke på "**Merge pull request**".
-10. Siste steget som trengs er nå å sikre at alle endringene kommer inn til din bruker i Studio. Naviger til fanen med den ny appen din og klikk på hamburger-menyen til høyre for "Del dine endringer". Velg "Lokale endringer" fra menyen.
-11. Klikk på "Slett lokale endringer" nederst på dialogen som dukker opp.
-12. Fyll ut navnet på app'en for å bekrefte, og klikk på knappen "Slett mine endringer". Vent til dialogen forsvinner og du får en bekreftelse på at slettingen gikk ok.
-13. Voila! Du er nå klar til å utvikle på den kopierte appen.
+6. Voila! Du er nå klar til å utvikle på den kopierte appen.


### PR DESCRIPTION
Removed obsolete steps.
Updates docs for Altinn/altinn-studio#14698