### PR TITLE
Broker/removed-notice-warning

### DIFF
--- a/content/broker/getting-started/developer-guides/events/_index.en.md
+++ b/content/broker/getting-started/developer-guides/events/_index.en.md
@@ -9,11 +9,6 @@ weight: 40
 
 {{<children />}}
 
-{{% notice warning  %}}
-Currently the Events for Broker are not ready for full-scale use, due to pending changes in Altinn Events and Authorization.
-This documents the expected scenario, but may be subject to change.
-{{% /notice %}}
-
 In order to use events/webhooks for a Broker resource, you need to setup a subscription for the given resource.
 This subscription is used to configure the endpoint where the events published by broker end up. [You can read more about how to setup an Events subscription in Altinn Events here](/events/subscribe-to-events/developer-guides/setup-subscription/).
 

--- a/content/broker/getting-started/developer-guides/events/_index.nb.md
+++ b/content/broker/getting-started/developer-guides/events/_index.nb.md
@@ -9,11 +9,6 @@ weight: 40
 
 {{<children />}}
 
-{{% notice warning  %}}
-For øyeblikket er hendelsene for Formidling ikke klare for fullskala bruk, på grunn av kommende endringer i Altinn Events og Autorisasjon.
-Dette dokumenterer det forventede scenarioet, men kan endres.
-{{% /notice %}}
-
 For å bruke hendelser/webhooks for en formidlingstjeneste, må du sette opp et abonnement for den gitte ressursen.
 Dette abonnementet brukes til å konfigurere endepunktet der hendelsene som publiseres av megleren havner. [Du kan lese mer om hvordan du setter opp et hendelsesabonnement i Altinn Events her](/events/subscribe-to-events/developer-guides/setup-subscription/).
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the warning notice about the readiness of Events for Broker/Formidling in both English and Norwegian guides. All setup instructions and event details remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->