### PR TITLE
When to use notificaton

### DIFF
--- a/content/authentication/guides/systemauthentication-for-apiproviders/_index.nb.md
+++ b/content/authentication/guides/systemauthentication-for-apiproviders/_index.nb.md
@@ -6,10 +6,6 @@ toc: false
 weight: 1
 ---
 
-{{<notice warning>}}
- Denne funksjonaliteten er i test og kan endres
-{{</notice>}}
-
 ## Bakgrunn
 
 Bakgrunnen til systembruker konsept kan leses om [her](../../what-do-you-get/systemuser/).
@@ -23,6 +19,11 @@ For å kunne bruke systembruker som API-leverandør må følgende forutsetninger
 - Opprettelse av [nødvendige ressurser](/authorization/guides/create-resource-resource-admin/) som skal autoriseres
 - Tildelt scope for PDP-integrasjon
 - Integrasjon med Altinn PDP
+
+{{<notice warning>}}
+Systembruker er kun egnet for tilfeller der det ikke er behov for at Altinn kan koble operasjonene som utføres med hvilken person som utfører dem.
+Som tjenesteier må du gjøre en vurdering om det er behov for å knytte person til utført handling. Dersom dette er behov må tjensten benytte ID-porten.
+{{</notice>}}
 
 ## Validering av Maskinporten token
 

--- a/content/authentication/what-do-you-get/systemuser/_index.nb.md
+++ b/content/authentication/what-do-you-get/systemuser/_index.nb.md
@@ -16,6 +16,8 @@ Systembruker bygger videre på Maskinporten, som gir sikker autentisering og gro
 Systembruker gjør det enkelt å sette opp en virtuell bruker som kan opperere på vegne av virksomehten, endten som egenoppreret system eller i et kunde - leverandørforhold 
 Systembruker både brukes mot tjenster som kjører i Altinn og mot eksterne tjenester som bruker Altinn Autorisasjon som autorisasjonsløsning.
 
+> Systembruker bør kun brukes i tilfeller der det ikke er behov for at Altinn kan koble operasjonene som utføres med hvilken person som utfører dem.
+
 For en overordnet funsjonell gjennomgang og brukerreise se [Samarbeidsportalen](https://samarbeid.digdir.no/altinn/systembruker/2542).
 
 ## Begrep


### PR DESCRIPTION

Added notification about consideration to take when using systembruker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated warning and clarification notices regarding the use of system users, emphasizing that this approach is only appropriate when there is no need to link actions to specific individuals. Service owners are advised to consider whether personal attribution is required and to use alternative authentication methods if necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->