### PR TITLE
Mark `/content/shared` as headless

### DIFF
--- a/content/shared/_index.nb.md
+++ b/content/shared/_index.nb.md
@@ -1,0 +1,3 @@
+---
+headless: true
+---


### PR DESCRIPTION
## Description
The [preview fix](https://github.com/Altinn/altinn-studio-docs/pull/2319) appears to have no affect on the Norwegian version of the site.

This patch adds the same logic to _index.nb.md




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the shared notebook index configuration to be headless. The shared index no longer renders as a standalone page or appears in menus/navigation.
  * No changes to the visible content of individual notebook pages; existing links to notebooks remain unaffected.
  * This change only affects how the index is displayed within the documentation structure, with no impact on public APIs or exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->