### PR TITLE
Update swagger spec with more coherent names

### DIFF
--- a/static/swagger/altinn-platform-profile-v1.json
+++ b/static/swagger/altinn-platform-profile-v1.json
@@ -1,11 +1,11 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
-    "title": "Altinn Platform Profile",
+    "title": "Altinn Profile",
     "version": "v1"
   },
   "paths": {
-    "/users/current/party-groups/favorites": {
+    "/profile/api/v1/users/current/party-groups/favorites": {
       "get": {
         "tags": [
           "Favorites"
@@ -28,7 +28,7 @@
         }
       }
     },
-    "/users/current/party-groups/favorites/{partyUuid}": {
+    "/profile/api/v1/users/current/party-groups/favorites/{partyUuid}": {
       "put": {
         "tags": [
           "Favorites"
@@ -54,6 +54,9 @@
           },
           "400": {
             "description": "Bad Request"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       },
@@ -80,13 +83,16 @@
           "400": {
             "description": "Bad Request"
           },
+          "403": {
+            "description": "Forbidden"
+          },
           "404": {
             "description": "Returns status code 404 if the party was not found in favorites"
           }
         }
       }
     },
-    "/users/current/notificationsettings/parties/{partyUuid}": {
+    "/profile/api/v1/users/current/notificationsettings/parties/{partyUuid}": {
       "get": {
         "tags": [
           "NotificationsSettings"
@@ -110,13 +116,16 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProfessionalNotificationAddressResponse"
+                  "$ref": "#/components/schemas/NotificationSettingsResponse"
                 }
               }
             }
           },
           "400": {
             "description": "Bad Request"
+          },
+          "403": {
+            "description": "Forbidden"
           },
           "404": {
             "description": "Not Found"
@@ -145,7 +154,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ProfessionalNotificationAddressRequest"
+                "$ref": "#/components/schemas/NotificationSettingsRequest"
               }
             }
           }
@@ -159,6 +168,9 @@
           },
           "400": {
             "description": "Bad Request"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       },
@@ -185,7 +197,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProfessionalNotificationAddressResponse"
+                  "$ref": "#/components/schemas/NotificationSettingsResponse"
                 }
               }
             }
@@ -199,7 +211,7 @@
         }
       }
     },
-    "/organizations/{organizationNumber}/notificationaddresses/mandatory": {
+    "/profile/api/v1/organizations/{organizationNumber}/notificationaddresses/mandatory": {
       "get": {
         "tags": [
           "Organizations"
@@ -253,7 +265,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/NotificationAddressModel"
+                "$ref": "#/components/schemas/NotificationAddressRequest"
               }
             }
           }
@@ -295,7 +307,7 @@
         }
       }
     },
-    "/organizations/{organizationNumber}/notificationaddresses/mandatory/{notificationAddressId}": {
+    "/profile/api/v1/organizations/{organizationNumber}/notificationaddresses/mandatory/{notificationAddressId}": {
       "get": {
         "tags": [
           "Organizations"
@@ -367,7 +379,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/NotificationAddressModel"
+                "$ref": "#/components/schemas/NotificationAddressRequest"
               }
             }
           }
@@ -455,7 +467,7 @@
         }
       }
     },
