### PR TITLE
Clarify the ip-annotation for event-subscriptions

### DIFF
--- a/content/events/subscribe-to-events/_index.en.md
+++ b/content/events/subscribe-to-events/_index.en.md
@@ -45,7 +45,7 @@ See more details in the developer guides
 
 ### IP for outgoing traffic
 {{% notice info %}}
-A static IP is used when pushing events to allow subscribers to whitelist the IP address. </br> </br>
+A static IP is used when pushing events to allow subscribers to whitelist the IP address. The addresses are provided in CIDR notation. </br> </br>
 __TT02__: 20.100.24.41/32  </br> </br>
 __Production__: 20.100.46.139/32
 {{% /notice %}}

--- a/content/events/subscribe-to-events/_index.nb.md
+++ b/content/events/subscribe-to-events/_index.nb.md
@@ -45,7 +45,7 @@ Se flere detaljer i utviklerguidene
 
 ### IP for utgående trafikk
 {{% notice info %}}
-En statisk IP brukes når hendelser pushes for å la abonnenter hviteliste IP-adressen. </br> </br>
+En statisk IP brukes når hendelser pushes for å la abonnenter hviteliste IP-adressen. Adressene er oppgitt i CIDR-notasjon. </br> </br>
 __TT02__: 20.100.24.41/32  </br> </br>
 __Produksjon__: 20.100.46.139/32
 {{% /notice %}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the “IP for outgoing traffic” notice in the “Subscribe to events” docs: static IP addresses are explicitly provided in CIDR notation.
  * Applied updates to both English and Norwegian Bokmål pages for consistency.
  * Aids users in configuring firewall rules and allowlists correctly.
  * No functional changes to features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->