### PR TITLE
Update tag name

### DIFF
--- a/static/swagger/altinn-notifications-v1.json
+++ b/static/swagger/altinn-notifications-v1.json
@@ -115,7 +115,7 @@
     "/future/orders": {
       "post": {
         "tags": [
-          "FutureOrders"
+          "Orders"
         ],
         "summary": "Creates a new notification order that has non or more reminders.",
         "description": "The API will accept the request after some basic validation of the request.\r\nThe system will also attempt to verify that it will be possible to fulfill the order.",
@@ -475,7 +475,7 @@
     "/future/shipment/{id}": {
       "get": {
         "tags": [
-          "Shipment"
+          "Orders"
         ],
         "summary": "Retrieve the delivery manifest for a specific notification order.",
         "parameters": [


### PR DESCRIPTION
## Description
The release pipeline I used to release the APIM template for the Notifications API failed because it contains new tags. Instead of introducing new tags, I decided to use the existing tag named 'Orders'.