### PR TITLE
Update consent_templates.json

### DIFF
--- a/content/authorization/architecture/resourceregistry/consent_templates.json
+++ b/content/authorization/architecture/resourceregistry/consent_templates.json
@@ -299,12 +299,12 @@
             "heading": {
                 "person": {
                     "nb": "{CoveredBy} ønsker å utføre tjenester på dine vegne",
-                    "nn": "{CoveredBy} ønsker å utføre tenester på dine vegne",
+                    "nn": "{CoveredBy} ønskjer å utføre tenester på dine vegne",
                     "en": "{CoveredBy} requests power of attorney from you"
                 },
                 "org": {
                     "nb": "{CoveredBy} ønsker å utføre tjenester på vegne av {OfferedBy}",
-                    "nn": "{CoveredBy} ønsker å utføre tenester på vegne av {OfferedBy}",
+                    "nn": "{CoveredBy} ønskjer å utføre tenester på vegne av {OfferedBy}",
                     "en": "{CoveredBy} requests power of attorney from {OfferedBy}"
                 }
             },


### PR DESCRIPTION
Mette sine nynorskendringar + bruk av opphøre/opphøyre i staden for "utløper".




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved and standardized Norwegian Bokmål and Nynorsk wording across consent templates: corrected verb forms, spellings, spacing and punctuation.
  * Updated expiration and history messaging to use consistent "opphører / opphøyrer" phrasing where applicable.
  * Harmonized headings, service intros and history text for clearer, more consistent user-facing messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->