### PR TITLE
Add pagefind search filtering

### DIFF
--- a/content/altinn-studio/_index.en.md
+++ b/content/altinn-studio/_index.en.md
@@ -6,6 +6,9 @@ aliases:
 - /teknologi/altinnstudio/solutions/altinn-studio/
 - /app/
 weight: 1
+cascade:
+  params:
+    product: product_studio
 ---
  <div class="row adocs-featuredBlocks">
     <div class="col-12 col-lg-6 mb-5">

--- a/content/altinn-studio/_index.nb.md
+++ b/content/altinn-studio/_index.nb.md
@@ -6,6 +6,9 @@ aliases:
 - /nb/teknologi/altinnstudio/solutions/altinn-studio/
 - /nb/app/
 weight: 1
+cascade:
+  params:
+    product: product_studio
 ---
  <div class="row adocs-featuredBlocks">
     <div class="col-12 col-lg-6 mb-5">

--- a/content/altinn-studio/about/_index.en.md
+++ b/content/altinn-studio/about/_index.en.md
@@ -5,6 +5,9 @@ aliases:
 - /altinn-studio/
 - /technology/altinnstudio/solutions/altinn-studio/
 weight: 10
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 Altinn Studio is a platform for developing, operating, and managing digital services for citizens and businesses. The platform 

--- a/content/altinn-studio/about/_index.nb.md
+++ b/content/altinn-studio/about/_index.nb.md
@@ -4,6 +4,9 @@ description: Overordnet beskrivelse av Altinn Studio
 aliases:
 - /nb/teknologi/altinnstudio/solutions/altinn-studio/
 weight: 10
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 Altinn Studio er en plattform for å utvikle, drifte og forvalte digitale tjenester til innbyggere og næringsliv. Plattformen

--- a/content/altinn-studio/concepts/_index.en.md
+++ b/content/altinn-studio/concepts/_index.en.md
@@ -2,6 +2,9 @@
 title: Concepts
 description: Explanation of concepts in Altinn Studio
 weight: 50
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 {{<children />}}

--- a/content/altinn-studio/concepts/_index.nb.md
+++ b/content/altinn-studio/concepts/_index.nb.md
@@ -2,6 +2,9 @@
 title: Konsepter
 description: Forklaring av konsepter i Altinn Studio
 weight: 50
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 {{<children />}}

--- a/content/altinn-studio/getting-started/_index.en.md
+++ b/content/altinn-studio/getting-started/_index.en.md
@@ -2,8 +2,14 @@
 title: Getting Started
 description: Get started with developing services in Altinn Studio
 weight: 21
+cascade:
+  params:
+    diataxis: diataxis_tutorials
 ---
-{{<children />}}
 
 ## Create a service with a basic form
-Get started with creating services on Altinn Studio by following our [guide for creating a basic form](../guides/development/basic-form/) or by trying out our [service development course](./app-dev-course/).
+Get started with creating services on Altinn Studio by following our
+[guide for creating a basic form](../guides/development/basic-form/) or by trying out our
+[service development course](./app-dev-course/).
+
+{{<children />}}

--- a/content/altinn-studio/getting-started/_index.nb.md
+++ b/content/altinn-studio/getting-started/_index.nb.md
@@ -2,10 +2,14 @@
 title: Kom i gang
 description: Kom i gang med utvikling av tjenester i Altinn Studio
 weight: 21
+cascade:
+  params:
+    diataxis: diataxis_tutorials
 ---
-{{<children />}}
 
 ## Lag en tjeneste med enkelt skjema
 Kom i gang med å lage tjenester på Altinn Studio ved å følge vår 
 [guide for å lage et enkelt skjema](../guides/development/basic-form/) eller ved å prøve deg på vårt
 [tjenesteutviklingskurs](./app-dev-course/).
+
+{{<children />}}

--- a/content/altinn-studio/guides/_index.en.md
+++ b/content/altinn-studio/guides/_index.en.md
@@ -2,6 +2,9 @@
 title: User guides
 description: User guides in Altinn Studio
 weight: 24
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 {{<children />}}

--- a/content/altinn-studio/guides/_index.nb.md
+++ b/content/altinn-studio/guides/_index.nb.md
@@ -2,6 +2,9 @@
 title: Guider
 description: Guider i Altinn Studio
 weight: 25
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 {{<children />}}

--- a/content/altinn-studio/reference/_index.en.md
+++ b/content/altinn-studio/reference/_index.en.md
@@ -2,6 +2,9 @@
 title: Reference
 description: Reference documentation for Altinn Studio
 weight: 40
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 {{<children />}}

--- a/content/altinn-studio/reference/_index.nb.md
+++ b/content/altinn-studio/reference/_index.nb.md
@@ -2,6 +2,9 @@
 title: Referanse
 description: Referanse-dokumentasjon for Altinn Studio
 weight: 40
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 {{<children />}}

--- a/content/api/_index.en.md
+++ b/content/api/_index.en.md
@@ -7,6 +7,9 @@ weight: 20
 aliases:
  - /altinn-api/
  - /teknologi/altinnstudio/altinn-api/
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 ## The APIs

--- a/content/api/_index.nb.md
+++ b/content/api/_index.nb.md
@@ -5,6 +5,9 @@ description: Beskrivelse av ulike Altinn API for sluttbrukere og applikasjonseie
 toc: true
 weight: 20
 tags: [translate-to-norwegian]
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 ## API-ene

