### PR TITLE
New note to correspondence get started

### DIFF
--- a/content/correspondence/getting-started/developer-guides/serviceowner/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/serviceowner/_index.en.md
@@ -54,6 +54,8 @@ Use Samarbeidsportalen self-service for registration. [Here's a detailed guide](
 - [Test environments](https://sjolvbetjening.test.samarbeid.digdir.no/)
 - [Production environment](https://sjolvbetjening.samarbeid.digdir.no/)
 
+**Note**: The resource policy on your resource must have assigned the required scopes to the organisation that your Maskinporten client(s) is registered on.
+
 ### 5. Authentication {#authentication}
 
 For all operations, you will need to authenticate using your Maskinporten Client, then [acquire an Altinn Token from Altinn Authentication](https://docs.altinn.studio/authentication/reference/architecture/accesstoken/).

--- a/content/correspondence/getting-started/developer-guides/serviceowner/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/serviceowner/_index.nb.md
@@ -53,6 +53,8 @@ Bruk Samarbeidsportalen for selvbetjent registrering. Følg den detaljerte guide
 - [Testmiljøer](https://sjolvbetjening.test.samarbeid.digdir.no/)
 - [Produksjonsmiljø](https://sjolvbetjening.samarbeid.digdir.no/)
 
+**Merk**: Ressurspolicyen på ressursen din må ha tildelt de nødvendige scopene til organisasjonen som Maskinporten-klienten(e) din er registrert på.
+
 ### 5. Integrer mot meldings-APIet {#integrate-against-correspondence-api}
 Siden Altinn Melding er åpen kildekode har du tilgang til koden vår i [vårt offentlige GitHub-repo](https://github.com/Altinn/altinn-correspondence) og bygge en lokal Docker-instans for å teste mot.
 


### PR DESCRIPTION
Added a new note to Getting started service owner. The note mentions that the resource policy on your resource must have assigned the required scopes to the organisation that your Maskinporten client(s) is registered on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added clarifying notes about the requirement for resource policies to assign necessary scopes to the organization associated with Maskinporten clients in both English and Norwegian guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->