### PR TITLE
Maskinporten, spesifisering og lenke

### DIFF
--- a/content/correspondence/getting-started/developer-guides/serviceowner/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/serviceowner/_index.nb.md
@@ -56,12 +56,10 @@ https://docs.altinn.studio/nb/api/authentication/digdirscopes/
 For å autentisere mot meldings-API-et, må du registrere Maskinporten-klienten(e) din med nødvendige scopes for om du skal sende og/eller motta meldinger:
 Scopene vedlikeholdes av Altinn og må være autorisert for de riktige API-operasjonene, og er derfor uavhengige av tilgangen satt av tjenesteeiere i steg 2 for den spesifikke meldingstjenesten.
 
-Bruk Samarbeidsportalen for selvbetjent registrering. Følg den detaljerte guiden som er tilgjengelig der. [Her er en detaljert guide](https://docs.digdir.no/docs/Maskinporten/maskinporten_sjolvbetjening_web#innlogging-og-tilgang).
+Samarbeidsportalen benyttes for selvbetjent registrering. Tjenesteeiere som ikke har signert bruksvilkår for Maskinporten må gjøre dette før de kan ta løsningen i bruk. Følg den detaljerte guiden som er tilgjengelig [her](https://docs.digdir.no/docs/Maskinporten/maskinporten_sjolvbetjening_web#innlogging-og-tilgang).
 
 - [Testmiljøer](https://sjolvbetjening.test.samarbeid.digdir.no/)
 - [Produksjonsmiljø](https://sjolvbetjening.samarbeid.digdir.no/)
-
-En guide for hvordan man sette opp en maskinporten klient i selvbetjeningsportalen
 
 **Merk**: Ressurspolicyen på ressursen din må ha tildelt de nødvendige scopene til organisasjonen som Maskinporten-klienten(e) din er registrert på.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified instructions for registering Maskinporten clients, emphasizing the use of Samarbeidsportalen for self-service registration.
  - Added a requirement for service owners to sign the Maskinporten terms of use before accessing the solution.
  - Improved formatting and removed redundant information for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->