--- a/content/api/accessmanagement/_index.en.md
+++ b/content/api/accessmanagement/_index.en.md
@@ -2,6 +2,9 @@
 title: Access Management
 linktitle: Access Management
 description: Documentation of available Access Management APIs in Altinn 3
+cascade:
+  params:
+    product: product_authorization
 ---
 
 {{<children />}}

--- a/content/api/accessmanagement/_index.nb.md
+++ b/content/api/accessmanagement/_index.nb.md
@@ -2,6 +2,9 @@
 title: Access Management
 linktitle: Access Management
 description: Beskrivelse av tilgjengelige API knyttet til Tilgangsstyring i Altinn 3
+cascade:
+  params:
+    product: product_authorization
 ---
 
 {{<children />}}

--- a/content/api/apps/_index.en.md
+++ b/content/api/apps/_index.en.md
@@ -6,6 +6,9 @@ toc: false
 tags: [api]
 aliases:
 - /teknologi/altinnstudio/altinn-api/app-api/
+cascade:
+  params:
+    product: product_studio
 ---
 
 ## Overview

--- a/content/api/apps/_index.nb.md
+++ b/content/api/apps/_index.nb.md
@@ -4,6 +4,9 @@ linktitle: App
 description: Standard-API-er eksponert av apper i Altinn 3
 toc: false
 tags: [api]
+cascade:
+  params:
+    product: product_studio
 ---
 
 ## Oversikt

--- a/content/api/authentication/_index.en.md
+++ b/content/api/authentication/_index.en.md
@@ -2,6 +2,9 @@
 title: Authentication API
 linktitle: Authentication
 description: Description of how systems and service owners can use Maskinporten or ID-porten to access APIs in Altinn 3
+cascade:
+  params:
+    product: product_authorization
 ---
 
 {{<children />}}

--- a/content/api/authentication/_index.nb.md
+++ b/content/api/authentication/_index.nb.md
@@ -2,6 +2,9 @@
 title: Authentication API
 linktitle: Authentication
 description: Beskrivelse av hvordan systemer og tjenesteeiere kan benytte Maskinporten eller ID-porten for å få tilgang til API-er i Altinn 3
+cascade:
+  params:
+    product: product_authorization
 ---
 
 {{<children />}}

--- a/content/api/authorization/_index.en.md
+++ b/content/api/authorization/_index.en.md
@@ -2,6 +2,9 @@
 title: Authorization API
 linktitle: Authorization
 description: Description of how systems and service owners can use Maskinporten or ID-porten to access APIs in Altinn 3
+cascade:
+  params:
+    product: product_authorization
 ---
 
 {{<children />}}

--- a/content/api/authorization/_index.nb.md
+++ b/content/api/authorization/_index.nb.md
@@ -2,6 +2,9 @@
 title: Authorization API
 linktitle: Authorization
 description: Beskrivelse av hvordan systemer og tjenesteeiere kan benytte Maskinporten eller ID-porten for å få tilgang til API-er i Altinn 3
+cascade:
+  params:
+    product: product_authorization
 ---
 
 {{<children />}}

--- a/content/api/broker/_index.en.md
+++ b/content/api/broker/_index.en.md
@@ -2,6 +2,9 @@
 title: Broker API
 linktitle: Broker
 description: API for Altinn 3 Broker functionality
+cascade:
+  params:
+    product: product_broker
 ---
 
 {{<children />}}

--- a/content/api/broker/_index.nb.md
+++ b/content/api/broker/_index.nb.md
@@ -2,6 +2,9 @@
 title: Formidlingstjenesten
 linktitle: Formidling
 description: API for Altinn 3 formidlingstjeneste
+cascade:
+  params:
+    product: product_broker
 ---
 
 {{<children />}}

--- a/content/api/correspondence/_index.en.md
+++ b/content/api/correspondence/_index.en.md
@@ -2,6 +2,9 @@
 title: Correspondence API
 linktitle: Correspondence
 description: API for Altinn 3 Correspondence functionality
+cascade:
+  params:
+    product: product_correspondence
 ---
 
 {{<children />}}

--- a/content/api/correspondence/_index.nb.md
+++ b/content/api/correspondence/_index.nb.md
@@ -2,6 +2,9 @@
 title: Meldingstjenesten
 linktitle: Melding
 description: API for Altinn 3 Meldingstjeneste
+cascade:
+  params:
+    product: product_correspondence
 ---
 
 {{<children />}}

--- a/content/api/dialogporten/_index.en.md
+++ b/content/api/dialogporten/_index.en.md
@@ -2,6 +2,9 @@
 title: Dialogporten API
 linktitle: Dialogporten
 description: API for Dialogporten functionality
+cascade:
+  params:
+    product: product_dialogporten
 ---
 
 Please refer to the following sections for Dialogporten API reference information

--- a/content/api/guides/_index.md
+++ b/content/api/guides/_index.md
@@ -5,6 +5,9 @@ description: Here you will find guides on how to integrate with the Altinn API
 tags: [architecture, devops, integration]
 toc: false
 hidden: false
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 We have divided the guides into two main areas based on use cases.

--- a/content/api/guides/_index.nb.md
+++ b/content/api/guides/_index.nb.md
@@ -5,6 +5,9 @@ description: Her finner du guider for hvordan man kan integrere seg med Altinn A
 tags: [architecture, devops, integration]
 toc: false
 hidden: false
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 Vi har delt guidene inn i to hovedområder basert på bruksområder.

