### PR TITLE
added docs for 830 content marked as read

### DIFF
--- a/content/correspondence/explanation/status-lifecycle/post-published/_index.en.md
+++ b/content/correspondence/explanation/status-lifecycle/post-published/_index.en.md
@@ -15,30 +15,31 @@ After a correspondence is published, recipients can interact with it:
 
 ## Post-Published Status States
 
-1. **Fetched**: Recipient has accessed the correspondence (via GetOverview or GetDetails API)
-2. **Read**: Recipient has explicitly marked the correspondence as read (requires prior Fetched status)
+1. **Fetched**: Recipient has accessed the correspondence (via GetOverview or GetContent API)
+2. **Read**: Recipient has either accessed the correspondence content for the first time or explicitly marked it as read (requires prior Fetched status)
 3. **AttachmentsDownloaded**: Recipient has downloaded one or more attachments (can occur at any time)
-4. **Confirmed**: Recipient has confirmed the correspondence (requires prior Fetched status, not Read)
+4. **Confirmed**: Recipient has confirmed the correspondence (requires prior Fetched status)
 5. **PurgedByRecipient**: Correspondence has been deleted by the recipient
 6. **PurgedByAltinn**: Correspondence has been deleted by the system
 
 ## Status Rules
 
-- **Fetched** is automatically set when recipients call GetOverview or GetDetails
-- **Read** requires explicit action via `/markasread` endpoint and requires prior Fetched status. This status is optional - recipients can confirm directly from Fetched without reading
+- **Fetched** is automatically set when recipients call GetOverview or GetContent
+- **Read** is set either automatically when accessing content for the first time or explicitly via `/markasread` endpoint.  This status is optional - recipients can confirm directly from Fetched without reading
 - **Confirmed** requires explicit action via `/confirm` endpoint and requires prior Fetched status
-- **AttachmentsDownloaded** can occur from any published state and does not require Read status
+- **AttachmentsDownloaded** can occur from any state after **Published**
 - **Confirmation** is only required if the correspondence has `IsConfirmationNeeded = true`
 
 ## Recipient Interaction Process
 
 ### Fetching Correspondence
 - Recipients access correspondence details (triggers Fetched status)
-- This is automatically triggered by GetOverview or GetDetails API calls
+- This is automatically triggered by GetOverview or GetContent API calls
 - Required before any other recipient actions
 
 ### Reading and Confirmation
-- Optionally mark as read (explicit action required)
+- Accessing content automatically marks as read (first time only)
+- Can also explicitly mark as read via `/markasread` endpoint
 - Download attachments at any time (triggers AttachmentsDownloaded status)
 - Confirm if required (only if `IsConfirmationNeeded = true`)
 - Read status is not required for confirmation

--- a/content/correspondence/explanation/status-lifecycle/post-published/_index.nb.md
+++ b/content/correspondence/explanation/status-lifecycle/post-published/_index.nb.md
@@ -15,31 +15,32 @@ Etter at en melding er publisert, kan mottakere samhandle med den:
 
 ## Statustilstander Etter Publisering
 
-1. **Hentet**: Mottaker har tilgang til meldingen (via GetOverview eller GetDetails API)
-2. **Lest**: Mottaker har eksplisitt markert meldingen som lest (krever forutgående Hentet status)
-3. **Vedlegg Lastet Ned**: Mottaker har lastet ned ett eller flere vedlegg (kan skje når som helst)
-4. **Bekreftet**: Mottaker har bekreftet meldingen (krever forutgående Hentet status, ikke Lest)
+1. **Hentet**: Mottaker har hentet meldingen (via GetOverview eller GetContent API)
+2. **Lest**: Mottaker har enten aksessert meldingsinnholdet for første gang eller eksplisitt markert den som lest (krever forutgående Hentet status)
+3. **Vedlegg Nedlastet**: Mottaker har nedlastet ett eller flere vedlegg (kan skje når som helst)
+4. **Bekreftet**: Mottaker har bekreftet meldingen (krever forutgående Hentet status)
 5. **Slettet av Mottaker**: Meldingen er slettet av mottaker
 6. **Slettet av Altinn**: Meldingen er slettet av systemet
 
 ## Regler for status
 
-- **Hentet** settes automatisk når mottakere kaller GetOverview eller GetDetails
-- **Lest** krever eksplisitt handling via `/markasread` endepunkt og krever forutgående Hentet status. Denne statusen er valgfri - mottakere kan bekrefte direkte fra Hentet uten å lese
+- **Hentet** settes automatisk når mottakere kaller GetOverview eller GetContent
+- **Lest** settes enten automatisk ved første GetContent-kall eller eksplisitt via `/markasread` endepunkt. Denne statusen er valgfri - mottakere kan bekrefte direkte fra Hentet uten å lese
 - **Bekreftet** krever eksplisitt handling via `/confirm` endepunkt og krever forutgående Hentet status
-- **Vedlegg Lastet Ned** kan skje fra enhver publisert tilstand og krever ikke Lest status
+- **Vedlegg Nedlastet** kan skje fra enhver tilstand etter **Publisert**
 - **Bekreftelse** er kun påkrevd hvis meldingen har `IsConfirmationNeeded = true`
 
 ## Mottaker Interaksjonsprosess
 
 ### Henting av Melding
 - Mottakere får tilgang til meldingsdetaljer (utløser Hentet status)
-- Dette utløses automatisk av GetOverview eller GetDetails API-kall
+- Dette utløses automatisk av GetOverview eller GetContent API-kall
 - Påkrevd før andre mottakerhandlinger
 
 ### Lesing og Bekreftelse
-- Eventuelt marker som lest (eksplisitt handling påkrevd)
-- Last ned vedlegg når som helst (utløser Vedlegg Lastet Ned status)
+- Første GetContent-kall markerer status som lest
+- Status kan også eksplisitt markeres som lest via `/markasread`-endepunkt
+- Last ned vedlegg når som helst (utløser Vedlegg Nedlastet status)
 - Bekreft hvis påkrevd (kun hvis `IsConfirmationNeeded = true`)
 - Lest status er ikke påkrevd for bekreftelse
 

--- a/layouts/shortcodes/correspondence-life-cycle-post-published.html
+++ b/layouts/shortcodes/correspondence-life-cycle-post-published.html
@@ -3,11 +3,12 @@
     %% Post-published flow
     A[Start: Published] --> B{Recipient Actions}
     
-    B -->|GetOverview or GetDetails| C[Set Status: Fetched]
+    B -->|GetOverview or GetContent| C[Set Status: Fetched]
     B -->|Download Attachments from any state| G[Set Status: AttachmentsDownloaded]
     
+    C -->|GetContent first time| E[Set Status: Read]
     C --> D{Recipient Actions}
-    D -->|Mark as Read| E[Set Status: Read]
+    D -->|Mark as Read| E
     D -->|Continue to Confirm| H{Confirm?}
     
     E --> H{Confirm?}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified and updated the status lifecycle descriptions for post-published correspondence, including more precise triggers for "Fetched," "Read," "Confirmed," and "AttachmentsDownloaded" statuses in both English and Norwegian documentation.
  - Updated the flowchart to reflect new API triggers and status transitions, including automatic "Read" status on first content access and revised transition labels for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->