### PR TITLE
fix: Fixed overflowing code tags

### DIFF
--- a/themes/hugo-theme-altinn/static/css/theme.css
+++ b/themes/hugo-theme-altinn/static/css/theme.css
@@ -641,6 +641,7 @@ code {
     border: 1px solid #fbf0cb;
     padding: 0px 2px;
     white-space : pre-wrap !important;
+    word-wrap: break-word;
 }
 code + .copy-to-clipboard {
     margin-left: -1px;


### PR DESCRIPTION
Closes issue #2316.

**Screenshot:**
<img width="817" height="152" alt="image" src="https://github.com/user-attachments/assets/79ce6984-9c3e-44a5-9224-f90fd9cda833" />
