### PR TITLE
Fjernet duplikat tekst

### DIFF
--- a/content/authorization/what-do-you-get/accessgroups/accessgroups/_index.nb.md
+++ b/content/authorization/what-do-you-get/accessgroups/accessgroups/_index.nb.md
@@ -10,7 +10,6 @@ For å kunne styre tilgang til apper og ressurser, må det opprettes policyfiler
 
 Fullmaktsområdene for tilgangsstyring er bygget på Statistisk sentralbyrå sin kategorisering av virksomheter, og de inneholder et sett med tilgangspakker innenfor området. Apper og ressurser knyttes til tilgangspakker i Altinn studio og Ressursregisteret.
 
-Fullmaktsområdene for tilgangsstyring er bygget på Statistisk sentralbyrå sin kategorisering av virksomheter, og de inneholder et sett med tilgangspakker innenfor området. Apper og ressurser knyttes til tilgangspakker i Altinn studio og Ressursregisteret.
 ![Fullmaktsområder](hierarki-tilgangspakker.jpg "Struktur på fullmaktsområder")
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed a duplicated introductory sentence on the Access Groups page in the Authorization section to improve readability and eliminate redundancy. No other content changes.
* **Style**
  * Applied a minor formatting tweak by adding a trailing newline to the page to align with documentation conventions and maintain consistency across files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->