### PR TITLE
Slack rename

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -3,6 +3,3 @@ title: Altinn docs
 description: Learn about Altinn
 jumbotron: true
 ---
-
-# Altinn docs
-

--- a/content/_index.nb.md
+++ b/content/_index.nb.md
@@ -3,6 +3,3 @@ title: Altinn docs
 description: Lær om Altinn
 jumbotron: true
 ---
-
-# Altinn docs
-

--- a/content/altinn-studio/guides/altinn-2/altinn-2-datamodel/_index.en.md
+++ b/content/altinn-studio/guides/altinn-2/altinn-2-datamodel/_index.en.md
@@ -130,5 +130,5 @@ F.eks.:
 [1]: https://www.altova.com/xmlspy-xml-editor
 [2]: https://code.visualstudio.com/
 [3]: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml
-[4]: https://altinn.slack.com/archives/C041WMBLYMB
+[4]: https://digdir-samarbeid.slack.com/archives/C041WMBLYMB
 [5]: /altinn-studio/reference/data/data-modeling/#altinn-studio-data-modeling

--- a/content/altinn-studio/guides/altinn-2/altinn-2-datamodel/_index.nb.md
+++ b/content/altinn-studio/guides/altinn-2/altinn-2-datamodel/_index.nb.md
@@ -129,5 +129,5 @@ F.eks.:
 [1]: https://www.altova.com/xmlspy-xml-editor
 [2]: https://code.visualstudio.com/
 [3]: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml
-[4]: https://altinn.slack.com/archives/C041WMBLYMB
+[4]: https://digdir-samarbeid.slack.com/archives/C041WMBLYMB
 [5]: /nb/altinn-studio/reference/data/data-modeling/#altinn-studio-datamodellering

--- a/content/altinn-studio/guides/contributing/add-new-component/_index.en.md
+++ b/content/altinn-studio/guides/contributing/add-new-component/_index.en.md
@@ -33,7 +33,7 @@ When adding an icon there are different approaches given that;
 
 - Or, if the component needs a new custom icon:
 
-  Then you can either create an SVG for the component yourself or outsource this task to the designers in Altinn Studio by reaching out to them [in Slack](https://altinn.slack.com/) or [create an issue in Altinn Studio Github repository](https://github.com/Altinn/altinn-studio/issues/new/choose). When an SVG is created for the icon, convert the SVG to JSX, e.g. using [this tool](https://svg2jsx.com/). Create a new file in `libs/studio-icons/src/react/icons/[YOUR_COMPONENT_NAME]Icon.tsx` and use the same format as for the other icons in the folder. The icon file must be added to the index file in the same folder.
+  Then you can either create an SVG for the component yourself or outsource this task to the designers in Altinn Studio by reaching out to them [in Slack](https://digdir-samarbeid.slack.com/) or [create an issue in Altinn Studio Github repository](https://github.com/Altinn/altinn-studio/issues/new/choose). When an SVG is created for the icon, convert the SVG to JSX, e.g. using [this tool](https://svg2jsx.com/). Create a new file in `libs/studio-icons/src/react/icons/[YOUR_COMPONENT_NAME]Icon.tsx` and use the same format as for the other icons in the folder. The icon file must be added to the index file in the same folder.
 
 ### 3. Add the new component in the list of Studio components
 For providing fully support for a new component in Studio, there are a few things to do. The order is arbitrary. 

--- a/content/altinn-studio/guides/contributing/add-new-component/_index.nb.md
+++ b/content/altinn-studio/guides/contributing/add-new-component/_index.nb.md
@@ -32,7 +32,7 @@ Når du legger til et ikon, er det forskjellige tilnærminger gitt at;
 
 - Eller, hvis komponenten trenger et nytt tilpasset ikon:
 
-  Da kan du enten lage en SVG for komponenten selv eller deleger denne oppgaven til designerne i Altinn Studio ved å kontakte dem [i Slack](https://altinn.slack.com/) eller [opprette et issue i Altinn Studio Github repository](https://github.com/Altinn/altinn-studio/issues/new/choose). Når en SVG er opprettet for ikonet, konverter SVG til JSX, f.eks. ved å bruke [dette verktøyet](https://svg2jsx.com/). Opprett en ny fil i `libs/studio-icons/src/react/icons/[NAVNET_PÅ_DIN_KOMPONENT]Icon.tsx` og bruk samme format som for de andre ikonene i mappen. Ikonfilen må legges til indeksfilen i samme mappe.
+  Da kan du enten lage en SVG for komponenten selv eller deleger denne oppgaven til designerne i Altinn Studio ved å kontakte dem [i Slack](https://digdir-samarbeid.slack.com/) eller [opprette et issue i Altinn Studio Github repository](https://github.com/Altinn/altinn-studio/issues/new/choose). Når en SVG er opprettet for ikonet, konverter SVG til JSX, f.eks. ved å bruke [dette verktøyet](https://svg2jsx.com/). Opprett en ny fil i `libs/studio-icons/src/react/icons/[NAVNET_PÅ_DIN_KOMPONENT]Icon.tsx` og bruk samme format som for de andre ikonene i mappen. Ikonfilen må legges til indeksfilen i samme mappe.
 
 ### 3. Legg til den nye komponenten i listen over Studio-komponenter
 For å gi full støtte for en ny komponent i Studio, er det noen få ting å gjøre. Rekkefølgen er vilkårlig.

--- a/content/altinn-studio/guides/design/guidelines/components/_index.en.md
+++ b/content/altinn-studio/guides/design/guidelines/components/_index.en.md
@@ -8,7 +8,7 @@ aliases:
 
 {{% panel-contribute 
 src1="https://github.com/Altinn/altinn-studio/issues/new/choose" title1="Create a new issue on github" 
-src2="https://altinn.slack.com/" title2="Write to us on Slack" %}}
+src2="https://digdir-samarbeid.slack.com/" title2="Write to us on Slack" %}}
 
 **Do you need a new component?**
 

--- a/content/altinn-studio/guides/design/guidelines/components/_index.nb.md
+++ b/content/altinn-studio/guides/design/guidelines/components/_index.nb.md
@@ -8,7 +8,7 @@ aliases:
 
 {{% panel-contribute 
 src1="https://github.com/Altinn/altinn-studio/issues/new/choose" title1="Opprett en sak i github" 
-src2="https://altinn.slack.com/" title2="Skriv til oss på Slack" %}}
+src2="https://digdir-samarbeid.slack.com/" title2="Skriv til oss på Slack" %}}
 
 **Har du behov for en ny komponent?**
 