--- a/content/api/resourceregistry/_index.en.md
+++ b/content/api/resourceregistry/_index.en.md
@@ -2,6 +2,9 @@
 title: Resource Registry API
 linktitle: Resource Registry
 description: Description of the Altinn 3 APIs supported by the Resource Registry component
+cascade:
+  params:
+    product: product_authorization
 ---
 
 {{<children />}}

--- a/content/api/resourceregistry/_index.nb.md
+++ b/content/api/resourceregistry/_index.nb.md
@@ -2,6 +2,9 @@
 title: Resource Registry API
 linktitle: Resource Registry
 description: Beskrivelse av API-et til Resource Registry-komponenten
+cascade:
+  params:
+    product: product_authorization
 ---
 
 {{<children />}}

--- a/content/api/storage/_index.en.md
+++ b/content/api/storage/_index.en.md
@@ -2,6 +2,9 @@
 title: Storage API
 linktitle: Storage
 description: Description of the Altinn 3 APIs supported by the storage component in the Altinn 3 Platform
+cascade:
+  params:
+    product: product_studio
 ---
 
 ## The two primary data structures

--- a/content/api/storage/_index.nb.md
+++ b/content/api/storage/_index.nb.md
@@ -2,6 +2,9 @@
 title: Storage API
 linktitle: Storage
 description: Beskrivelse av API-et til Storage-komponenten i Altinn 3-plattformen
+cascade:
+  params:
+    product: product_studio
 ---
 
 ## De to primære datastrukturene

--- a/content/api/studio/_index.en.md
+++ b/content/api/studio/_index.en.md
@@ -3,6 +3,9 @@ title: Altinn Studio Repository API
 linktitle: Studio
 description: The OpenAPI (swagger) specification for Altinn Studio
 toc: true
+cascade:
+  params:
+    product: product_studio
 ---
 
 See https://altinn.studio/repos/api/swagger

--- a/content/api/studio/_index.nb.md
+++ b/content/api/studio/_index.nb.md
@@ -2,6 +2,9 @@
 title: Altinn Studio Repository API
 linktitle: Studio
 description: OpenAPI (swagger)-spesifikasjon for Altinn Studio
+cascade:
+  params:
+    product: product_studio
 ---
 
 Se https://altinn.studio/repos/api/swagger

--- a/content/authorization/_index.md
+++ b/content/authorization/_index.md
@@ -1,12 +1,13 @@
 ---
 title: Authorization
-linktitle: Authorization
 description: The authorization components provide access management and control functionality for digital and analog services hosted in the Altinn Platform or other places.
-tags: [architecture, solution]
 toc: false
 weight: 1
 aliases:
   - /technology/solutions/altinn-platform/authorization/
+cascade:
+  params:
+    product: product_authorization
 ---
 
 {{<children />}}

--- a/content/authorization/_index.nb.md
+++ b/content/authorization/_index.nb.md
@@ -1,12 +1,13 @@
 ---
 title: Autorisasjon
-linktitle: Autorisasjon
 description: Altinn Autorisasjon er en samling løsninger som gir tilgangsstyring og tilgangskontroll for digitale og analoge tjenester som kjører i Altinn-plattformen eller andre steder.
-tags: [architecture, solution]
 toc: false
 weight: 1
 aliases:
   - /technology/solutions/altinn-platform/authorization/
+cascade:
+  params:
+    product: product_authorization
 ---
 
 {{<children />}}

--- a/content/authorization/about/_index.md
+++ b/content/authorization/about/_index.md
@@ -2,11 +2,13 @@
 title: About Authorization
 linktitle: About Authorization
 description: The authorization components provide access management and control functionality for digital and analog services hosted in the Altinn Platform or other places.
-tags: [architecture, solution]
 toc: false
 weight: 1
 aliases:
  - /technology/solutions/altinn-platform/authorization/
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 The typical scenario is that some event will be triggered, or data will be read, updated, or created by a digital or analog service. A service owner owns this service and has defined some business rules for who is allowed to use the service.

--- a/content/authorization/about/_index.nb.md
+++ b/content/authorization/about/_index.nb.md
@@ -7,6 +7,9 @@ toc: false
 weight: 1
 aliases:
   - /technology/solutions/altinn-platform/authorization/
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 Det typiske scenariet er at en hendelse vil bli utløst, eller data vil bli lest, oppdatert eller opprettet av en digital eller analog tjeneste. En tjenesteeier eier denne tjenesten og har definert noen forretningsregler for hvem som har lov til å bruke tjenesten.

--- a/content/authorization/getting-started/_index.md
+++ b/content/authorization/getting-started/_index.md
@@ -4,6 +4,9 @@ linktitle: Getting started
 description: Getting started
 toc: false
 weight: 3
+cascade:
+  params:
+    diataxis: diataxis_tutorials
 ---
 
 ## Resource Administration in Altinn Studio

--- a/content/authorization/getting-started/_index.nb.md
+++ b/content/authorization/getting-started/_index.nb.md
@@ -4,6 +4,9 @@ linktitle: Kom i gang
 description: Her finner informasjon om hvordan komme i gang med Altinn autorisasjon
 toc: false
 weight: 3
+cascade:
+  params:
+    diataxis: diataxis_tutorials
 ---
 
 ## Ressursadministrasjon i Altinn Studio

