### PR TITLE
Use OpenAPI version 3.0.1

### DIFF
--- a/static/swagger/altinn-notifications-v1.json
+++ b/static/swagger/altinn-notifications-v1.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.4",
+  "openapi": "3.0.1",
   "info": {
     "title": "Altinn.Notifications",
     "version": "1.0"


### PR DESCRIPTION
### Description
This pull request is created to revert the OpenAPI version back to 3.0.1 because the version 3.0.4 caused a rendering bug in the production

## Related Issue(s)
- https://github.com/Altinn/altinn-notifications/issues/786
- https://github.com/Altinn/altinn-studio-docs/pull/2103