### PR TITLE
Remove subscription key from documentation

### DIFF
--- a/content/correspondence/getting-started/developer-guides/systemprovider/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/systemprovider/_index.nb.md
@@ -17,7 +17,7 @@ For å komme i gang som systemleverandør følg denne veiledningen:
 For å kunne autentisere og sikre at du kan utføre operasjoner via meldings-APIet, må Altinn gi deg tilgang på de scopes du trenger. Dette sikrer at kun autoriserte klienter kan sende og motta filer, og opprettholder dermed sikkerheten i tjenesten. Følgende scopes brukes for å motta meldinger:
 - `altinn:correspondence.read`
 
-For å få Altinn API-nøkkel og scopes må du sende en forespørsel til: servicedesk@altinn.no 
+For å få tilgang til scopes scopes må du sende en forespørsel til: servicedesk@altinn.no 
 Forespørselen må inneholde de scopes du trenger. Vær obs på at du kan trenge flere scopes for integrasjonen din enn bare altinn:correspondence.read. 
 Utfyllende liste over scopes finner du her: 
 https://docs.altinn.studio/nb/api/authentication/digdirscopes/ 

--- a/content/correspondence/getting-started/developer-guides/systemprovider/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/systemprovider/_index.nb.md
@@ -17,7 +17,7 @@ For å komme i gang som systemleverandør følg denne veiledningen:
 For å kunne autentisere og sikre at du kan utføre operasjoner via meldings-APIet, må Altinn gi deg tilgang på de scopes du trenger. Dette sikrer at kun autoriserte klienter kan sende og motta filer, og opprettholder dermed sikkerheten i tjenesten. Følgende scopes brukes for å motta meldinger:
 - `altinn:correspondence.read`
 
-For å få tilgang til scopes scopes må du sende en forespørsel til: servicedesk@altinn.no 
+For å få tilgang til scopes, send en forespørsel til: [servicedesk@altinn.no](mailto:servicedesk@altinn.no)
 Forespørselen må inneholde de scopes du trenger. Vær obs på at du kan trenge flere scopes for integrasjonen din enn bare altinn:correspondence.read. 
 Utfyllende liste over scopes finner du her: 
 [Utfyllende liste over scopes](https://docs.altinn.studio/nb/api/authentication/digdirscopes/)

--- a/content/correspondence/getting-started/developer-guides/systemprovider/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/systemprovider/_index.nb.md
@@ -20,4 +20,4 @@ For å kunne autentisere og sikre at du kan utføre operasjoner via meldings-API
 For å få tilgang til scopes scopes må du sende en forespørsel til: servicedesk@altinn.no 
 Forespørselen må inneholde de scopes du trenger. Vær obs på at du kan trenge flere scopes for integrasjonen din enn bare altinn:correspondence.read. 
 Utfyllende liste over scopes finner du her: 
-https://docs.altinn.studio/nb/api/authentication/digdirscopes/ 
+[Utfyllende liste over scopes](https://docs.altinn.studio/nb/api/authentication/digdirscopes/)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for obtaining access to API scopes, directing requests to servicedesk@altinn.no.
  * Removed outdated reference to needing an Altinn API key.
  * Minor formatting adjustments to the documentation link and end-of-file whitespace to improve readability without changing the link destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->