### PR TITLE
Fix nynorsk string in consent template

### DIFF
--- a/content/authorization/architecture/resourceregistry/consent_templates.json
+++ b/content/authorization/architecture/resourceregistry/consent_templates.json
@@ -360,7 +360,7 @@
             },
             "historyUsedByHandledByBody": {
                 "nb": "{HandledBy} har, på vegne av {CoveredBy}, handlet på vegne av {OfferedBy}. Fullmakten utløper {Expiration}",
-                "nn": "{HandledBy} har, på vegne av {CoveredBy}, handla på vegne av {OfferedBy}. Samtykket utløper {Expiration}",
+                "nn": "{HandledBy} har, på vegne av {CoveredBy}, handla på vegne av {OfferedBy}. Fullmakta utløper {Expiration}",
                 "en": "{HandledBy} has, on behalf of {CoveredBy}, acted on behalf of {OfferedBy}. The authority expires {Expiration}"
             }
         }


### PR DESCRIPTION
In the nynorsk translation for Power of attorney template, "Samtykke" is used instead of "Fullmakt" (Bokmål and English use "Fullmakt and "power of attorney")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Norwegian Nynorsk translation in the power of attorney consent template to use the correct term for expiration, ensuring clearer and more accurate messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->