### PR TITLE
Docs/issue 733 https certificate requirements

### DIFF
--- a/content/events/subscribe-to-events/developer-guides/setup-subscription/_index.en.md
+++ b/content/events/subscribe-to-events/developer-guides/setup-subscription/_index.en.md
@@ -47,7 +47,7 @@ if your subscription request is not being accepted.
 - webhook URL to receive HTTP POST request from Altinn Events
 
 {{% notice warning %}}
-HTTPS endpoints must use publicly valid certificates. Self-signed certificates are not supported and will cause subscription validation to fail.
+HTTPS endpoints must use publicly trusted TLS-certificates. Self-signed certificates are not supported and will cause subscription validation to fail.
 {{% /notice %}}
 
 Endpoint should respond with 200 OK when an event is received. 

--- a/content/events/subscribe-to-events/developer-guides/setup-subscription/_index.nb.md
+++ b/content/events/subscribe-to-events/developer-guides/setup-subscription/_index.nb.md
@@ -46,7 +46,7 @@ hvis abonnementsforespørselen din ikke blir akseptert.
 - webhook-URL for å motta HTTP POST-forespørsel fra Altinn Events
 
 {{% notice warning %}}
-HTTPS-endepunkter må bruke offentlig gyldige sertifikater. Selvsignerte sertifikater støttes ikke og vil føre til at abonnementsvalidering feiler.
+HTTPS-endepunkter må bruke offentlig gyldige TLS-sertifikater. Selvsignerte sertifikater støttes ikke og vil føre til feil ved validering av abonnement.
 {{% /notice %}}
 
 Endepunktet bør svare med 200 OK når en hendelse mottas. 


### PR DESCRIPTION
Resolving https://github.com/Altinn/altinn-events/issues/733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a warning clarifying that subscription endpoints using HTTPS must have publicly valid certificates; self-signed certificates are not supported and will cause validation to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->