### PR TITLE
updated docs for edit button text config for subform

### DIFF
--- a/content/altinn-studio/guides/development/subform/config-options/_index.en.md
+++ b/content/altinn-studio/guides/development/subform/config-options/_index.en.md
@@ -28,6 +28,7 @@ The following keys in the `textResourceBindings` object are available for custom
 - `title` - The title of the subform component.
 - `description` - The description text shown underneath the title.
 - `addButton` - The text for the add-button.
+- `tableEditButton` - The text for the edit button.
 
 ## tableColumns
 

--- a/content/altinn-studio/guides/development/subform/config-options/_index.nb.md
+++ b/content/altinn-studio/guides/development/subform/config-options/_index.nb.md
@@ -28,6 +28,7 @@ Du kan tilpasse disse nøklene i `textResourceBindings`-objektet:
 - `title` - Tittelen på underskjema-komponenten.
 - `description` - En beskrivelse av komponenten, som vises under tittelen.
 - `addButton` - Hva Legg-til knappen skal inneholde.
+- `tableEditButton` - Tekst for Rediger knappen.
 
 ## tableColumns
 


### PR DESCRIPTION
We have added a config option for custom edit button text for subform, this updates docs.

Issue: https://github.com/Altinn/app-frontend-react/issues/3212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated subform configuration documentation to include the new `tableEditButton` key for customizing the edit button text in the subform component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->