### PR TITLE
Feature/profile update org address

### DIFF
--- a/content/api/profile/reference/organization-notification-addresses/_index.en.md
+++ b/content/api/profile/reference/organization-notification-addresses/_index.en.md
@@ -45,7 +45,7 @@ In the path for managing notification addresses, you must include the organizati
     * **countryCode** (string) Country code belonging to the phone number.
 
 {{% notice warning  %}}
-**Updating an address may result in a new id**
+**Updating an address may result in a new ID**
 If you update an address to a value (email or phone number) that has been used before for the selected organization, you may receive the old `notificationAddressId` in return. 
 Therefore, it is important to always check the response when you have changed a notification address.
 {{% / notice %}}

--- a/content/api/profile/reference/organization-notification-addresses/_index.nb.md
+++ b/content/api/profile/reference/organization-notification-addresses/_index.nb.md
@@ -46,6 +46,6 @@ I stien for å administrere varslingsadresser må man ha med organisasjonsnummer
     * **countryCode** (string) Landkode som hører til telefonnummeret. 
 
 {{% notice warning  %}}
-**Oppdatering av en adresse kan føre til en ny id**
+**Oppdatering av en adresse kan føre til en ny ID**
 Dersom man oppdaterer en adresse til en verdi(e-post eller telefonnummer) som har blitt brukt før for valgte virksomhet, kan man få tilbake den gamle `notificationAddressId`. Derfor er det viktig å alltid sjekke responsen når man har endret en varslingsadresse. 
 {{% / notice %}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that updating notification addresses is supported by the API.
  * Added a warning about possible reuse of old notification address IDs when updating to a previously used email or phone number, advising users to verify the response after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->