--- a/content/altinn-studio/guides/design/guidelines/consistency/_index.en.md
+++ b/content/altinn-studio/guides/design/guidelines/consistency/_index.en.md
@@ -20,7 +20,7 @@ You will be required and responsible in following all [WCAG-demands](https://www
 
 {{% panel-contribute 
 src1="https://github.com/Altinn/altinn-studio/issues/new/choose" title1="Opprett en sak i github" 
-src2="https://altinn.slack.com/" title2="Skriv til oss på Slack" %}}
+src2="https://digdir-samarbeid.slack.com/" title2="Skriv til oss på Slack" %}}
 
 
 **Do you need a new component?**

--- a/content/altinn-studio/guides/design/guidelines/consistency/_index.nb.md
+++ b/content/altinn-studio/guides/design/guidelines/consistency/_index.nb.md
@@ -20,7 +20,7 @@ Velger du likevel å gå bort fra designet, er du selv ansvarlig for å følge a
 
 {{% panel-contribute 
 src1="https://github.com/Altinn/altinn-studio/issues/new/choose" title1="Opprett en sak i github" 
-src2="https://altinn.slack.com/" title2="Skriv til oss på Slack" %}}
+src2="https://digdir-samarbeid.slack.com/" title2="Skriv til oss på Slack" %}}
 
 
 **Har du behov for en ny komponent?**

--- a/content/authorization/migration/informasjon-sent/letter-api-reources.md
+++ b/content/authorization/migration/informasjon-sent/letter-api-reources.md
@@ -38,4 +38,4 @@ I dag opprettes nye tjenester av typen «Delegerbare API ressurser» via et REST
 
 Vi kommer til å lage nye API for å registrere tjenester av typen “Delegerbare API ressurser», men i en overgangsfase må de som ønsker å opprette nye tjenester gjøre dette ved å sende epost til Digdir slik at vi kan gjøre det for dere. 
 
-Hvis dere har spørsmål så kan dere nå oss via altinn.slack.com eller ved å sende epost til tjenesteeier@altinn.no. 
+Hvis dere har spørsmål så kan dere nå oss via digdir-samarbeid.slack.com eller ved å sende epost til tjenesteeier@altinn.no. 

--- a/content/broker/explanation/very-large-files/_index.en.md
+++ b/content/broker/explanation/very-large-files/_index.en.md
@@ -13,5 +13,5 @@ The theoretical maximum size is 1.6TB, but we only regularly benchmark it to 100
 
 # How to break the 2GB limit
 
-1. Contact us [@Slack#team-formidling](https://altinn.slack.com/archives/C06982E0UGH) for pre-approval.
+1. Contact us [@Slack#team-formidling](https://digdir-samarbeid.slack.com/archives/C06982E0UGH) for pre-approval.
 2. Set the "DisableVirusScan" flag in the [initialize file transfer call](https://docs.altinn.studio/broker/getting-started/developer-guides/send-files/#operation-initialize-filetransfer) to true.

--- a/content/broker/explanation/very-large-files/_index.nb.md
+++ b/content/broker/explanation/very-large-files/_index.nb.md
@@ -13,5 +13,5 @@ Den teoretiske maksimale størrelsen er 1,6TB, men vi gjennomfører regelmessig 
 
 # Hvordan bryte 2GB-grensen
 
-1. Kontakt oss på [@Slack#team-formidling](https://altinn.slack.com/archives/C06982E0UGH) for godkjenning.
+1. Kontakt oss på [@Slack#team-formidling](https://digdir-samarbeid.slack.com/archives/C06982E0UGH) for godkjenning.
 2. Sett "DisableVirusScan" i [fileoverføringsinitialiseringskallet](https://docs.altinn.studio/broker/getting-started/developer-guides/send-files/#operation-initialize-filetransfer) til true.

--- a/layouts/partials/footer-content.html
+++ b/layouts/partials/footer-content.html
@@ -10,10 +10,10 @@
                         <a href="https://github.com/Altinn/altinn-studio/issues">Backlog</a>
                     </li>
                     <li>
-                        <a href="https://altinn.slack.com">Slack</a>
+                        <a href="https://digdir-samarbeid.slack.com">Slack</a>
                     </li>
                     <li>
-                        <a href="https://github.com/Altinn/altinn-studio">GitHub</a>
+                        <a href="https://github.com/Altinn">GitHub</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION

Renamed altinn.slack.com to https://digdir-samarbeid.slack.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed redundant top-level headings from the main English and Norwegian landing pages.

- **Documentation**
  - Updated all Slack workspace URLs from "altinn.slack.com" to "digdir-samarbeid.slack.com" across multiple guides and documentation pages.
  - Updated a GitHub link in the site footer to point to the main organization page.
  - Corrected reference links and contact information in both English and Norwegian documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->