### PR TITLE
add docs for instance owner name expr

### DIFF
--- a/content/altinn-studio/reference/logic/expressions/_index.en.md
+++ b/content/altinn-studio/reference/logic/expressions/_index.en.md
@@ -803,7 +803,7 @@ This function allows retrieving information about the current instance. The foll
 | `instanceId`             | Current instance ID            | `512345/48c31ffc-dcdd-416d-8bc7-194bec3b7bf0`       |
 | `instanceOwnerPartyId`   | Current actor ID               | `512345`                                            |
 | `instanceOwnerPartyType` | Type of actor owning instance  | `"org", "person", "selfIdentified", or "unknown"`   |
-| `instanceOwnerName`      | The nam of the instance owner  | `"Firstname Lastname", "My company AS"`             |
+| `instanceOwnerName`      | The name of the instance owner  | `"Firstname Lastname", "My company AS"`             |
 | `appId`                  | ID of the active app           | `org/app-name`                                      |
 
 All these lookups will return a value of `null` if working in a [stateless context](../../configuration/stateless). 

--- a/content/altinn-studio/reference/logic/expressions/_index.en.md
+++ b/content/altinn-studio/reference/logic/expressions/_index.en.md
@@ -199,8 +199,6 @@ when used in an `if`. Read more about this in the sections on [if](#func-if) and
 
 {{% /expandlarge %}}
 
-### Testing, feilsøking og utvikling av uttrykk 
-
 ### Testing, Debugging, and Developing Expressions  
   
 When writing an expression, it's useful to have an idea of what the result will be and whether the expression is valid. 
@@ -805,6 +803,7 @@ This function allows retrieving information about the current instance. The foll
 | `instanceId`             | Current instance ID            | `512345/48c31ffc-dcdd-416d-8bc7-194bec3b7bf0`       |
 | `instanceOwnerPartyId`   | Current actor ID               | `512345`                                            |
 | `instanceOwnerPartyType` | Type of actor owning instance  | `"org", "person", "selfIdentified", or "unknown"`   |
+| `instanceOwnerName`      | The nam of the instance owner  | `"Firstname Lastname", "My company AS"`             |
 | `appId`                  | ID of the active app           | `org/app-name`                                      |
 
 All these lookups will return a value of `null` if working in a [stateless context](../../configuration/stateless). 

--- a/content/altinn-studio/reference/logic/expressions/_index.en.md
+++ b/content/altinn-studio/reference/logic/expressions/_index.en.md
@@ -803,7 +803,7 @@ This function allows retrieving information about the current instance. The foll
 | `instanceId`             | Current instance ID            | `512345/48c31ffc-dcdd-416d-8bc7-194bec3b7bf0`       |
 | `instanceOwnerPartyId`   | Current actor ID               | `512345`                                            |
 | `instanceOwnerPartyType` | Type of actor owning instance  | `"org", "person", "selfIdentified", or "unknown"`   |
-| `instanceOwnerName`      | The name of the instance owner  | `"Firstname Lastname", "My company AS"`             |
+| `instanceOwnerName`      | The name of the instance owner | `"Firstname Lastname", "My company AS"`             |
 | `appId`                  | ID of the active app           | `org/app-name`                                      |
 
 All these lookups will return a value of `null` if working in a [stateless context](../../configuration/stateless). 

--- a/content/altinn-studio/reference/logic/expressions/_index.nb.md
+++ b/content/altinn-studio/reference/logic/expressions/_index.nb.md
@@ -799,6 +799,7 @@ argument:
 | `instanceId`             | Gjeldende instans-ID           | `512345/48c31ffc-dcdd-416d-8bc7-194bec3b7bf0`       |
 | `instanceOwnerPartyId`   | Gjeldende aktør-ID             | `512345`                                            |
 | `instanceOwnerPartyType` | Hva slags aktør eier instansen | `"org", "person", "selfIdentified" eller "unknown"` |
+| `instanceOwnerName`      | Navnet på instanse-eier        | `"Fornavn Etternavn", "Mitt Selskap AS"`            |
 | `appId`                  | Den aktive appen sin ID        | `org/app-name`                                      |
 
 Alle disse oppslagene vil gi verdien `null` om man jobber i en [tiltandsløs kontekst](../../configuration/stateless).

--- a/content/altinn-studio/reference/logic/expressions/_index.nb.md
+++ b/content/altinn-studio/reference/logic/expressions/_index.nb.md
@@ -799,7 +799,7 @@ argument:
 | `instanceId`             | Gjeldende instans-ID           | `512345/48c31ffc-dcdd-416d-8bc7-194bec3b7bf0`       |
 | `instanceOwnerPartyId`   | Gjeldende aktør-ID             | `512345`                                            |
 | `instanceOwnerPartyType` | Hva slags aktør eier instansen | `"org", "person", "selfIdentified" eller "unknown"` |
-| `instanceOwnerName`      | Navnet på instanse-eier        | `"Fornavn Etternavn", "Mitt Selskap AS"`            |
+| `instanceOwnerName`      | Navnet på instans-eier        | `"Fornavn Etternavn", "Mitt Selskap AS"`            |
 | `appId`                  | Den aktive appen sin ID        | `org/app-name`                                      |
 
 Alle disse oppslagene vil gi verdien `null` om man jobber i en [tiltandsløs kontekst](../../configuration/stateless).

--- a/content/altinn-studio/reference/logic/expressions/_index.nb.md
+++ b/content/altinn-studio/reference/logic/expressions/_index.nb.md
@@ -799,7 +799,7 @@ argument:
 | `instanceId`             | Gjeldende instans-ID           | `512345/48c31ffc-dcdd-416d-8bc7-194bec3b7bf0`       |
 | `instanceOwnerPartyId`   | Gjeldende aktør-ID             | `512345`                                            |
 | `instanceOwnerPartyType` | Hva slags aktør eier instansen | `"org", "person", "selfIdentified" eller "unknown"` |
-| `instanceOwnerName`      | Navnet på instans-eier        | `"Fornavn Etternavn", "Mitt Selskap AS"`            |
+| `instanceOwnerName`      | Navnet på instans-eier         | `"Fornavn Etternavn", "Mitt Selskap AS"`            |
 | `appId`                  | Den aktive appen sin ID        | `org/app-name`                                      |
 
 Alle disse oppslagene vil gi verdien `null` om man jobber i en [tiltandsløs kontekst](../../configuration/stateless).

--- a/content/altinn-studio/reference/ux/texts/_index.en.md
+++ b/content/altinn-studio/reference/ux/texts/_index.en.md
@@ -205,7 +205,8 @@ It is currently possible to fetch values from 3 different data sources.
    By defining `instanceContext` as the data source you will be able to access certain properties from the active instance. The properties that are currently available are:
    1. `instanceOwnerPartyId` contains the party ID of the instance owner.
    2. `instanceId` contains the ID of the active instance.
-   3. `appId` contains the ID of the application, which the active instance belongs to.
+   3. `instanceOwnerName` contains the name of the instance owner.
+   4. `appId` contains the ID of the application, which the active instance belongs to.
    
 ### Default value
 

--- a/content/altinn-studio/reference/ux/texts/_index.nb.md
+++ b/content/altinn-studio/reference/ux/texts/_index.nb.md
@@ -200,7 +200,8 @@ Det er per nå mulig å hente verdier fra 3 ulike datakilder.
    Ved å angi `instanceContext` som datakilde kan man hente ut enkelte verdier fra den aktive instansen. Vi har altså ikke gitt tilgang til hele instans objektet. Listen med egenskaper så langt er:
    1. `instanceOwnerPartyId` inneholder avgiver sin party id.
    2. `instanceId` inneholder id'en til den aktive instansen.
-   3. `appId` inneholder id'en til appen instansen er knyttet til.
+   3. `instanceOwnerName` inneholder navnet til instanse-eieren.
+   4. `appId` inneholder id'en til appen instansen er knyttet til.
     
 ### Standardverdi
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced instance details by introducing a new field, `instanceOwnerName`, that displays the instance owner's name.
  - Updated the list of instance properties to replace `appId` with `instanceOwnerName` for improved clarity across supported languages.
  - Removed an outdated section on testing and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->