### PR TITLE
Make a field optional

### DIFF
--- a/static/swagger/altinn-notifications-v1.json
+++ b/static/swagger/altinn-notifications-v1.json
@@ -178,9 +178,6 @@
           },
           "499": {
             "description": "Request terminated - The client disconnected or cancelled the request before the server could complete processing"
-          },
-          "500": {
-            "description": "An unexpected error occurred"
           }
         }
       }
@@ -1562,15 +1559,14 @@
       },
       "SmsSendingOptionsExt": {
         "required": [
-          "body",
-          "sender"
+          "body"
         ],
         "type": "object",
         "properties": {
           "sender": {
-            "minLength": 1,
             "type": "string",
-            "description": "Gets or sets the sender identifier displayed in the recipient's SMS message."
+            "description": "Gets or sets the sender identifier displayed in the recipient's SMS message.",
+            "nullable": true
           },
           "body": {
             "minLength": 1,


### PR DESCRIPTION
### Description
We decided to make the sender field an optional value in regarding to https://github.com/Altinn/altinn-notifications/pull/791 This pull request would update the API specification to reflect this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Refined API response definitions by removing an unexpected error response.
	- Updated the SMS messaging options: the sender information is now optional, while the message body remains required with a clarified description for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->