### PR TITLE
remove duplicate key in swagger for broker

### DIFF
--- a/static/swagger/altinn-broker-v1.json
+++ b/static/swagger/altinn-broker-v1.json
@@ -1093,7 +1093,7 @@
                 "type": "string"
               }
             },
-            "description": "User-defined properties related to the file",
+            "description": "User-defined properties related to the file"
           },
           "checksum": {
             "type": "string",

--- a/static/swagger/altinn-broker-v1.json
+++ b/static/swagger/altinn-broker-v1.json
@@ -1094,7 +1094,6 @@
               }
             },
             "description": "User-defined properties related to the file",
-            "nullable": true
           },
           "checksum": {
             "type": "string",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated API validation: a specific data field now requires a valid object rather than accepting a null value, ensuring improved data consistency and integration reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->