--- a/content/authorization/guides/_index.md
+++ b/content/authorization/guides/_index.md
@@ -4,6 +4,9 @@ linktitle: User Guides
 description: Read our collection of user guides related to Altinn Authorization.
 toc: false
 weight: 4
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 ## Creating and publishing resources in Altinn Studio

--- a/content/authorization/guides/_index.nb.md
+++ b/content/authorization/guides/_index.nb.md
@@ -4,6 +4,9 @@ linktitle: Brukerveiledninger
 description: Les vår samling av brukerveiledninger knyttet til Altinn Autorisasjon.
 toc: false
 weight: 4
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 ## Inndeling

--- a/content/authorization/reference/_index.md
+++ b/content/authorization/reference/_index.md
@@ -4,7 +4,9 @@ linktitle: Reference
 description: Reference
 toc: false
 weight: 5
-aliases:
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 {{<children />}}

--- a/content/authorization/reference/_index.nb.md
+++ b/content/authorization/reference/_index.nb.md
@@ -4,7 +4,9 @@ linktitle: Reference
 description: Reference
 toc: false
 weight: 5
-aliases:
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 {{<children />}}

--- a/content/broker/_index.en.md
+++ b/content/broker/_index.en.md
@@ -2,9 +2,11 @@
 title: Altinn 3 Broker
 linktitle: Broker
 description: Altinn 3 Broker offers managed file transfer with support for large files and advanced features for information security, status monitoring and quality of service.
-tags: [Broker]
 toc: false
 weight: 1
+cascade:
+  params:
+    product: product_broker
 ---
 
 

--- a/content/broker/_index.nb.md
+++ b/content/broker/_index.nb.md
@@ -2,9 +2,11 @@
 title: Altinn 3 Formidling
 linktitle: Formidling
 description: Altinn 3 Formidling ('Broker' på engelsk) tilbyr styrt filoverføring med støtte for store filer og avansert funksjonalitet for informasjonssikkerhet, statusmonitorering og tjenestekvalitet.   
-tags: [Broker, Formidling]
 toc: false
 weight: 1
+cascade:
+  params:
+    product: product_broker
 ---
 
 {{<children />}}

--- a/content/broker/about/_index.en.md
+++ b/content/broker/about/_index.en.md
@@ -5,6 +5,9 @@ description: What is Altinn 3 Broker?
 tags: []
 toc: true
 weight: 1
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 <!--

--- a/content/broker/about/_index.nb.md
+++ b/content/broker/about/_index.nb.md
@@ -5,6 +5,9 @@ description: Hva er Altinn Formidling?
 tags: []
 toc: true
 weight: 1
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 <!--

--- a/content/broker/explanation/_index.en.md
+++ b/content/broker/explanation/_index.en.md
@@ -5,6 +5,9 @@ description: Explanation of concepts related to Altinn 3 Broker
 tags: []
 toc: false
 weight: 50
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 {{<children />}}

--- a/content/broker/explanation/_index.nb.md
+++ b/content/broker/explanation/_index.nb.md
@@ -5,6 +5,9 @@ description: Forklaring om konsepter for Altinn 3 Formidling
 tags: []
 toc: false
 weight: 50
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 {{<children />}}

--- a/content/broker/getting-started/_index.en.md
+++ b/content/broker/getting-started/_index.en.md
@@ -5,6 +5,9 @@ description: Tutorials for how to get started with Altinn 3 Broker, for service 
 tags: []
 toc: false
 weight: 30
+cascade:
+  params:
+    diataxis: diataxis_tutorials
 ---
 
 {{<children />}}

--- a/content/broker/getting-started/_index.nb.md
+++ b/content/broker/getting-started/_index.nb.md
@@ -5,6 +5,9 @@ description: Lær om hvordan komme i gang med Altinn 3 Formidling, for tjenestee
 tags: []
 toc: false
 weight: 30
+cascade:
+  params:
+    diataxis: diataxis_tutorials
 ---
 
 {{<children />}}

--- a/content/broker/guides/_index.en.md
+++ b/content/broker/guides/_index.en.md
@@ -6,6 +6,9 @@ tags: []
 toc: false
 weight: 40
 hidden: true
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 {{<children />}}

--- a/content/broker/guides/_index.nb.md
+++ b/content/broker/guides/_index.nb.md
@@ -6,6 +6,9 @@ tags: []
 toc: false
 weight: 40
 hidden: true
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 {{% notice warning  %}}

--- a/content/broker/reference/_index.en.md
+++ b/content/broker/reference/_index.en.md
@@ -5,6 +5,9 @@ description: Reference documentation for Altinn 3 Broker
 tags: []
 toc: false
 weight: 70
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 {{<children />}}

--- a/content/broker/reference/_index.nb.md
+++ b/content/broker/reference/_index.nb.md
@@ -5,6 +5,9 @@ description: Referansedokumentasjon for Altinn 3 Formidling
 tags: []
 toc: true
 weight: 70
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 

--- a/content/correspondence/_index.en.md
+++ b/content/correspondence/_index.en.md
@@ -2,9 +2,11 @@
 title: Altinn 3 Correspondence
 linktitle: Correspondence
 description: Altinn 3 Correspondence is a messaging service, enabling the secure exchange of correspondence, such as official letters, notifications, and other documents, between public agencies and individuals or businesses.
