### PR TITLE
Add access package Tinglysning eiendom

### DIFF
--- a/content/authorization/architecture/resourceregistry/accesspackages_hier.json
+++ b/content/authorization/architecture/resourceregistry/accesspackages_hier.json
@@ -652,6 +652,16 @@
                         "isAssignable": false,
                         "area": null,
                         "resources": null
+                    },
+                    {
+                        "id": "0195efb8-7c80-7642-b9b8-c748ee4fecd4",
+                        "name": "Tinglysing eiendom",
+                        "urn": "urn:altinn:accesspackage:tinglysing-eiendom",
+                        "description": "Denne tilgangspakken gir fullmakter til tjenester knyttet til elektronisk tinglysing av rettigheter i eiendom.",
+                        "isDelegable": true,
+                        "isAssignable": false,
+                        "area": null,
+                        "resources": null
                     }
                 ]
             },
@@ -944,9 +954,9 @@
             },
             {
                 "id": "6e152c10-0f63-4060-9b14-66808e7ac320",
-                "name": "Energi, vann,avløp og avfall",
+                "name": "Energi, vann, avløp og avfall",
                 "urn": "accesspackage:area:energi_vann_avlop_og_avfall",
-                "description": "Dette fullmaktsområdet omfatter tilgangspakker knyttet til energi, vann,avløp og avfall.",
+                "description": "Dette fullmaktsområdet omfatter tilgangspakker knyttet til energi, vann, avløp og avfall.",
                 "icon": "https://altinncdn.no/authorization/accesspackageicons/Aksel_Workplace_TapWater.svg",
                 "packages": [
                     {
@@ -1366,7 +1376,7 @@
                         "id": "2f176732-b1e9-449b-9918-090d1fa986f6",
                         "name": "Ansvarlig revisor",
                         "urn": "urn:altinn:accesspackage:ansvarlig-revisor",
-                        "description": "Denne fullmakten gir revisor tilgang til å opptre som ansvarlig revisor for en kunde og utføre alle tjenester som krever denne fullmakten. Dette er tjenester som tjenestetilbyder har vurdert det som naturlig at en revisor utfører på vegne av sin kunde. Fullmakten gis kun til autoriserte revisorer. Fullmakt hos revisor oppstår når kunden registrerer regnskapsfører i Enhetsregisteret. Ved regelverksendringer eller innføring av nye digitale tjenester kan det bli endringer i tilganger som fullmakten gir.",
+                        "description": "Denne fullmakten gir revisor tilgang til å opptre som ansvarlig revisor for en kunde og utføre alle tjenester som krever denne fullmakten. Dette er tjenester som tjenestetilbyder har vurdert det som naturlig at en revisor utfører på vegne av sin kunde. Fullmakten gis kun til autoriserte revisorer. Fullmakt hos revisor oppstår når kunden registrerer revisor i Enhetsregisteret. Ved regelverksendringer eller innføring av nye digitale tjenester kan det bli endringer i tilganger som fullmakten gir.",
                         "isDelegable": true,
                         "isAssignable": false,
                         "area": null,
@@ -1376,7 +1386,7 @@
                         "id": "96120c32-389d-46eb-8212-0a6540540c25",
                         "name": "Revisormedarbeider",
                         "urn": "urn:altinn:accesspackage:revisormedarbeider",
-                        "description": "Denne fullmakten gir revisor tilgang til å opptre som revisormedarbeider for en kunde og utføre alle tjenester som krever denne fullmakten. Dette er tjenester som tjenestetilbyder har vurdert det som naturlig at en revisor utfører på vegne av sin kunde. Fullmakten gis kun til autoriserte revisorer. Fullmakt hos revisor oppstår når kunden registrerer regnskapsfører i Enhetsregisteret. Ved regelverksendringer eller innføring av nye digitale tjenester kan det bli endringer i tilganger som fullmakten gir.",
+                        "description": "Denne fullmakten gir revisor tilgang til å opptre som revisormedarbeider for en kunde og utføre alle tjenester som krever denne fullmakten. Dette er tjenester som tjenestetilbyder har vurdert det som naturlig at en revisor utfører på vegne av sin kunde. Fullmakten gis kun til autoriserte revisorer. Fullmakt hos revisor oppstår når kunden registrerer revisor i Enhetsregisteret. Ved regelverksendringer eller innføring av nye digitale tjenester kan det bli endringer i tilganger som fullmakten gir.",
                         "isDelegable": true,
                         "isAssignable": false,
                         "area": null,


### PR DESCRIPTION
access packages copied from https://platform.tt02.altinn.no/accessmanagement/api/v1/meta/info/accesspackages/export at 07.05.25 08.35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new access package for electronic registration of property rights under the "Bygg, anlegg og eiendom" area.

- **Bug Fixes**
  - Corrected area name and description formatting for "Energi, vann, avløp og avfall" by adding missing spaces.
  - Updated descriptions in the "Fullmakter for revisor" area to accurately reference "revisor" instead of "regnskapsfører".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->