### PR TITLE
Fix Broker Postman collection

### DIFF
--- a/static/swagger/altinn-broker-v1.json
+++ b/static/swagger/altinn-broker-v1.json
@@ -10,7 +10,7 @@
       "url": "https://platform.tt02.altinn.no",
       "description": "TT02"
     }
-  ],
+  ],  
   "webhooks": {
     "no.altinn.broker.filetransferinitialized": {
       "post": {
@@ -246,14 +246,14 @@
             "name": "status",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/FileTransferStatusExt"
+              "$ref": "#/components/schemas/FileTransferStatusExtNullable"
             }
           },
           {
             "name": "recipientStatus",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/RecipientFileTransferStatusExt"
+              "$ref": "#/components/schemas/RecipientFileTransferStatusExtNullable"
             }
           },
           {
@@ -309,145 +309,146 @@
             }
           }
         }
-      },
-      "/broker/api/v1/filetransfer/{fileTransferId}/upload": {
-        "post": {
-          "tags": [
-            "FileTransfer"
-          ],
-          "summary": "Upload to an initialized file using a binary stream.",
-          "description": "One of the scopes: \r\n\r\n- altinn:broker.write",
-          "parameters": [
-            {
-              "name": "fileTransferId",
-              "in": "path",
-              "required": true,
-              "schema": {
-                "type": "string",
-                "format": "uuid"
-              }
-            }
-          ],
-          "responses": {
-            "200": {
-              "description": "Returns the id of the uploaded File transfer",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/FileTransferUploadResponseExt"
-                  }
-                }
-              }
-            },
-            "400": {
-              "description": "<ul>\r\n  <li>Service owner needs to be configured to use the broker API</li>\r\n  <li>File size exceeds maximum</li>\r\n  <li>The checksum of uploaded file did not match the checksum specified in initialize call</li>\r\n</ul>",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "401": {
-              "description": "You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "403": {
-              "description": "The resource needs to be registered as an Altinn 3 resource and it has to be associated with a service owner",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "404": {
-              "description": "The requested file transfer was not found",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "409": {
-              "description": "A file transfer has already been, or attempted to be, created. Create a new file transfer resource to try again",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/ProblemDetails"
-                  }
-                }
-              }
-            },
-            "503": {
-              "description": "Storage provider is not ready yet. Please try again later"
+      }
+    },
+    "/broker/api/v1/filetransfer/{fileTransferId}/upload": {
+      "post": {
+        "tags": [
+          "FileTransfer"
+        ],
+        "summary": "Upload to an initialized file using a binary stream.",
+        "description": "One of the scopes: \r\n\r\n- altinn:broker.write",
+        "parameters": [
+          {
+            "name": "fileTransferId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
             }
           }
-        }
-      },
-      "/broker/api/v1/filetransfer/upload": {
-        "post": {
-          "tags": [
-            "FileTransfer"
-          ],
-          "summary": "Initialize a filetransfer and uploads the file in the same request using form-data",
-          "description": "One of the scopes: \r\n\r\n- altinn:broker.write",
-          "requestBody": {
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the id of the uploaded File transfer",
             "content": {
-              "multipart/form-data": {
+              "application/json": {
                 "schema": {
-                  "required": [
-                    "FileTransfer",
-                    "Metadata.FileName",
-                    "Metadata.Recipients",
-                    "Metadata.ResourceId",
-                    "Metadata.Sender"
-                  ],
-                  "type": "object",
-                  "properties": {
-                    "Metadata.FileName": {
-                      "maxLength": 255,
-                      "minLength": 1,
-                      "type": "string",
-                      "description": "The filename including extension"
+                  "$ref": "#/components/schemas/FileTransferUploadResponseExt"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "<ul>\r\n  <li>Service owner needs to be configured to use the broker API</li>\r\n  <li>File size exceeds maximum</li>\r\n  <li>The checksum of uploaded file did not match the checksum specified in initialize call</li>\r\n</ul>",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "You must use a bearer token that represents a system user with access to the resource in the Resource Rights Registry",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The resource needs to be registered as an Altinn 3 resource and it has to be associated with a service owner",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested file transfer was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "A file transfer has already been, or attempted to be, created. Create a new file transfer resource to try again",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Storage provider is not ready yet. Please try again later"
+          }
+        }
+      }
+    },
+    "/broker/api/v1/filetransfer/upload": {
+      "post": {
+        "tags": [
+          "FileTransfer"
+        ],
+        "summary": "Initialize a filetransfer and uploads the file in the same request using form-data",
+        "description": "One of the scopes: \r\n\r\n- altinn:broker.write",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "FileTransfer",
+                  "Metadata.FileName",
+                  "Metadata.Recipients",
+                  "Metadata.ResourceId",
+                  "Metadata.Sender"
+                ],
+                "type": "object",
+                "properties": {
+                  "Metadata.FileName": {
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string",
+                    "description": "The filename including extension"
+                  },
+                  "Metadata.ResourceId": {
+                    "maxLength": 255,
+                    "minLength": 1,
+                    "type": "string",
+                    "description": "The Altinn resource ID"
+                  },
+                  "Metadata.SendersFileTransferReference": {
+                    "maxLength": 4096,
+                    "minLength": 1,
+                    "type": "string",
+                    "description": "Used by senders and receivers to identify specific file using external identification methods."
+                  },
+                  "Metadata.Sender": {
+                    "pattern": "^\\d{4}:\\d{9}$",
+                    "type": "string",
+                    "description": "The sender organization of the file"
+                  },
+                  "Metadata.Recipients": {
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     },
-                    "Metadata.ResourceId": {
-                      "maxLength": 255,
-                      "minLength": 1,
-                      "type": "string",
-                      "description": "The Altinn resource ID"
-                    },
-                    "Metadata.SendersFileTransferReference": {
-                      "maxLength": 4096,
-                      "minLength": 1,
-                      "type": "string",
-                      "description": "Used by senders and receivers to identify specific file using external identification methods."
-                    },
-                    "Metadata.Sender": {
-                      "pattern": "^\\d{4}:\\d{9}$",
-                      "type": "string",
-                      "description": "The sender organization of the file"
-                    },
-                    "Metadata.Recipients": {
-                      "minItems": 1,
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      },
-                      "description": "The recipient organizations of the broker fileTransfer"
-                    },
-                    "Metadata.PropertyList": {
-                      "type": "object",
+                    "description": "The recipient organizations of the broker fileTransfer"
+                  },
+                  "Metadata.PropertyList": {
+                    "type": "object",
                       "additionalProperties": false,
                       "maxProperties": 10,
                       "nullable": true,
@@ -456,8 +457,7 @@
                           "maxLength": 300,
                           "type": "string"
                         }
-                      }
-                    },
+                      },
                     "description": "User-defined properties related to the file"
                   },
                   "Metadata.Checksum": {
@@ -1313,7 +1313,7 @@
           }
         },
         "additionalProperties": false,
-        "description": "Overview of a broker file transfer which also includes the status history of the file transfer."
+        "description": "Overview of a broker file transfer which also includes the status history of the file transfer.|"
       },
       "FileTransferStatusEventExt": {
         "type": "object",
@@ -1347,6 +1347,21 @@
           "Failed"
         ],
         "type": "string"