-tags: [architecture, solution]
 toc: false
 weight: 1
+cascade:
+  params:
+    product: product_correspondence
 ---
 
 {{<children />}}

--- a/content/correspondence/_index.nb.md
+++ b/content/correspondence/_index.nb.md
@@ -2,9 +2,11 @@
 title: Altinn 3 Melding
 linktitle: Melding
 description: Altinn 3 Melding ('Correspondence' på engelsk) er en meldingstjeneste for sikker utveksling av korrespondanse, som offisielle brev, varsler og andre dokumenter, mellom offentlige etater og enkeltpersoner eller bedrifter.
-tags: [architecture, solution]
 toc: false
 weight: 1
+cascade:
+  params:
+    product: product_correspondence
 ---
 
 {{<children />}}

--- a/content/correspondence/about/_index.en.md
+++ b/content/correspondence/about/_index.en.md
@@ -5,6 +5,9 @@ description: What is Altinn 3 Correspondence?
 tags: []
 toc: false
 weight: 1
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 Altinn Correspondence is a service within the Altinn platform used for securely sending and receiving messages. The service is utilized by public authorities, businesses and individuals. It has integrated authorization and encryption, ensuring that important information is transmitted safely and made easily accessible to the correct recipient.  

--- a/content/correspondence/about/_index.nb.md
+++ b/content/correspondence/about/_index.nb.md
@@ -5,6 +5,9 @@ description: Altinn Melding er en sikker og effektiv digital tjeneste som gjør 
 tags: []
 toc: false
 weight: 1
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 ### I tråd med Digitaliseringsrundskrivet

--- a/content/correspondence/explanation/_index.en.md
+++ b/content/correspondence/explanation/_index.en.md
@@ -5,6 +5,9 @@ description: Explanation of concepts related to Altinn 3 Correspondence
 tags: []
 toc: false
 weight: 50
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 {{<children />}}

--- a/content/correspondence/explanation/_index.nb.md
+++ b/content/correspondence/explanation/_index.nb.md
@@ -5,6 +5,9 @@ description: Forklaring om konsepter for Altinn 3 Melding
 tags: []
 toc: false
 weight: 50
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 {{<children />}}

--- a/content/correspondence/getting-started/_index.en.md
+++ b/content/correspondence/getting-started/_index.en.md
@@ -5,6 +5,9 @@ description: You can either use Altinn as a service owner to send messages, or i
 tags: []
 toc: false
 weight: 30
+cascade:
+  params:
+    diataxis: diataxis_tutorials
 ---
 
 {{<children />}}

--- a/content/correspondence/getting-started/_index.nb.md
+++ b/content/correspondence/getting-started/_index.nb.md
@@ -5,6 +5,9 @@ description: Du kan enten bruke Altinn som tjenesteeier for å sende meldinger e
 tags: []
 toc: false
 weight: 30
+cascade:
+  params:
+    diataxis: diataxis_tutorials
 ---
 
 {{<children />}}

--- a/content/correspondence/guides/_index.en.md
+++ b/content/correspondence/guides/_index.en.md
@@ -6,6 +6,9 @@ tags: []
 toc: false
 weight: 40
 hidden: true
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 {{<children />}}

--- a/content/correspondence/guides/_index.nb.md
+++ b/content/correspondence/guides/_index.nb.md
@@ -6,6 +6,9 @@ tags: []
 toc: false
 weight: 40
 hidden: true
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 {{% notice warning  %}}

--- a/content/correspondence/reference/_index.en.md
+++ b/content/correspondence/reference/_index.en.md
@@ -5,6 +5,9 @@ description: Reference documentation for Altinn 3 Correspondence
 tags: []
 toc: false
 weight: 70
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 {{<children />}}

--- a/content/correspondence/reference/_index.nb.md
+++ b/content/correspondence/reference/_index.nb.md
@@ -5,6 +5,9 @@ description: Referansedokumentasjon for Altinn 3 Melding
 tags: []
 toc: true
 weight: 70
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 

--- a/content/dialogporten/_index.en.md
+++ b/content/dialogporten/_index.en.md
@@ -1,8 +1,10 @@
 ---
-title: 'Dialogporten'
-linktitle: 'Dialogporten'
+title: Dialogporten
 description: 'Dialogporten is a solution that allows messages and dialogs implemented on Altinn 3 and other digital service platforms accessible to end-user systems in a common format.'
 weight: 1
+cascade:
+  params:
+    product: product_dialogporten
 ---
 
 {{<notice warning>}}

--- a/content/dialogporten/_index.nb.md
+++ b/content/dialogporten/_index.nb.md
@@ -1,8 +1,10 @@
 ---
-title: 'Dialogporten'
-linktitle: 'Dialogporten'
+title: Dialogporten
 description: 'Dialogporten er en løsning som tillater meldinger og dialoger implementert på Altinn 3 og andre digitale tjenesteplattformer tilgjengelig for sluttbruker-systemer i et felles format.'
 weight: 1
+cascade:
+  params:
+    product: product_dialogporten
 ---
 
 {{<notice warning>}}

--- a/content/dialogporten/about-dialogporten/_index.en.md
+++ b/content/dialogporten/about-dialogporten/_index.en.md
@@ -2,6 +2,9 @@
 title: 'About Dialogporten'
 description: 'A brief introduction to Dialogporten.'
 weight: 10
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 ## What is Dialogporten?

