### PR TITLE
docs: Added recommendation rutine for access control

### DIFF
--- a/content/altinn-studio/reference/access-management/studio/_index.en.md
+++ b/content/altinn-studio/reference/access-management/studio/_index.en.md
@@ -29,6 +29,11 @@ As a member of this team, you can:
 #### Configuration
 This team is standard in all organizations and it is not possible to change the configuration for this team.
 
+#### Recommendation: Establish routines for absence of owners
+The organization should have its own routines for managing access control if one or more owners are unavailable — for example, due to vacation, leave of absence, or role changes.
+The Norwegian Digitalisation Agency (Digitaliseringsdirektoratet) and Altinn cannot add users, change teams, or make any other modifications to an organization’s access settings. This is for security reasons. 
+We therefore recommend that the organization has clear routines in place for how to handle situations where one or more owners are unavailable.
+
 ### Deploy-Production
 Members of this team can deploy applications to the production environment.
 

--- a/content/altinn-studio/reference/access-management/studio/_index.nb.md
+++ b/content/altinn-studio/reference/access-management/studio/_index.nb.md
@@ -29,6 +29,11 @@ Som medlem i dette teamet kan man blant annet:
 #### Konfigurasjon
 Dette teamet ligger inne som standard i alle organisasjoner og det er ikke mulig å endre konfigurasjonen for dette teamet.
 
+#### Anbefaling: Ha rutiner for fravær blant eiere (owners)
+Organisasjonen må selv ha rutiner for hvordan tilgangsstyring håndteres dersom en eller flere eiere er borte – for eksempel ved ferie, permisjon eller endringer i rolle.
+Digitaliseringsdirektoratet og Altinn kan ikke legge til brukere, endre team eller gjøre andre endringer i tilgangene til organisasjonen. Dette er av sikkerhetshensyn.
+Vi anbefaler derfor at organisasjonen har tydelige rutiner for hva som skjer dersom eier(e) er utilgjengelig.
+
 ### Deploy-Production
 Medlemmer i dette teamet kan deploye applikasjoner til produksjonsmiljøet.
 


### PR DESCRIPTION
This PR adds a new section to the Altinn Studio access management documentation with a recommendation that organizations should have rutines to access control when owners are unavailable.