### PR TITLE
Removed documentation on APIM key as no longer needed

### DIFF
--- a/content/broker/getting-started/common-steps/_index.en.md
+++ b/content/broker/getting-started/common-steps/_index.en.md
@@ -11,13 +11,7 @@ weight: 10
 
 These are common steps that all roles (Service Owner, Senders and Recipients) need to complete in order to start using the Altinn Broker component.
 
-## 1. Get an Altinn API Key {#get-an-altinn-api-key}
-
-In order to use any Altinn APIs, you need a subscription key for the APIs. This is passed as the header `Ocp-Apim-Subscription-Key` in every request.
-
-If you do not already possess an API Key for the Maskinporten Client(s) you intend to use against Broker, you can get it by contacting us at [Altinn@Slack#produkt-formidling](https://join.slack.com/t/altinn/shared_invite/zt-7c77c9si-ZnMFwGNtab1aFdC6H_vwog).
-
-## 2. Register your Maskinporten Client with correct scopes {#register-your-maskinporten-client-with-correct-scopes}
+## 1. Get access to scopes {#get-access-to-scopes}
 
 Register your Maskinporten client(s) to authenticate with the Broker API, assigning them relevant scopes:
 
@@ -25,6 +19,12 @@ Register your Maskinporten client(s) to authenticate with the Broker API, assign
 - `altinn:broker.read` - For clients receiving files.
 
 These scopes are maintained by Altinn and are required to be authorized for the appropriate API operations, and as such are independent of the [access set by Service Owners](../service-owner#register-a-resource-in-altinn-resource-registry) for the specific Broker Service Resource.
+
+To obtain access to scopes, you must submit a request to: [servicedesk@altinn.no](mailto:servicedesk@altinn.no).
+Please include all necessary scopes in your request. For example, beyond `altinn:broker`-scopes, your integration may require additional scopes. 
+You can find the complete list of available scopes here: [Complete list of scopes](https://docs.altinn.studio/api/authentication/digdirscopes/)
+
+## 2. Register your Maskinporten Client with correct scopes {#register-your-maskinporten-client-with-correct-scopes}
 
 Use Samarbeidsportalen self-service for registration. [Here's a detailed guide](https://docs.digdir.no/docs/Maskinporten/maskinporten_sjolvbetjening_web#selvbetjening-som-api-konsument).
 

--- a/content/broker/getting-started/common-steps/_index.nb.md
+++ b/content/broker/getting-started/common-steps/_index.nb.md
@@ -11,11 +11,7 @@ weight: 10
 
 Før du går i gang med spesifikke oppgaver som avsender, mottaker, eller tjenesteeier i Altinn Formidling, er det noen grunnleggende forberedelser og krav som gjelder for alle brukere. Denne seksjonen dekker de nødvendige stegene du må gjennomføre for å sikre en smidig og effektiv oppstart. Her vil du finne veiledning om generelle systemkrav, påloggingsprosedyrer, og grunnleggende oppsett som må være på plass før du kan begynne å bruke tjenesten fullt ut. Det er viktig at alle brukere følger disse instruksjonene nøye for å unngå problemer senere i prosessen.
 
-## 1. Skaff deg en Altinn API-nøkkel {#get-an-altinn-api-key}
-
-Først må du skaffe en abonnementsnøkkel fra Altinn. Når du sender en forespørsel til API-et, må du inkludere abonnementsnøkkelen i forespørselens `Ocp-Apim-Subscription-Key` header. Inkluderingen av abonnementsnøkkelen i forespørselen er nødvendig for at Altinn skal kunne verifisere at du har rett til å bruke API-et. Uten denne nøkkelen vil forespørselen din bli avvist. Dersom du mangler en API-nøkkel for Maskinporten-klientene du planlegger å bruke mot formidlingstjenesten, ta kontakt med oss på [Altinn@Slack#produkt-formidling](https://join.slack.com/t/altinn/shared_invite/zt-7c77c9si-ZnMFwGNtab1aFdC6H_vwog).
-
-## 2. Registrer Maskinporten-klient med nødvendige scopes. {#register-your-maskinporten-client-with-correct-scopes}
+## 1. Skaff tilgang til scopes {#get-access-to-scopes}
 
 Registreringen av Maskinporten-klient med nødvendige scopes er viktig for å autentisere og sikre at du kan utføre nødvendige operasjoner via formidlings-API-et. Dette trinnet sikrer at kun autoriserte klienter kan sende og motta filer, og opprettholder dermed sikkerheten i tjenesten.
 For å autentisere mot Formidlings-API-et, må du registrere Maskinporten-klienten(e) din med de nødvendige scopene:
@@ -24,6 +20,13 @@ For å autentisere mot Formidlings-API-et, må du registrere Maskinporten-klient
 - `altinn:broker.read` - For klienter som mottar filer.
 
 Disse scopene vedlikeholdes av Altinn og må være autorisert for de riktige API-operasjonene, og er derfor uavhengige av [tilgangen satt av tjenesteeiere](../service-owner#register-a-resource-in-altinn-resource-registry) for den spesifikke formidlingstjenesten.
+
+For å få tilgang til scopes må du sende en forespørsel til: servicedesk@altinn.no 
+Forespørselen må inneholde de scopes du trenger. Vær obs på at du kan trenge flere scopes for integrasjonen din enn bare altinn:broker-scopes. 
+Utfyllende liste over scopes finner du her: 
+https://docs.altinn.studio/nb/api/authentication/digdirscopes/ 
+
+## 2. Registrer Maskinporten-klient med nødvendige scopes. {#register-your-maskinporten-client-with-correct-scopes}
 
 Bruk Samarbeidsportalen for selvbetjent registrering. Følg den detaljerte guiden som er tilgjengelig der. [Her er en detaljert guide](https://docs.digdir.no/docs/Maskinporten/maskinporten_sjolvbetjening_web#selvbetjening-som-api-konsument).
 

--- a/content/correspondence/getting-started/developer-guides/serviceowner/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/serviceowner/_index.en.md
@@ -42,12 +42,11 @@ A user with that access can then delegate the access to the enterprise user / sy
 
 **TIP**: Verify your configurations using the [Postman collection](https://github.com/Altinn/altinn-correspondence/blob/main/altinn-correspondence-postman-collection.json), substituting the test tokens with your own Altinn tokens (See "Login to Maskinporten (Initialize)" request in Authenticator folder).
 
-### 5. Altinn API key and access to scopes {#get-an-altinn-api-key}
-To use Altinn Correspondence, you need a subscription key. Technically, this is an API key that must be included in the header of the request `Ocp-Apim-Subscription-Key`, to verify that you have the right to use the Correspondence API. Without this key, your request will be denied.
+### 5. Access to scopes {#get-access-to-scopes}
 To authenticate and ensure that you can perform operations via the Correspondence API, Altinn must grant you access to the necessary scopes. This ensures that only authorized clients can send and receive files, thereby maintaining the security of the service. The following scopes are used to send and/or receive messages:
 - `altinn:correspondence.write` 
 
-To obtain an Altinn API key and access to scopes, you must submit a request to: [servicedesk@altinn.no](mailto:servicedesk@altinn.no).
+To obtain access to scopes, you must submit a request to: [servicedesk@altinn.no](mailto:servicedesk@altinn.no).
 The request must include the scopes you need. Note that you may require more than just altinn:correspondence.write for your integration. A complete list of scopes can be found here:
 [Complete list of scopes](https://docs.altinn.studio/api/authentication/digdirscopes/)
 

--- a/content/correspondence/getting-started/developer-guides/serviceowner/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/serviceowner/_index.nb.md
@@ -42,12 +42,11 @@ En bruker med denne tilgangen kan deretter delegere tilgangen til virksomhetsbru
 
 **TIPS**: Verifiser konfigurasjonene dine ved hjelp av [Postman-samlingen](https://github.com/Altinn/altinn-correspondence/blob/main/altinn-correspondence-postman-collection.json), og erstatt testtokenene med dine egne Altinn-token. (Se forespørselen "Logg inn i Maskinporten (Initialiser)" i Authenticator-mappen.)
 
-### 5. Skaff Altinn API-nøkkel og tilgang til scopes {#get-an-altinn-api-key}
-For å bruke Altinn Melding må man ha en abonnementsnøkkel. Teknisk sett er dette en API-nøkkel som må inkluderes i forespørselens `Ocp-Apim-Subscription-Key` header for å verifisere at du har rett til å bruke Meldings API-et. Uten denne nøkkelen vil forespørselen din bli avvist.
+### 5. Tilgang til scopes {#get-access-to-scopes}
 For å kunne autentisere og sikre at du kan utføre operasjoner via meldings-APIet, må Altinn gi deg tilgang på de scopes du trenger. Dette sikrer at kun autoriserte klienter kan sende og motta filer, og opprettholder dermed sikkerheten i tjenesten. Følgende scopes brukes for å sende og/eller motta meldinger:
 - `altinn:correspondence.write` 
 
-For å få Altinn API-nøkkel og scopes må du sende en forespørsel til: servicedesk@altinn.no 
+For å få tilgang til scopes må du sende en forespørsel til: servicedesk@altinn.no 
 Forespørselen må inneholde de scopes du trenger. Vær obs på at du kan trenge flere scopes for integrasjonen din enn bare altinn:correspondence.write. 
 Utfyllende liste over scopes finner du her: 
 https://docs.altinn.studio/nb/api/authentication/digdirscopes/ 

--- a/content/correspondence/getting-started/developer-guides/systemprovider/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/systemprovider/_index.en.md
@@ -13,8 +13,7 @@ To get started as a system provider, follow this guide:
 
 [Autentisering for systemleverandører](https://docs.altinn.studio/authentication/guides/systemvendor/)
 
-### Altinn API key and access to scopes {#get-an-altinn-api-key}
-To use Altinn Correspondence, you need a subscription key. Technically, this is an API key that must be included in the header of the request `Ocp-Apim-Subscription-Key`, to verify that you have the right to use the Correspondence API. Without this key, your request will be denied.
+### Access to scopes {#get-access-to-scopes}
 To authenticate and ensure that you can perform operations via the Correspondence API, Altinn must grant you access to the necessary scopes. This ensures that only authorized clients can send and receive files, thereby maintaining the security of the service. The following scopes are used to receive messages:
 - `altinn:correspondence.read`
 

--- a/content/correspondence/getting-started/developer-guides/systemprovider/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/systemprovider/_index.nb.md
@@ -13,8 +13,7 @@ For å komme i gang som systemleverandør følg denne veiledningen:
 
 [Autentisering for systemleverandører](https://docs.altinn.studio/nb/authentication/guides/systemvendor/)
 
-### Skaff Altinn API-nøkkel og tilgang til scopes {#get-an-altinn-api-key}
-For å bruke Altinn Melding må man ha en abonnementsnøkkel. Teknisk sett er dette en API-nøkkel som må inkluderes i forespørselens `Ocp-Apim-Subscription-Key` header for å verifisere at du har rett til å bruke Meldings API-et. Uten denne nøkkelen vil forespørselen din bli avvist.
+### Tilgang til scopes {#get-access-to-scopes}
 For å kunne autentisere og sikre at du kan utføre operasjoner via meldings-APIet, må Altinn gi deg tilgang på de scopes du trenger. Dette sikrer at kun autoriserte klienter kan sende og motta filer, og opprettholder dermed sikkerheten i tjenesten. Følgende scopes brukes for å motta meldinger:
 - `altinn:correspondence.read`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated getting started guides to remove all references to the Altinn API subscription key.
  - Clarified and restructured instructions to focus solely on obtaining access to necessary scopes for API usage.
  - Provided clearer guidance on requesting scopes via servicedesk@altinn.no and linked to comprehensive scope lists.
  - Improved step-by-step instructions for both English and Norwegian documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->