### PR TITLE
Document that you should set app owned on payment information data type.

### DIFF
--- a/content/altinn-studio/guides/development/payment/backend-manual/add-process-task.en.md
+++ b/content/altinn-studio/guides/development/payment/backend-manual/add-process-task.en.md
@@ -17,7 +17,7 @@ This data type is used to store information and status about the payment. Put it
     "allowedContentTypes": [
       "application/json"
     ],
-    "allowedContributers": [
+    "allowedContributors": [
       "app:owned"
     ],
     "maxCount": 1,
@@ -33,12 +33,17 @@ This data type is used to store the PDF-receipt for the payment. Configure it ne
     "allowedContentTypes": [
         "application/pdf"
     ],
+    "allowedContributors": [
+      "app:owned"
+    ],
     "maxCount": 1,
     "minCount": 0,
 }
 ```
 
- The IDs can be set to something else, but they must match the IDs entered in `paymentDataType` and `paymentReceiptPdfDataType` in the process step, as shown in step 2.
+It is important to set `allowedContributors` to `"app:owned"`. This ensures that these data items cannot be edited via the app’s API but only by the app itself. Before version 8.6, this was misspelled `allowedContributers`.
+
+The IDs can be set to something else, but they must match the IDs entered in `paymentDataType` and `paymentReceiptPdfDataType` in the process step, as shown in step 2.
 
 ### Extend the app process with payment task:
 

--- a/content/altinn-studio/guides/development/payment/backend-manual/add-process-task.en.md
+++ b/content/altinn-studio/guides/development/payment/backend-manual/add-process-task.en.md
@@ -15,7 +15,10 @@ This data type is used to store information and status about the payment. Put it
 {
     "id": "paymentInformation",
     "allowedContentTypes": [
-        "application/json"
+      "application/json"
+    ],
+    "allowedContributers": [
+      "app:owned"
     ],
     "maxCount": 1,
     "minCount": 0,

--- a/content/altinn-studio/guides/development/payment/backend-manual/add-process-task.nb.md
+++ b/content/altinn-studio/guides/development/payment/backend-manual/add-process-task.nb.md
@@ -15,7 +15,7 @@ Den første datatypen benyttes av betalingssteget for å lagre informasjon og st
     "allowedContentTypes": [
       "application/json"
     ],
-    "allowedContributers": [
+    "allowedContributors": [
       "app:owned"
     ],
     "maxCount": 1,
@@ -31,10 +31,15 @@ Den andre datatypen benyttes for å lagre PDF-kvittering for betalingen. Legg de
     "allowedContentTypes": [
         "application/pdf"
     ],
+    "allowedContributors": [
+      "app:owned"
+    ],
     "maxCount": 1,
     "minCount": 0,
 }
 ```
+
+Det er viktig å sette `allowedContributors` til ```"app:owned"```. Det gjør at disse dataene ikke kan redigeres via appens API, men kun av appen selv. Før versjon 8.6 var denne konfigurasjonen feilstavet `allowedContributers`.
 
 ID-ene kan settes til noe annet, men det må matche ID-ene som legges inn i `paymentDataType` og `paymentReceiptPdfDataType` i prossessteget, som vist i punktet under.
 

--- a/content/altinn-studio/guides/development/payment/backend-manual/add-process-task.nb.md
+++ b/content/altinn-studio/guides/development/payment/backend-manual/add-process-task.nb.md
@@ -13,7 +13,10 @@ Den første datatypen benyttes av betalingssteget for å lagre informasjon og st
 {
     "id": "paymentInformation",
     "allowedContentTypes": [
-        "application/json"
+      "application/json"
+    ],
+    "allowedContributers": [
+      "app:owned"
     ],
     "maxCount": 1,
     "minCount": 0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated English and Norwegian guides to explain the new allowedContributors property restricting edits to the app for payment data types.
  - Clarified the property's correct spelling and usage since version 8.6.
  - Improved formatting for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->