--- a/content/dialogporten/about-dialogporten/_index.nb.md
+++ b/content/dialogporten/about-dialogporten/_index.nb.md
@@ -2,6 +2,9 @@
 title: 'Om Dialogporten'
 description: 'En kort introduksjon til Dialogporten.'
 weight: 10
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 ## Hva er Dialogporten?

--- a/content/dialogporten/getting-started/_index.en.md
+++ b/content/dialogporten/getting-started/_index.en.md
@@ -2,6 +2,9 @@
 title: 'Getting started'
 description: 'Learning resources for Dialogporten'
 weight: 30
+cascade:
+  params:
+    diataxis: diataxis_tutorials
 ---
 
 {{<children />}}

--- a/content/dialogporten/getting-started/_index.nb.md
+++ b/content/dialogporten/getting-started/_index.nb.md
@@ -2,6 +2,9 @@
 title: 'Komme i gang'
 description: 'Læringsressurser for Dialogporten'
 weight: 30
+cascade:
+  params:
+    diataxis: diataxis_tutorials
 ---
 
 {{<children />}}

--- a/content/dialogporten/reference/_index.en.md
+++ b/content/dialogporten/reference/_index.en.md
@@ -2,6 +2,9 @@
 title: 'Reference'
 description: 'Find technical reference information for the features Dialgporten offers'
 weight: 50
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 See the sections below for detailed technial reference information. The most important resource for you as a developer, either for a end user systems (EUS) provider or for a service owner, is the [REST OpenAPI specifications]({{<relref "./openapi">}}), as this contains detailed information on a model/field level. 

--- a/content/dialogporten/reference/_index.nb.md
+++ b/content/dialogporten/reference/_index.nb.md
@@ -2,6 +2,9 @@
 title: 'Referanse'
 description: 'Finn teknisk referanseinformasjon for funksjonene Dialogporten tilbyr'
 weight: 50
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 Se seksjonene nedenfor for detaljert teknisk referanseinformasjon. Den viktigste ressursen for deg som utvikler, enten for en sluttbrukersystem (EUS)-leverandør eller for en tjenesteeier, er [REST OpenAPI-spesifikasjonene]({{<relref "./openapi">}}), siden denne inneholder detaljert informasjon på modell-/feltnivå.

--- a/content/dialogporten/user-guides/_index.en.md
+++ b/content/dialogporten/user-guides/_index.en.md
@@ -3,6 +3,9 @@ title: 'User Guides'
 linktitle: 'User Guides'
 description: 'Guides for using Dialogporten.'
 weight: 40
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 {{<children />}}

--- a/content/dialogporten/user-guides/_index.nb.md
+++ b/content/dialogporten/user-guides/_index.nb.md
@@ -3,6 +3,9 @@ title: 'Brukerhåndbøker'
 linktitle: 'Brukerhåndbøker'
 description: 'Håndbøker for bruk av Dialogporten.'
 weight: 40
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 {{<children />}}

--- a/content/events/_index.en.md
+++ b/content/events/_index.en.md
@@ -5,6 +5,9 @@ toc: true
 weight: 20
 aliases:
  - /altinn-events/
+cascade:
+  params:
+    product: product_events
 ---
 
 ## Design goals

--- a/content/events/_index.nb.md
+++ b/content/events/_index.nb.md
@@ -5,6 +5,9 @@ toc: true
 weight: 20
 aliases:
  - /altinn-events/
+cascade:
+  params:
+    product: product_events
 ---
 
 ## Designmål

--- a/content/events/explanation/_index.en.md
+++ b/content/events/explanation/_index.en.md
@@ -2,6 +2,9 @@
 title: Explanation
 description: Underlying concepts or principle explained
 weight: 60
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 {{<children />}}

--- a/content/events/explanation/_index.nb.md
+++ b/content/events/explanation/_index.nb.md
@@ -2,6 +2,9 @@
 title: Forklaring
 description: Underliggende konsepter eller prinsipper forklart
 weight: 60
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 {{<children />}}

--- a/content/events/reference/_index.en.md
+++ b/content/events/reference/_index.en.md
@@ -2,6 +2,9 @@
 title: Reference
 description: Reference documentation for Altinn Events
 weight: 50
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 {{<children />}}

--- a/content/events/reference/_index.nb.md
+++ b/content/events/reference/_index.nb.md
@@ -2,6 +2,9 @@
 title: Referanse
 description: Referansedokumentasjon for Altinn Events
 weight: 50
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 {{<children />}}

--- a/content/notifications/_index.en.md
+++ b/content/notifications/_index.en.md
@@ -1,11 +1,13 @@
 ---
 title: Notifications
-linktitle: Notifications
 description: Altinn Notifications offers capabilities for one way communication with citizens and businesses operating in Norway.
 toc: false
 weight: 20
 aliases:
   - /altinn-notifications/
+cascade:
+  params:
+    product: product_notifications
 ---
 
  <div class="row adocs-featuredBlocks">

--- a/content/notifications/_index.nb.md
+++ b/content/notifications/_index.nb.md
@@ -1,11 +1,13 @@
 ---
 title: Varslinger
-linktitle: Varslinger
 description: Altinn Varslinger tilbyr funksjonalitet for enveis kommunikasjon med innbyggere og virksomheter i Norge.
 toc: false
 weight: 20
 aliases:
   - /altinn-notifications/
