### PR TITLE
Studio - update Maskinporten-related docs to use new built-in client

### DIFF
--- a/content/altinn-studio/guides/development/eFormidling/_index.en.md
+++ b/content/altinn-studio/guides/development/eFormidling/_index.en.md
@@ -22,7 +22,7 @@ Before setting up eFormidling you will need to have the following set up:
 
 In order to enable eFormidling in your application you will need to [setup an integration between your app and Maskinporten](/altinn-studio/guides/integration/maskinporten/).
 
-* **NB!** In `Program.cs` add the following instead of what is described in the steps above in the `RegisterCustomAppServices`-method:
+* **NB!** The application automatically includes the built-in `IMaskinportenClient`. If you need custom configuration, you can use:
   
   {{< code-title >}}
     App/Program.cs
@@ -30,8 +30,8 @@ In order to enable eFormidling in your application you will need to [setup an in
   ```csharp {hl_lines=[3,4]}
   void RegisterCustomAppServices(IServiceCollection services, IConfiguration config, IWebHostEnvironment env)
   {
-    services.Configure<MaskinportenSettings>(config.GetSection("MaskinportenSettings"));
-    services.AddMaskinportenJwkTokenProvider("MaskinportenSettings--EncodedJwk");
+    // Optional: Only needed if using non-default configuration path
+    services.ConfigureMaskinportenClient("CustomMaskinportenSettingsPath");
   }
   ```
 
@@ -90,13 +90,9 @@ void RegisterCustomAppServices(IServiceCollection services, IConfiguration confi
 {
   services.AddSingleton<IEventSecretCodeProvider, EventSecretCodeProvider>();
 
-  services.AddMaskinportenHttpClient<SettingsJwkClientDefinition, EventsSubscriptionClient>(
-  config.GetSection("MaskinportenSettings"), clientDefinition =>
-  {
-      clientDefinition.ClientSettings.Scope = "altinn:serviceowner/instances.read";
-      clientDefinition.ClientSettings.ExhangeToAltinnToken = true;
-      clientDefinition.ClientSettings.EnableDebugLogging = true;
-  }).AddTypedClient<IEventsSubscription, EventsSubscriptionClient>();
+  // Configure HTTP client for Events API with Maskinporten authorization
+  services.AddHttpClient<IEventsSubscription, EventsSubscriptionClient>()
+    .UseMaskinportenAltinnAuthorisation("altinn:serviceowner/instances.read");
 }
 ```
 {{% /expandlarge %}}

--- a/content/altinn-studio/guides/development/eFormidling/_index.nb.md
+++ b/content/altinn-studio/guides/development/eFormidling/_index.nb.md
@@ -22,7 +22,7 @@ Before setting up eFormidling you will need to have the following set up:
 
 In order to enable eFormidling in your application you will need to [setup an integration between your app and Maskinporten](/altinn-studio/guides/integration/maskinporten/).
 
-* **NB!** In `Program.cs` add the following instead of what is described in the steps above in the `RegisterCustomAppServices`-method:
+* **NB!** Applikasjonen inkluderer automatisk den innebygde `IMaskinportenClient`. Hvis du trenger tilpasset konfigurasjon, kan du bruke:
   
   {{< code-title >}}
     App/Program.cs
@@ -30,8 +30,8 @@ In order to enable eFormidling in your application you will need to [setup an in
   ```csharp {hl_lines=[3,4]}
   void RegisterCustomAppServices(IServiceCollection services, IConfiguration config, IWebHostEnvironment env)
   {
-    services.Configure<MaskinportenSettings>(config.GetSection("MaskinportenSettings"));
-    services.AddMaskinportenJwkTokenProvider("MaskinportenSettings--EncodedJwk");
+    // Valgfritt: Kun nødvendig hvis du bruker ikke-standard konfigurasjonsbane
+    services.ConfigureMaskinportenClient("CustomMaskinportenSettingsPath");
   }
   ```
 
@@ -90,13 +90,9 @@ void RegisterCustomAppServices(IServiceCollection services, IConfiguration confi
 {
   services.AddSingleton<IEventSecretCodeProvider, EventSecretCodeProvider>();
 
-  services.AddMaskinportenHttpClient<SettingsJwkClientDefinition, EventsSubscriptionClient>(
-  config.GetSection("MaskinportenSettings"), clientDefinition =>
-  {
-      clientDefinition.ClientSettings.Scope = "altinn:serviceowner/instances.read";
-      clientDefinition.ClientSettings.ExhangeToAltinnToken = true;
-      clientDefinition.ClientSettings.EnableDebugLogging = true;
-  }).AddTypedClient<IEventsSubscription, EventsSubscriptionClient>();
+  // Konfigurer HTTP-klient for Events API med Maskinporten-autorisasjon
+  services.AddHttpClient<IEventsSubscription, EventsSubscriptionClient>()
+    .UseMaskinportenAltinnAuthorisation("altinn:serviceowner/instances.read");
 }
 ```
 {{% /expandlarge %}}

--- a/content/altinn-studio/guides/integration/maskinporten/_index.en.md
+++ b/content/altinn-studio/guides/integration/maskinporten/_index.en.md
@@ -94,7 +94,7 @@ void RegisterCustomAppServices(IServiceCollection services, IConfiguration confi
 
 For typed HTTP clients that need Maskinporten authorization, you can use the extension methods:
 
-{{< highlight csharp "linenos=false,hl_lines=5-6,8-9" >}}
+{{< highlight csharp "linenos=false,hl_lines=5-6 8-9" >}}
 void RegisterCustomAppServices(IServiceCollection services, IConfiguration config, IWebHostEnvironment env)
 {
     // ...

--- a/content/altinn-studio/guides/integration/maskinporten/_index.en.md
+++ b/content/altinn-studio/guides/integration/maskinporten/_index.en.md
@@ -51,11 +51,11 @@ When preparing the application to use secrets from Azure Key Vault, there are so
 
    ```json
    {
-       "MaskinportenSettings": {
-            "Authority": "https://test.maskinporten.no/",
-            "ClientId": "",
-            "JwkBase64": ""
-       }
+     "MaskinportenSettings": {
+       "Authority": "https://test.maskinporten.no/",
+       "ClientId": "",
+       "JwkBase64": ""
+     }
    }
    ```
    

--- a/content/altinn-studio/guides/integration/maskinporten/_index.nb.md
+++ b/content/altinn-studio/guides/integration/maskinporten/_index.nb.md
@@ -98,7 +98,7 @@ void RegisterCustomAppServices(IServiceCollection services, IConfiguration confi
 
 For typede HTTP-klienter som trenger Maskinporten-autorisasjon, kan du bruke utvidelsesmetodene:
 
-{{< highlight csharp "linenos=false,hl_lines=5-6,8-9" >}}
+{{< highlight csharp "linenos=false,hl_lines=5-6 8-9" >}}
 void RegisterCustomAppServices(IServiceCollection services, IConfiguration config, IWebHostEnvironment env)
 {
     // ...

--- a/content/altinn-studio/guides/integration/maskinporten/_index.nb.md
+++ b/content/altinn-studio/guides/integration/maskinporten/_index.nb.md
@@ -9,16 +9,14 @@ aliases:
 - /altinn-studio/guides/integration/maskinporten-app-integration
 ---
 
-Denne veiledningen viser hvordan du setter opp en Altinn-applikasjon med en HTTP-klient som benytter Maskinporten for
-autentisering av forespørslene. Dette er nyttig når applikasjonen må utføre autoriserte forespørsler på vegne av eieren
-av applikasjonen, i stedet for den aktive brukeren.
+Denne veiledningen viser hvordan du setter opp en Altinn-applikasjon til å bruke den innebygde Maskinporten-klienten (`IMaskinportenClient`) for å utføre autoriserte forespørsler på vegne av eieren av applikasjonen, i stedet for den aktive brukeren.
 
 For å sette dette opp, må følgende gjøres:
 
 1. Sørg for at organisasjonen har tilgang til Azure Key Vault.
 2. Opprett integrasjonen mot Maskinporten i [Samarbeidsportalen](https://samarbeid.digdir.no/).
 3. Lagre autentiseringsnøkkelen for integrasjonen i Azure Key Vault.
-4. Konfigurer applikasjonen til å bruke Maskinporten-klienten og hente hemmeligheter fra Azure Key Vault.
+4. Sett opp applikasjonen til å bruke Maskinporten-klienten og hente hemmeligheter fra Azure Key Vault.
 
 ## Tilgang til Azure Key Vault
 
@@ -54,24 +52,23 @@ Når applikasjonen forberedes til å bruke hemmeligheter fra Azure Key Vault, m�
    kodebasen til applikasjonen.
 
    For eksempel, hvis seksjonen for Maskinporten-integrasjonen ser slik ut:
+
    ```json
    {
-     "MaskinportenSettings": {
-       "Environment": "test",
-       "ClientId": "",
-       "Scope": "altinn:serviceowner/instances.read",
-       "EncodedJwk": "",
-       "ExhangeToAltinnToken": true,
-       "EnableDebugLog": true
-     }
+       "MaskinportenSettings": {
+            "Authority": "https://test.maskinporten.no/",
+            "ClientId": "",
+            "JwkBase64": ""
+       }
    }
    ```
-
+   
    Må hemmelighetene i Azure Key Vault ha navn som dette:
-
+   
    ```
+   MaskinportenSettings--Authority
    MaskinportenSettings--ClientId
-   MaskinportenSettings--EncodedJwk
+   MaskinportenSettings--JwkBase64
    ```
 2. For at applikasjonen skal kunne lese hemmelighetene fra Azure Key Vault, må konfigureres først.
    Se [seksjoner om hemmeligheter](../../../reference/configuration/secrets) for hvordan dette oppnås.
@@ -84,16 +81,33 @@ publisere applikasjonen på nytt før endringene trer i kraft._
 
 ## Sett opp applikasjonen til å bruke Maskinporten-integrasjonen
 
-Når applikasjonen skal tilpasses for å bruke Maskinporten-integrasjonen, må vi gjøre noen endringer i `Program.cs`-filen.
+Applikasjonen inkluderer automatisk den innebygde `IMaskinportenClient` som kan injiseres i tjenestene dine. Klienten finner og bruker automatisk `MaskinportenSettings`-konfigurasjonen.
 
-Først må vi legge til MaskinportenHttpClient-tjenesten med riktig konfigurasjon i metoden `RegisterCustomAppServices`:
+Hvis du trenger å bruke en annen konfigurasjonsbane enn standardbanen, kan du konfigurere den i `RegisterCustomAppServices`-metoden:
 
-{{< highlight csharp "linenos=false,hl_lines=5" >}}
+{{< highlight csharp "linenos=false,hl_lines=5-7" >}}
 void RegisterCustomAppServices(IServiceCollection services, IConfiguration config, IWebHostEnvironment env)
 {
     // ...
 
-    services.AddMaskinportenHttpClient<SettingsJwkClientDefinition, YourCustomClient>(config.GetSection("MaskinportenSettings"));
+    services.ConfigureMaskinportenClient(
+        "YourCustomMaskinportenSettingsPath"
+    );
+}
+{{< / highlight >}}
+
+For typede HTTP-klienter som trenger Maskinporten-autorisasjon, kan du bruke utvidelsesmetodene:
+
+{{< highlight csharp "linenos=false,hl_lines=5-6,8-9" >}}
+void RegisterCustomAppServices(IServiceCollection services, IConfiguration config, IWebHostEnvironment env)
+{
+    // ...
+
+    // For eksterne API-er som krever rå Maskinporten-tokens
+    services.AddHttpClient<YourCustomClient>().UseMaskinportenAuthorisation("scope:1", "scope:2");
+    
+    // For Altinn API-er som krever Altinn-tokens (veksler Maskinporten-token)
+    services.AddHttpClient<YourCustomClient2>().UseMaskinportenAltinnAuthorisation("scope:1", "scope:2");
 }
 {{< / highlight >}}
 

--- a/content/altinn-studio/guides/integration/maskinporten/_index.nb.md
+++ b/content/altinn-studio/guides/integration/maskinporten/_index.nb.md
@@ -55,11 +55,11 @@ Når applikasjonen forberedes til å bruke hemmeligheter fra Azure Key Vault, m�
 
    ```json
    {
-       "MaskinportenSettings": {
-            "Authority": "https://test.maskinporten.no/",
-            "ClientId": "",
-            "JwkBase64": ""
-       }
+     "MaskinportenSettings": {
+       "Authority": "https://test.maskinporten.no/",
+       "ClientId": "",
+       "JwkBase64": ""
+     }
    }
    ```
    

--- a/content/altinn-studio/guides/integration/maskinporten/_index.nb.md
+++ b/content/altinn-studio/guides/integration/maskinporten/_index.nb.md
@@ -81,7 +81,7 @@ publisere applikasjonen på nytt før endringene trer i kraft._
 
 ## Sett opp applikasjonen til å bruke Maskinporten-integrasjonen
 
-Applikasjonen inkluderer automatisk den innebygde `IMaskinportenClient` som kan injiseres i tjenestene dine. Klienten finner og bruker automatisk `MaskinportenSettings`-konfigurasjonen.
+Applikasjonen inkluderer automatisk den innebygde `IMaskinportenClient` som kan brukes i tjenestene dine. Klienten finner og bruker automatisk `MaskinportenSettings`-konfigurasjonen.
 
 Hvis du trenger å bruke en annen konfigurasjonsbane enn standardbanen, kan du konfigurere den i `RegisterCustomAppServices`-metoden:
 

--- a/content/altinn-studio/guides/shared/maskinporten-integration/maskinporten-integration-samarbeidsportal.md
+++ b/content/altinn-studio/guides/shared/maskinporten-integration/maskinporten-integration-samarbeidsportal.md
@@ -101,7 +101,7 @@ from any client that can provide the private and public parts of the JWK.
 
     !["The JWK"](/altinn-studio/guides/shared/maskinporten-integration/jwk.png "The JWK")
 
-In Altinn libraries this key pair is referenced as EncodedJwk  and must be base64 encoded before
+In Altinn applications this key pair is referenced as JwkBase64 and must be base64 encoded before
 it is included in application configuration or uploaded to a Key Vault.
 
 [Base64encode.org](https://www.base64encode.org/) can be used for encoding.

--- a/content/altinn-studio/guides/shared/maskinporten-integration/maskinporten-integration-samarbeidsportal.md
+++ b/content/altinn-studio/guides/shared/maskinporten-integration/maskinporten-integration-samarbeidsportal.md
@@ -101,7 +101,7 @@ from any client that can provide the private and public parts of the JWK.
 
     !["The JWK"](/altinn-studio/guides/shared/maskinporten-integration/jwk.png "The JWK")
 
-In Altinn applications this key pair is referenced as JwkBase64 and must be base64 encoded before
+In Altinn applications this key pair is referenced as `JwkBase64` and must be base64 encoded before
 it is included in application configuration or uploaded to a Key Vault.
 
 [Base64encode.org](https://www.base64encode.org/) can be used for encoding.

--- a/content/altinn-studio/reference/logic/events/subscribing/_index.en.md
+++ b/content/altinn-studio/reference/logic/events/subscribing/_index.en.md
@@ -17,37 +17,38 @@ Currently the localtest environment does not support generating inbound events f
 
 
 ## Configuring Maskinporten integration
-Even though we are authenticating through Maskinporten, we can't use the received token directly since Altinn Events only supports an Altinn token. To solve this we need to exchange the Maskinporten token into an Altinn token. The example below adds a message handler to the EventsSubscriptionClient used to communicate with Maskinporten. This handler automatically requests a token from Maskinporten, exchanges it to an Altinn token and adds the token to the request to the Event System when creating a subscription.
+The application uses the built-in `IMaskinportenClient` to authenticate with Maskinporten and automatically exchange the token to an Altinn token for communicating with Altinn Events.
 
-This code should be added to _Program.cs_.
-
-```csharp
-services.AddMaskinportenHttpClient<MaskinportenClientDefinition, EventsSubscriptionClient>(
-    config.GetSection("MaskinportenSettings"), clientDefinition =>
-    {
-        clientDefinition.ClientSettings.Scope = "altinn:serviceowner/instances.read";
-        clientDefinition.ClientSettings.ExhangeToAltinnToken = true;
-    }).AddTypedClient<IEventsSubscription, EventsSubscriptionClient>();
-```
-
-Scope and ExchangeToAltinnToken need to be configured in code and not in _AppSettings.json_ if you have multiple external dependencies that requires the use of Maskinporten. This is to avoid scopes belonging to one external api being sent to another api. Some api's accept this while others will reject the request due to unknown scopes. It's also best practice not to leak unnecessary scopes to other api's that don't require it to avoid token misuse.
-
-{{% notice info %}}
-The `MaskinportenClientDefinition` in the example above is a custom implementation of `IClientDefinition` from the nuget package [Altinn.ApiClients.Maskinporten](https://github.com/Altinn/altinn-apiclient-maskinporten) which is included as a part of the `Altinn.App.Core` package. If you don't need a custom implementation you can use one of the [built in client definitions](https://github.com/Altinn/altinn-apiclient-maskinporten).
-{{% /notice %}}
-
-Depending on what type of ClientDefinition you use you typically need to specify either a certificate file and password, encoded jwk, encoded x509 certificate or enterprise username/password in order to authenticate with Maskinporten in addition to the environment and client id. These can be shared between the various integrations.
+You need to configure the Maskinporten settings in your _appsettings.json_:
 
 ```json
   "MaskinportenSettings": {
-    "Environment": "test",
-    "ClientId": "",
-    "CertificatePkcs12Path": "",
-    "CertificatePkcs12Password": ""
+    "Authority": "https://test.maskinporten.no/",
+    "ClientId": "your-client-id",
+    "JwkBase64": "base64-encoded-jwk"
   }
 ```
 
-Here is a [C# class of the settings available](https://github.com/Altinn/altinn-apiclient-maskinporten/blob/main/src/Altinn.ApiClients.Maskinporten/Config/MaskinportenSettings.cs) for reference.
+If you need to use a different configuration path than the default `MaskinportenSettings`, you can configure it in _Program.cs_:
+
+```csharp
+services.ConfigureMaskinportenClient(
+    "YourCustomMaskinportenSettingsPath"
+);
+```
+
+The built-in Maskinporten client will automatically handle token acquisition and exchange for Altinn APIs, including the Events service.
+
+You also need to configure the HTTP client for the Events API in your `RegisterCustomAppServices` method:
+
+```csharp
+void RegisterCustomAppServices(IServiceCollection services, IConfiguration config, IWebHostEnvironment env)
+{
+    // Configure HTTP client for Events API with Maskinporten authorization
+    services.AddHttpClient<IEventsSubscription, EventsSubscriptionClient>()
+        .UseMaskinportenAltinnAuthorisation("altinn:serviceowner/instances.read");
+}
+```
 
 ### Protecting the event endpoint with a secret
 Receiving events in the application is based on exposing a webhook endpoint to which the Event Service posts the event. Upon receiving an event, the application validates if a secret is provided before accepting the event. The secret  is provided by implementing the `IEventSecretCodeProvider` interface. By default there is an example implementation in place using a key from the key vault using a key with the name `EventSubscription--SecretCode` in the key vault the value of that key is used. You should hover not use the same key/value for multiple applications so it's recommended to create your own implementation.

--- a/content/altinn-studio/reference/logic/events/subscribing/_index.nb.md
+++ b/content/altinn-studio/reference/logic/events/subscribing/_index.nb.md
@@ -1,25 +1,24 @@
 ---
-title: Subscribing
-description: How to set up event subscription in an app
+title: Abonnement
+description: Hvordan sette opp hendelses-abonnement i en app
 toc: false
-tags: [translate-to-norwegian]
 weight: 10
 ---
 
-## Subscribing to events
-In order to receive events in the application you need create a subscription. While you can create a subscription authenticated as a user, most scenarios will probably be to authenticate as the organization owning the application, and to create the subscription as part of the startup process of the application. This example covers authenticating as an organization through maskinporten.
+## Abonnere på hendelser
+For å motta hendelser i applikasjonen må du opprette et abonnement. Selv om du kan opprette et abonnement autentisert som innlogget bruker, vil de fleste scenarioer sannsynligvis være å autentisere som tjenesteeier for applikasjonen, og å opprette abonnementet som del av oppstartsprosessen til applikasjonen. Dette eksempelet dekker autentisering som tjenesteeier gjennom Maskinporten.
 
 {{% notice warning %}}
-You should first make sure you have a client definition registered in Maskinporten for your application. See [Authenticating with Maskinporten](/api/authentication/maskinporten) on how register a client.<br><br>
+Du bør først sørge for at du har en klientdefinisjon registrert i Maskinporten for applikasjonen din. Se [Autentisering med Maskinporten](/nb/api/authentication/maskinporten) for hvordan du registrerer en klient.<br><br>
 
-Currently the localtest environment does not support generating inbound events for an app. In order to do this you need use tools like Postman or REST Client in VS Code to send a request to the application's event endpoint. 
+For øyeblikket støtter ikke lokaltest-miljøet generering av innkommende hendelser for en app. For å gjøre dette må du bruke verktøy som Postman eller REST Client i VS Code for å sende en forespørsel til applikasjonens hendelsesendepunkt.
 {{% /notice %}}
 
 
-## Configuring Maskinporten integration
-The application uses the built-in `IMaskinportenClient` to authenticate with Maskinporten and automatically exchange the token to an Altinn token for communicating with Altinn Events.
+## Konfigurering av Maskinporten-integrasjon
+Applikasjonen bruker den innebygde `IMaskinportenClient` for å autentisere med Maskinporten og automatisk utveksle tokenet til et Altinn-token for kommunikasjon med Altinn Events.
 
-You need to configure the Maskinporten settings in your _appsettings.json_:
+Du må konfigurere Maskinporten-innstillingene i din _appsettings.json_:
 
 ```json
   "MaskinportenSettings": {
@@ -29,7 +28,7 @@ You need to configure the Maskinporten settings in your _appsettings.json_:
   }
 ```
 
-If you need to use a different configuration path than the default `MaskinportenSettings`, you can configure it in _Program.cs_:
+Hvis du trenger å bruke en annen konfigurasjonsbane enn standard `MaskinportenSettings`, kan du konfigurere det i _Program.cs_:
 
 ```csharp
 services.ConfigureMaskinportenClient(
@@ -37,9 +36,9 @@ services.ConfigureMaskinportenClient(
 );
 ```
 
-The built-in Maskinporten client will automatically handle token acquisition and exchange for Altinn APIs, including the Events service.
+Den innebygde Maskinporten-klienten vil automatisk håndtere tokeninnhenting og utveksling for Altinn-API-er, inkludert Events-tjenesten.
 
-You also need to configure the HTTP client for the Events API in your `RegisterCustomAppServices` method:
+Du må også konfigurere HTTP-klienten for Events API i din `RegisterCustomAppServices`-metode:
 
 ```csharp
 void RegisterCustomAppServices(IServiceCollection services, IConfiguration config, IWebHostEnvironment env)
@@ -50,23 +49,23 @@ void RegisterCustomAppServices(IServiceCollection services, IConfiguration confi
 }
 ```
 
-### Protecting the event endpoint with a secret
-Receiving events in the application is based on exposing a webhook endpoint to which the Event Service posts the event. Upon receiving an event, the application validates if a secret is provided before accepting the event. The secret  is provided by implementing the `IEventSecretCodeProvider` interface. By default there is an example implementation in place using a key from the key vault using a key with the name `EventSubscription--SecretCode` in the key vault the value of that key is used. You should hover not use the same key/value for multiple applications so it's recommended to create your own implementation.
+### Beskytte hendelsesendepunktet med en hemmelighet
+Mottak av hendelser i applikasjonen er basert på å eksponere et webhook-endepunkt som Event Service sender hendelsen til. Ved mottak av en hendelse validerer applikasjonen om en hemmelighet er oppgitt før hendelsen aksepteres. Hemmeligheten oppgis ved å implementere `IEventSecretCodeProvider`-grensesnittet. Som standard finnes det en eksempelimplementasjon som bruker en nøkkel fra key vault med navnet `EventSubscription--SecretCode` i Azure KeyVault - verdien av denne nøkkelen brukes. Du bør imidlertid ikke bruke samme nøkkel/verdi for flere applikasjoner, så det anbefales å lage din egen implementasjon.
 
-When developing locally you should set the secret as a dotnet user-secret by running the following command in the root folder of the application:
+Når du utvikler lokalt kan du sette hemmeligheten som en dotnet user-secret ved å kjøre følgende kommando i rotmappen til applikasjonen:
 
 ```bash
 dotnet user-secrets set "EventSubscription--SecretCode" "your-secret-code"
 ```
 
 {{% notice info %}}
-Note that the return url and the secret code is part of the subscription definition. This means that if you rotate the key, you should remove the existing subscription first, or else you will have two active subscriptions for the same events.
+Merk at retur-URL-en og hemmelighetskoden er del av abonnementdefinisjonen. Dette betyr at hvis du roterer nøkkelen, bør du fjerne det eksisterende abonnementet først, ellers vil du ha to aktive abonnementer for samme hendelser.
 {{% /notice %}}
 
-### Create subscription
-Once you have your client registered with Maskinporten, your config setup, your ClientDefinition in place and your webhook secret defined - you are ready to add the code required to make a subscription.
+### Opprette abonnement
+Når du har klienten registrert med Maskinporten, konfigurasjonen satt opp, ClientDefinition på plass og webhook-hemmeligheten definert - er du klar til å legge til koden som kreves for å opprette et abonnement.
 
-The example below is using the `IHostedService` from Microsoft which, in this case, run once after the services are registered in the container, but before the application is configured.
+Eksemplet nedenfor bruker `IHostedService` fra Microsoft som, i dette tilfellet, kjører én gang etter at tjenestene er registrert i containeren, men før applikasjonen konfigureres.
 
 ```csharp
 using Altinn.App.Core.Infrastructure.Clients.Events;
@@ -124,5 +123,5 @@ namespace Altinn.App.Core.EFormidling
 
 ```
 {{% notice theme="warning"  %}}
-If the hosted service fail to run successfully, ie. throws an exception, the application will fail to start. If you don't want this behavior you should catch any exception and not rethrow it.
+Hvis hosted service feiler i å kjøre, dvs. kaster en exception, vil hele applikasjonen feile på oppstart. Hvis du ikke ønsker denne oppførselen bør du fange opp eventuelle exceptions og ikke kaste dem videre.
 {{% /notice %}}


### PR DESCRIPTION
* Don't reference `Altinn.ApiClients.Maskinporten` client, use the new built in one with simplified configuration


Issue: https://github.com/Altinn/altinn-studio-docs/issues/2253 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified and clarified instructions for integrating Maskinporten in Altinn applications, including updated configuration keys and usage of built-in clients.
  * Updated code examples to use new extension methods for HTTP client authorization.
  * Revised terminology from "EncodedJwk" to "JwkBase64" and improved guidance on Azure Key Vault configuration.
  * Translated the event subscription guide to Norwegian, ensuring all technical instructions and notices are localized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->