-    "/users/{userID}": {
+    "/profile/api/v1/users/{userID}": {
       "get": {
         "tags": [
           "Users"
@@ -490,7 +502,7 @@
         }
       }
     },
-    "/users/byuuid/{userUuid}": {
+    "/profile/api/v1/users/byuuid/{userUuid}": {
       "get": {
         "tags": [
           "Users"
@@ -525,7 +537,7 @@
         }
       }
     },
-    "/users/current": {
+    "/profile/api/v1/users/current": {
       "get": {
         "tags": [
           "Users"
@@ -548,7 +560,7 @@
         }
       }
     },
-    "/users": {
+    "/profile/api/v1/users": {
       "post": {
         "tags": [
           "Users"
@@ -609,7 +621,7 @@
         "additionalProperties": false,
         "description": "GroupResponse is used to represent a group of parties"
       },
-      "NotificationAddressModel": {
+      "NotificationAddressRequest": {
         "type": "object",
         "properties": {
           "countryCode": {
@@ -663,6 +675,70 @@
         },
         "additionalProperties": false,
         "description": "Represents a notification address"
+      },
+      "NotificationSettingsRequest": {
+        "type": "object",
+        "properties": {
+          "emailAddress": {
+            "pattern": "^((\"[^\"]+\")|(([a-zA-Z0-9!#$%&'*+\\-=?\\^_`{|}~])+(\\.([a-zA-Z0-9!#$%&'*+\\-=?\\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\\.)|[a-zA-Z0-9æøåÆØÅ]\\.){1,9})([a-zA-Z]{2,14}))|((\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})))$",
+            "type": "string",
+            "description": "The email address. May be null if no email address is set.",
+            "nullable": true
+          },
+          "phoneNumber": {
+            "pattern": "^(([0-9]{5})|([0-9]{8})|((00[0-9]{2})[0-9]+)|((\\+[0-9]{2})[0-9]+))$",
+            "type": "string",
+            "description": "The phone number. May be null if no phone number is set.",
+            "nullable": true
+          },
+          "resourceIncludeList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "A list of resources that the user has registered to receive notifications for. The format is in URN. This is used to determine which resources the user can receive notifications for.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Request model for the professional notification address for an organization, also called personal notification address."
+      },
+      "NotificationSettingsResponse": {
+        "type": "object",
+        "properties": {
+          "emailAddress": {
+            "pattern": "^((\"[^\"]+\")|(([a-zA-Z0-9!#$%&'*+\\-=?\\^_`{|}~])+(\\.([a-zA-Z0-9!#$%&'*+\\-=?\\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\\.)|[a-zA-Z0-9æøåÆØÅ]\\.){1,9})([a-zA-Z]{2,14}))|((\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})))$",
+            "type": "string",
+            "description": "The email address. May be null if no email address is set.",
+            "nullable": true
+          },
+          "phoneNumber": {
+            "pattern": "^(([0-9]{5})|([0-9]{8})|((00[0-9]{2})[0-9]+)|((\\+[0-9]{2})[0-9]+))$",
+            "type": "string",
+            "description": "The phone number. May be null if no phone number is set.",
+            "nullable": true
+          },
+          "resourceIncludeList": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "A list of resources that the user has registered to receive notifications for. The format is in URN. This is used to determine which resources the user can receive notifications for.",
+            "nullable": true
+          },
+          "userId": {
+            "type": "integer",
+            "description": "The user id of logged-in user for whom the specific contact information belongs to.",
+            "format": "int32"
+          },
+          "partyUuid": {
+            "type": "string",
+            "description": "Id of the party",
+            "format": "uuid"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Response model for the professional notification address for an organization, also called personal notification address."
       },
       "Organization": {
         "type": "object",
@@ -919,70 +995,6 @@
           }
         },
         "additionalProperties": { }
-      },
-      "ProfessionalNotificationAddressRequest": {
-        "type": "object",
-        "properties": {
-          "emailAddress": {
-            "pattern": "^((\"[^\"]+\")|(([a-zA-Z0-9!#$%&'*+\\-=?\\^_`{|}~])+(\\.([a-zA-Z0-9!#$%&'*+\\-=?\\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\\.)|[a-zA-Z0-9æøåÆØÅ]\\.){1,9})([a-zA-Z]{2,14}))|((\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})))$",
-            "type": "string",
-            "description": "The email address. May be null if no email address is set.",
-            "nullable": true
-          },
-          "phoneNumber": {
-            "pattern": "^(([0-9]{5})|([0-9]{8})|((00[0-9]{2})[0-9]+)|((\\+[0-9]{2})[0-9]+))$",
-            "type": "string",
-            "description": "The phone number. May be null if no phone number is set.",
-            "nullable": true
-          },
-          "resourceIncludeList": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "A list of resources that the user has registered to receive notifications for. The format is in URN. This is used to determine which resources the user can receive notifications for.",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false,
-        "description": "Request model for the professional notification address for an organization, also called personal notification address."
-      },
-      "ProfessionalNotificationAddressResponse": {
-        "type": "object",
-        "properties": {
-          "emailAddress": {
-            "pattern": "^((\"[^\"]+\")|(([a-zA-Z0-9!#$%&'*+\\-=?\\^_`{|}~])+(\\.([a-zA-Z0-9!#$%&'*+\\-=?\\^_`{|}~])+)*))@((((([a-zA-Z0-9æøåÆØÅ]([a-zA-Z0-9\\-æøåÆØÅ]{0,61})[a-zA-Z0-9æøåÆØÅ]\\.)|[a-zA-Z0-9æøåÆØÅ]\\.){1,9})([a-zA-Z]{2,14}))|((\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})))$",
-            "type": "string",
-            "description": "The email address. May be null if no email address is set.",
-            "nullable": true
-          },
-          "phoneNumber": {
-            "pattern": "^(([0-9]{5})|([0-9]{8})|((00[0-9]{2})[0-9]+)|((\\+[0-9]{2})[0-9]+))$",
-            "type": "string",
-            "description": "The phone number. May be null if no phone number is set.",
-            "nullable": true
-          },
-          "resourceIncludeList": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "A list of resources that the user has registered to receive notifications for. The format is in URN. This is used to determine which resources the user can receive notifications for.",
-            "nullable": true
-          },
-          "userId": {
-            "type": "integer",
-            "description": "The user id of logged-in user for whom the specific contact information belongs to.",
-            "format": "int32"
-          },
-          "partyUuid": {
-            "type": "string",
-            "description": "Id of the party",
-            "format": "uuid"
-          }
-        },
-        "additionalProperties": false,
-        "description": "Response model for the professional notification address for an organization, also called personal notification address."
       },
       "ProfileSettingPreference": {
         "type": "object",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced NotificationSettings request/response schemas (email, phone, resource includes) and updated related endpoints.
  - Added Forbidden (403) responses to relevant operations.

- Documentation
  - OpenAPI spec updated to 3.0.4 with revised API title.
  - All endpoints documented under new base path: /profile/api/v1.

- Chores
  - Replaced deprecated ProfessionalNotificationAddress types with NotificationSettings equivalents.
  - Renamed NotificationAddress request schema to align with current usage.
  - Updated favorites and notification-related endpoints to reference new schemas and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->