+cascade:
+  params:
+    product: product_notifications
 ---
 
  <div class="row adocs-featuredBlocks">

--- a/content/notifications/about/_index.en.md
+++ b/content/notifications/about/_index.en.md
@@ -4,6 +4,9 @@ description: High-level description of Altinn Notifications
 aliases:
 - /altinn-notifications/
 weight: 10
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 **Altinn Notifications** is a service designed to facilitate efficient communication with end users through various channels. Key features include:

--- a/content/notifications/about/_index.nb.md
+++ b/content/notifications/about/_index.nb.md
@@ -4,6 +4,9 @@ description: Overordnet beskrivelse av Altinn Varslinger
 aliases:
 - /altinn-notifications/
 weight: 10
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 **Altinn Varslinger** er en tjeneste utviklet for å fasilitere effektiv kommunikasjon med sluttbrukere gjennom ulike kanaler. Nøkkelfunksjoner inkluderer:

--- a/content/notifications/explanation/_index.en.md
+++ b/content/notifications/explanation/_index.en.md
@@ -2,6 +2,9 @@
 title: Explanation
 description: Underlying concepts or principle explained
 weight: 60
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 {{<children />}}

--- a/content/notifications/explanation/_index.nb.md
+++ b/content/notifications/explanation/_index.nb.md
@@ -2,6 +2,9 @@
 title: Forklaringer
 description: Forklaring av underliggende konsepter og prinsipper
 weight: 60
+cascade:
+  params:
+    diataxis: diataxis_explanation
 ---
 
 {{<children />}}

--- a/content/notifications/getting-started/_index.en.md
+++ b/content/notifications/getting-started/_index.en.md
@@ -2,6 +2,9 @@
 title: Getting Started
 description: Get started with sending notifications
 weight: 21
+cascade:
+  params:
+    diataxis: diataxis_tutorials
 ---
 
 {{<children />}}

--- a/content/notifications/getting-started/_index.nb.md
+++ b/content/notifications/getting-started/_index.nb.md
@@ -2,6 +2,9 @@
 title: Kom i gang
 description: Kom i gang med å sende varsler
 weight: 21
+cascade:
+  params:
+    diataxis: diataxis_tutorials
 ---
 
 {{<children />}}

--- a/content/notifications/guides/_index.en.md
+++ b/content/notifications/guides/_index.en.md
@@ -2,6 +2,9 @@
 title: User guides
 description: User guides in Altinn Notifications
 weight: 24
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 ### Guidelines on notification content

--- a/content/notifications/guides/_index.nb.md
+++ b/content/notifications/guides/_index.nb.md
@@ -2,6 +2,9 @@
 title: Brukerveiledninger
 description: Brukerveiledninger for Altinn Notifications
 weight: 24
+cascade:
+  params:
+    diataxis: diataxis_how-to-guides
 ---
 
 ### Retningslinjer for varslingsinnhold

--- a/content/notifications/reference/_index.en.md
+++ b/content/notifications/reference/_index.en.md
@@ -2,6 +2,9 @@
 title: Reference
 description: Reference documentation for Altinn Notifications
 weight: 50
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 {{<children />}}

--- a/content/notifications/reference/_index.nb.md
+++ b/content/notifications/reference/_index.nb.md
@@ -2,6 +2,9 @@
 title: 'Referanse'
 description: Referansedokumentasjon for Altinn Notifications
 weight: 50
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 {{<children />}}

--- a/content/technology/_index.en.md
+++ b/content/technology/_index.en.md
@@ -5,6 +5,9 @@ weight: 40
 aliases:
  - /altinn3/
  - /teknologi/altinnstudio/
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 Altinn Studio is the next generation Altinn application development and hosting solution.

--- a/content/technology/_index.nb.md
+++ b/content/technology/_index.nb.md
@@ -2,6 +2,9 @@
 title: Teknologi
 description: Systemdokumentasjon for Altinn Studio, Altinn Apps og Altinn Platform.
 weight: 40
+cascade:
+  params:
+    diataxis: diataxis_reference
 ---
 
 Dokumentasjon for teknologi er foreløpig [kun tilgjengelig på engelsk](/technology/).

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -33,20 +33,36 @@
   translation: technology
 - id: content
   translation: content
-- id: products
-  translation: products
-- id: studio
-  translation: Studio
-- id: authorization
+
+# Products
+- id: product
+  translation: Product
+- id: product_studio
+  translation: Altinn Studio
+- id: product_authorization
   translation: Authorization
-- id: broker
+- id: product_broker
   translation: Broker
-- id: correspondence
+- id: product_correspondence
   translation: Correspondence
-- id: notifications
-  translation: Notifications
-- id: dialogporten
+- id: product_dialogporten
   translation: Dialogporten
+- id: product_events
+  translation: Events
+- id: product_notifications
+  translation: Notifications
+
+# Diataxis
+- id: diataxis
+  translation: Type
+- id: diataxis_explanation
+  translation: Explanation
+- id: diataxis_how-to-guides
+  translation: How-to guides
+- id: diataxis_reference
+  translation: Reference
+- id: diataxis_tutorials
+  translation: Tutorials
 
 # Frontpage
 - id: altinn-your-dialogue

--- a/i18n/nb.yaml
+++ b/i18n/nb.yaml
@@ -33,20 +33,36 @@
   translation: teknologi
 - id: content
   translation: innhold
