### PR TITLE
Mark /content/shared as headless

### DIFF
--- a/content/shared/_index.md
+++ b/content/shared/_index.md
@@ -1,0 +1,3 @@
+---
+headless: true
+---


### PR DESCRIPTION
## Description
The `shared` folder contains various Maskinporten-instructions, currently `insert`-ed in other pages.

However, the folder shows up in the navigation menu, which is unwanted.

This patch (hopefully) fixes that issue 🤞 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automatic index/directory listings from appearing for the shared content section, keeping it hidden from navigation and listing pages as intended.
  * No impact on application features or public APIs; change only affects content rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->