### PR TITLE
More details on events and resource registry

### DIFF
--- a/content/events/publish-events/developer-guides/grant-subscriber-access/_index.en.md
+++ b/content/events/publish-events/developer-guides/grant-subscriber-access/_index.en.md
@@ -11,7 +11,7 @@ In general, access to events for a given party will be authorized based on roles
 
 ## Generic events
 Granting a subscriber access to your published events is done through the policy of the 
-resource in the resource registry. 
+resource in the resource registry. In order to query events or setup subscription the authorization policy has to grant the "subscribe" action.
 
 {{% notice info  %}}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the authorization policy must explicitly grant the "subscribe" action when providing subscriber access to published events, improving the accuracy of access control instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->