-- id: products
-  translation: produkter
-- id: studio
-  translation: Studio
-- id: authorization
+
+# Produkter
+- id: product
+  translation: Produkt
+- id: product_studio
+  translation: Altinn Studio
+- id: product_authorization
   translation: Autorisasjon
-- id: broker
+- id: product_broker
   translation: Formidling
-- id: correspondence
+- id: product_correspondence
   translation: Melding
-- id: notifications
-  translation: Varsling
-- id: dialogporten
+- id: product_dialogporten
   translation: Dialogporten
+- id: product_events
+  translation: Hendelser
+- id: product_notifications
+  translation: Varsling
+
+# Diataxis
+- id: diataxis
+  translation: Type
+- id: diataxis_explanation
+  translation: Forklaring
+- id: diataxis_how-to-guides
+  translation: Guider
+- id: diataxis_reference
+  translation: Referanse
+- id: diataxis_tutorials
+  translation: Veiledninger
 
 # Frontpage
 - id: altinn-your-dialogue

--- a/layouts/partials/product-switcher.html
+++ b/layouts/partials/product-switcher.html
@@ -1,23 +1,26 @@
 <a class="nav-link dropdown-toggle a-languageSwitcher" aria-expanded="false" data-toggle="dropdown" aria-haspopup="true" href="#">
-  <span>{{ T "products" }}</span>
+  <span>{{ T "product" }}</span>
 </a>
 <div class="dropdown-menu a-dropdown-languages a-dropdownTriangle">
     <a aria-hidden="true" class="dropdown-item" href="{{ with .Site.GetPage `/altinn-studio`}}{{.RelPermalink}}{{end}}">
-      <p class="product-item">{{ T "studio" }}</p>
+      <p class="product-item">{{ T "product_studio" }}</p>
     </a>
     <a aria-hidden="true" class="dropdown-item" href="{{ with .Site.GetPage `/authorization`}}{{.RelPermalink}}{{end}}">
-      <p class="product-item">{{ T "authorization" }}</p>
+      <p class="product-item">{{ T "product_authorization" }}</p>
     </a>
     <a aria-hidden="true" class="dropdown-item" href="{{ with .Site.GetPage `/dialogporten`}}{{.RelPermalink}}{{end}}">
-      <p class="product-item">{{ T "dialogporten" }}</p>
+      <p class="product-item">{{ T "product_dialogporten" }}</p>
     </a>
     <a aria-hidden="true" class="dropdown-item" href="{{ with .Site.GetPage `/broker`}}{{.RelPermalink}}{{end}}">
-      <p class="product-item">{{ T "broker" }}</p>
+      <p class="product-item">{{ T "product_broker" }}</p>
+    </a>
+    <a aria-hidden="true" class="dropdown-item" href="{{ with .Site.GetPage `/events`}}{{.RelPermalink}}{{end}}">
+      <p class="product-item">{{ T "product_events" }}</p>
     </a>
     <a aria-hidden="true" class="dropdown-item" href="{{ with .Site.GetPage `/correspondence`}}{{.RelPermalink}}{{end}}">
-      <p class="product-item">{{ T "correspondence" }}</p>
+      <p class="product-item">{{ T "product_correspondence" }}</p>
     </a>
     <a aria-hidden="true" class="dropdown-item" href="{{ with .Site.GetPage `/notifications`}}{{.RelPermalink}}{{end}}">
-      <p class="product-item">{{ T "notifications" }}</p>
+      <p class="product-item">{{ T "product_notifications" }}</p>
     </a>
 </div>

--- a/themes/hugo-theme-altinn/layouts/partials/meta.html
+++ b/themes/hugo-theme-altinn/layouts/partials/meta.html
@@ -1,4 +1,6 @@
 <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}" />
 <meta name="altinn_pagedir" class="elastic" content="{{ with .Page.File }}{{ .Dir }}{{ end }}" />
 <meta name="altinn_title" class="elastic" content="{{ .Title }}" />
-{{ with .Site.Params.author }}<meta name="author" content="{{ . }}" />{{ end }}
+{{ with .Page.Params.product }}<meta name="product" data-pagefind-filter="{{ T "product" }}[content]" content="{{ T . }}" />{{ end }}
+{{ with .Page.Params.diataxis }}<meta name="diataxis" data-pagefind-filter="{{ T "diataxis" }}[content]" content="{{ T . }}" />{{ end }}
+{{ with .Page.Params.author }}<meta name="author" content="{{ . }}" />{{ end }}


### PR DESCRIPTION
Added initial pagefind filtering for products and diataxis types.

No Filter:

<img width="1007" height="1102" alt="image" src="https://github.com/user-attachments/assets/da95bcb0-32e4-46e4-b071-d4ca5641dc17" />

Filter by Dialogporten:

<img width="1198" height="848" alt="image" src="https://github.com/user-attachments/assets/fbe268c8-5f3b-4d92-abb0-9032f2ecbd55" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Product switcher updated with clearer product labels and a new Events entry.
  - Search/filtering improved via new page metadata (product and content type/Diataxis).
- Documentation
  - Added consistent product and content-type metadata across sections (Studio, APIs, Authorization, Broker, Correspondence, Dialogporten, Events, Notifications, Technology).
  - Minor layout/content tweaks on some pages (e.g., repositioned children listings).
- Internationalization
  - English/Norwegian translations reorganized to product_* and diataxis_* keys.
  - Significant expansion of Norwegian frontpage translations and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->