### PR TITLE
Fix outdated storage instances response

### DIFF
--- a/content/api/storage/instances/_index.en.md
+++ b/content/api/storage/instances/_index.en.md
@@ -107,19 +107,18 @@ They can be combined to define a range:
 dueBefore=gt:2019-02&dueBefore=lt:2019-03-01
 ```
 
-The query returns a result object (page) which includes a collection of instances that matched the query. 100 instances is returned by default. Use *size* to get more or less instances per page. To get to the next page you have to use the *continuationToken* present in the *next* link.
-
-The instances endpoint returns a query result object with information about how many total hits *totalHits* that the query matched and how many objects returned *count*. 
+The query returns a result object (page) which includes a collection of instances that matched the query.
+100 instances is returned by default. Use *size* to get more or fewer instances per page. 
+To get to the next page you have to use the *continuationToken* present in the *next* link.
 
 The endpoint supports *application/json*.
 
 ```json
 Accept: application/json
 {
-    "totalHits": 234,
     "count": 50,
     "self": "{storagePath}/instances?appId=org/app&size=50",
-    "next": "{storagePath}/instances?appId=org/app&size=50&continuationToken=%257b%2522token%2522%253a%2522%252bRID%..."
+    "next": "{storagePath}/instances?appId=org/app&size=50&continuationToken=%257b%2522token%2522%253a%2522%252bRID%...",
     "instances": [
             {...},
             {...},

--- a/content/api/storage/instances/_index.en.md
+++ b/content/api/storage/instances/_index.en.md
@@ -108,10 +108,8 @@ dueBefore=gt:2019-02&dueBefore=lt:2019-03-01
 ```
 
 The query returns a result object (page) which includes a collection of instances that matched the query.
-100 instances is returned by default. Use *size* to get more or fewer instances per page. 
+100 instances are returned by default. Use *size* to get more or fewer instances per page. 
 To get to the next page you have to use the *continuationToken* present in the *next* link.
-
-The endpoint supports *application/json*.
 
 ```json
 Accept: application/json

--- a/content/api/storage/instances/_index.nb.md
+++ b/content/api/storage/instances/_index.nb.md
@@ -111,17 +111,16 @@ Operatorene kan kombineres for å lage et intervall:
 dueBefore=gt:2019-02&dueBefore=lt:2019-03-01
 ```
 
-Spørringen returerer et resultatobjekt med en samling av instanser som oppfyller kriteriene for spørringen. Størrelsen er som standard *100* instanser, men man kan bruke *size*-parameteret for å endre antall treff per side. 
-For å hente neste site, bruk tokenet under _next_ i resultatobjektet. 
-Resultatobjektet inneholder informasjon om antall resultater som traff kriteriene totalt *totalHits*, og hvor mange som ble returnert *count*.
+Spørringen returerer et resultatobjekt med en samling av instanser som oppfyller kriteriene for spørringen. 
+Størrelsen er som standard 100 instanser, men man kan bruke *size*-parameteret for å endre antall treff per side. 
+For å hente neste side, bruk *continuationToken* under *next* i resultatobjektet. 
 
 ```json
 Accept: application/json
 {
-    "totalHits": 234,
     "count": 50,
     "self": "{storagePath}/instances?appId=org/app&size=50",
-    "next": "{storagePath}/instances?appId=org/app&size=50&continuationToken=%257b%2522token%2522%253a%2522%252bRID%..."
+    "next": "{storagePath}/instances?appId=org/app&size=50&continuationToken=%257b%2522token%2522%253a%2522%252bRID%...",
     "instances": [
             {...},
             {...},

--- a/content/api/storage/instances/_index.nb.md
+++ b/content/api/storage/instances/_index.nb.md
@@ -111,7 +111,7 @@ Operatorene kan kombineres for å lage et intervall:
 dueBefore=gt:2019-02&dueBefore=lt:2019-03-01
 ```
 
-Spørringen returerer et resultatobjekt med en samling av instanser som oppfyller kriteriene for spørringen. 
+Spørringen returnerer et resultatobjekt med en samling av instanser som oppfyller kriteriene for spørringen. 
 Størrelsen er som standard 100 instanser, men man kan bruke *size*-parameteret for å endre antall treff per side. 
 For å hente neste side, bruk *continuationToken* under *next* i resultatobjektet. 
 


### PR DESCRIPTION
Better late than never https://github.com/Altinn/altinn-studio/pull/5580

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified and streamlined the description of the query result object for the instances endpoint.
  - Removed references to the totalHits field from both the documentation text and example JSON response.
  - Improved instructions for pagination, specifying the use of the continuationToken in the next link.
  - Updated example JSON formatting for consistency and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->