### PR TITLE
Update the URL for TT02 and production

### DIFF
--- a/content/altinn-studio/guides/shared/api/base-urls.md
+++ b/content/altinn-studio/guides/shared/api/base-urls.md
@@ -14,11 +14,11 @@ The following base urls correspond to each environment
 - TT02 (Application owner test environment)
 
   ```http
-  https://platform.tt02.altinn.cloud/{0}/api/v1
+  https://platform.tt02.altinn.no/{0}/api/v1
   ```
 
 - Production
 
   ```http
-   https://platform.altinn.cloud/{0}/api/v1
+   https://platform.altinn.no/{0}/api/v1
   ```


### PR DESCRIPTION
Correct the base URLs for the TT02 and production to use `.no` instead of `.cloud`