+      },
+      "FileTransferStatusExtNullable": {
+        "enum": [
+          "Initialized",
+          "UploadStarted",
+          "UploadProcessing",
+          "Published",
+          "Cancelled",
+          "AllConfirmedDownloaded",
+          "Purged",
+          "Failed",
+          null
+        ],
+        "type": "string",
+        "nullable": true
       },
       "FileTransferUploadResponseExt": {
         "type": "object",
@@ -1385,7 +1400,7 @@
             "nullable": true
           }
         },
-        "additionalProperties": {}
+        "additionalProperties": { }
       },
       "RecipientFileTransferStatusDetailsExt": {
         "type": "object",
@@ -1444,6 +1459,16 @@
           "DownloadConfirmed"
         ],
         "type": "string"
+      },
+      "RecipientFileTransferStatusExtNullable": {
+        "enum": [
+          "Initialized",
+          "DownloadStarted",
+          "DownloadConfirmed",
+          null
+        ],
+        "type": "string",
+        "nullable": true
       },
       "ResourceExt": {
         "type": "object",


### PR DESCRIPTION
There was an extra curly brace at line 460 that threw off everything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The API now allows null values for the status and recipientStatus query parameters when listing file transfers.
- **Documentation**
  - Improved API documentation formatting and consistency, including clearer schema definitions and corrected endpoint structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->