### PR TITLE
Tydeliggjøring av at melding blir en dialog.

### DIFF
--- a/content/correspondence/about/_index.en.md
+++ b/content/correspondence/about/_index.en.md
@@ -1,7 +1,7 @@
 ---
 title: About Altinn Correspondence
 linktitle: About Correspondence
-description: Altinn Correspondence is a secure and efficient digital service that enables public sector organizations to send messages to citizens, businesses, and other public entities. An Altinn 3 Correspondence automatically becomes a dialogue, and is made available through Dialogporten in Altinn 3 Arbeidsflate.
+description: Altinn Correspondence is a secure and efficient digital service that enables public sector organizations to send messages to citizens, businesses, and other public entities. Since all organization numbers and personal identification numbers have a inbox in Altinn Arbeidsglate you will always be able to reach the correct recipient. An Altinn 3 Correspondence automatically becomes a dialogue and is made available through Dialogporten in Altinn 3 Arbeidsflate.
 tags: []
 toc: false
 weight: 1
@@ -10,22 +10,19 @@ cascade:
     diataxis: diataxis_explanation
 ---
 
-### About Altinn Correspondence
-Altinn Correspondence is a secure and efficient digital service that enables public sector organizations to send messages to citizens, businesses, and other public entities. Since all organization numbers and personal identification numbers have a user in Altinn, you can always reach the correct recipient.
-
 ### In line with the Digitalization Circular
 The Digitalization Circular requires the use of digital communication with organizations. By choosing Altinn Correspondence, you comply with this requirement and ensure that messages are sent and received securely.
 
 ### Security and access control
-Altinn Authorization ensures that only those with access can read the message, maintaining strict confidentiality and protecting personal data.
+Altinn Authorization ensures that only those with necessary access rights can read the message, maintaining strict confidentiality and protecting personal data.
 
 ### Notification and reminders
 The service provides notifications and follow-up reminders to recipients via SMS and email, in accordance with the requirements of the eGovernment Regulations. This means recipients can be alerted when a new message is waiting.
 
 ### Flexible message reception
-An Altinn 3 Correspondence automatically becomes a dialogue, and is made available through Dialogporten in Altinn 3 Arbeidsflate. Recipients can read the Correspondence directly in Arbeidsflate or integrate with their own systems using the Dialogporten API. This allows for a smooth workflow and full control over the exchange of information.
+An Altinn 3 Correspondence automatically becomes a dialogue and is available through Dialogporten in Altinn 3 Arbeidsflate. Recipients can read the Correspondence directly in Arbeidsflate or integrate with their own systems using the Dialogporten API. This allows for a smooth workflow and full control over the exchange of information.
 
-### Integration with Altinn Message
+### Integration with Altinn Correspondence
 You can use Altinn as a service owner to send messages, or integrate with Altinn as an end-user system to display messages.
 
 ![altinn3-correspondence-logo](./altinn3-correspondence-logo.png "Altinn 3 Correspondence features secure and easy to use message exchange")

--- a/content/correspondence/about/_index.en.md
+++ b/content/correspondence/about/_index.en.md
@@ -1,7 +1,7 @@
 ---
 title: About Altinn Correspondence
 linktitle: About Correspondence
-description: What is Altinn 3 Correspondence?
+description: Altinn Correspondence is a secure and efficient digital service that enables public sector organizations to send messages to citizens, businesses, and other public entities. An Altinn 3 Correspondence automatically becomes a dialogue, and is made available through Dialogporten in Altinn 3 Arbeidsflate.
 tags: []
 toc: false
 weight: 1
@@ -10,11 +10,23 @@ cascade:
     diataxis: diataxis_explanation
 ---
 
-Altinn Correspondence is a service within the Altinn platform used for securely sending and receiving messages. The service is utilized by public authorities, businesses and individuals. It has integrated authorization and encryption, ensuring that important information is transmitted safely and made easily accessible to the correct recipient.  
+### About Altinn Correspondence
+Altinn Correspondence is a secure and efficient digital service that enables public sector organizations to send messages to citizens, businesses, and other public entities. Since all organization numbers and personal identification numbers have a user in Altinn, you can always reach the correct recipient.
 
-Altinn functions as a digital mailbox and plays a key role in digital communication with public authorities in Norway. Altinn Correspondence is used for sending digital letters , information notices, reports, approvals and certificates.
+### In line with the Digitalization Circular
+The Digitalization Circular requires the use of digital communication with organizations. By choosing Altinn Correspondence, you comply with this requirement and ensure that messages are sent and received securely.
 
-The goal is to streamline and improve communication between authorities and the public. Altinn Correspondence has traditionally been used for communication with public entities, but it can also be used for message exchanges between private parties.
+### Security and access control
+Altinn Authorization ensures that only those with access can read the message, maintaining strict confidentiality and protecting personal data.
+
+### Notification and reminders
+The service provides notifications and follow-up reminders to recipients via SMS and email, in accordance with the requirements of the eGovernment Regulations. This means recipients can be alerted when a new message is waiting.
+
+### Flexible message reception
+An Altinn 3 Correspondence automatically becomes a dialogue, and is made available through Dialogporten in Altinn 3 Arbeidsflate. Recipients can read the Correspondence directly in Arbeidsflate or integrate with their own systems using using Dialogporten API. This allows for a smooth workflow and full control over the exchange of information.
+
+### Integration with Altinn Message
+You can use Altinn as a service owner to send messages, or integrate with Altinn as an end-user system to display messages.
 
 ![altinn3-correspondence-logo](./altinn3-correspondence-logo.png "Altinn 3 Correspondence features secure and easy to use message exchange")
 
@@ -31,4 +43,3 @@ How to navigate from there depends on your role and competencies.
 
 _Note: Further reading guides are planned. We appreciate your input._
 <!-- Erik TBD: Add reference to where to give input -->
--->

--- a/content/correspondence/about/_index.en.md
+++ b/content/correspondence/about/_index.en.md
@@ -23,7 +23,7 @@ Altinn Authorization ensures that only those with access can read the message, m
 The service provides notifications and follow-up reminders to recipients via SMS and email, in accordance with the requirements of the eGovernment Regulations. This means recipients can be alerted when a new message is waiting.
 
 ### Flexible message reception
-An Altinn 3 Correspondence automatically becomes a dialogue, and is made available through Dialogporten in Altinn 3 Arbeidsflate. Recipients can read the Correspondence directly in Arbeidsflate or integrate with their own systems using using Dialogporten API. This allows for a smooth workflow and full control over the exchange of information.
+An Altinn 3 Correspondence automatically becomes a dialogue, and is made available through Dialogporten in Altinn 3 Arbeidsflate. Recipients can read the Correspondence directly in Arbeidsflate or integrate with their own systems using the Dialogporten API. This allows for a smooth workflow and full control over the exchange of information.
 
 ### Integration with Altinn Message
 You can use Altinn as a service owner to send messages, or integrate with Altinn as an end-user system to display messages.

--- a/content/correspondence/about/_index.nb.md
+++ b/content/correspondence/about/_index.nb.md
@@ -1,7 +1,7 @@
 ---
 title: Om Altinn Melding
 linktitle: Om Altinn Melding
-description: Altinn Melding er en sikker og effektiv digital tjeneste som gjør det mulig for offentlige virksomheter å sende meldinger til både innbyggere, næringsliv og andre offentlige virksomheter. Fordi alle organisasjonsnummer og personnummer allerede har en bruker i Altinn, når du alltid riktig mottaker.
+description: Altinn Melding er en sikker og effektiv digital tjeneste som gjør det mulig for offentlige virksomheter å sende meldinger til både innbyggere, næringsliv og andre offentlige virksomheter. En Altinn 3 Melding blir automatisk en dialog, og gjøres tilgjengelig gjennom Dialogporten i Altinn 3 Arbeidsflate.
 tags: []
 toc: false
 weight: 1
@@ -20,7 +20,7 @@ Gjennom Altinn Autorisasjon blir kun de med tjenstlig behov gitt tilgang til å 
 Tjenesten tilbyr varsling og revarsling til mottaker på SMS og e‑post i samsvar med kravene i eForvaltningsforskriften. Det betyr at mottakere får beskjed når en ny melding venter.
 
 ### Fleksibel mottaksløsning
-Mottakeren kan lese meldingen direkte i Altinn-portalen eller integrere meldingen i sitt eget sak- og arkivsystem ved hjelp av Altinn API. Dette gir en smidig arbeidsflyt og full kontroll over informasjonsutvekslingen.
+En Altinn 3 Melding blir automatisk en dialog, og gjøres tilgjengelig gjennom Dialogporten i Altinn 3 Arbeidsflate. Mottakeren kan lese meldingen direkte i Arbeidsflate, eller integrere meldingen i sitt eget sak- og arkivsystem ved hjelp av Dialogportens API. Dette gir en smidig arbeidsflyt og full kontroll over informasjonsutvekslingen.
 
 ### Integrasjon med Altinn Melding
 Man kan bruke Altinn som tjenesteeier for å sende meldinger eller integrere seg mot Altinn som sluttbrukersystem for å vise meldinger:

--- a/content/correspondence/about/_index.nb.md
+++ b/content/correspondence/about/_index.nb.md
@@ -1,7 +1,7 @@
 ---
 title: Om Altinn Melding
 linktitle: Om Altinn Melding
-description: Altinn Melding er en sikker og effektiv digital tjeneste som gjør det mulig for offentlige virksomheter å sende meldinger til både innbyggere, næringsliv og andre offentlige virksomheter. En Altinn 3 Melding blir automatisk en dialog, og gjøres tilgjengelig gjennom Dialogporten i Altinn 3 Arbeidsflate.
+description: Altinn Melding er en sikker og effektiv digital tjeneste som gjør det mulig for offentlige virksomheter å sende meldinger til innbyggere, næringsliv og andre offentlige virksomheter. Siden alle organisasjonsnummer og personnummer har en innboks i Altinn Arbeidsflate vil du alltid kunne nå riktig mottaker. En Altinn 3 Melding blir automatisk en dialog, og gjøres tilgjengelig gjennom Dialogporten i Altinn 3 Arbeidsflate.
 tags: []
 toc: false
 weight: 1
@@ -20,7 +20,7 @@ Gjennom Altinn Autorisasjon blir kun de med tjenstlig behov gitt tilgang til å 
 Tjenesten tilbyr varsling og revarsling til mottaker på SMS og e‑post i samsvar med kravene i eForvaltningsforskriften. Det betyr at mottakere får beskjed når en ny melding venter.
 
 ### Fleksibel mottaksløsning
-En Altinn 3 Melding blir automatisk en dialog, og gjøres tilgjengelig gjennom Dialogporten i Altinn 3 Arbeidsflate. Mottakeren kan lese meldingen direkte i Arbeidsflate, eller integrere meldingen i sitt eget saks- og arkivsystem ved hjelp av Dialogportens API. Dette gir en smidig arbeidsflyt og full kontroll over informasjonsutvekslingen.
+En Altinn 3 Melding blir automatisk en dialog og gjøres tilgjengelig gjennom Dialogporten i Altinn 3 Arbeidsflate. Mottakeren kan lese meldingen direkte i Arbeidsflate, eller integrere meldingen i sitt eget saks- og arkivsystem ved hjelp av Dialogportens API. Dette gir en smidig arbeidsflyt og full kontroll over informasjonsutvekslingen.
 
 ### Integrasjon med Altinn Melding
 Man kan bruke Altinn som tjenesteeier for å sende meldinger eller integrere seg mot Altinn som sluttbrukersystem for å vise meldinger:

--- a/content/correspondence/about/_index.nb.md
+++ b/content/correspondence/about/_index.nb.md
@@ -20,7 +20,7 @@ Gjennom Altinn Autorisasjon blir kun de med tjenstlig behov gitt tilgang til å 
 Tjenesten tilbyr varsling og revarsling til mottaker på SMS og e‑post i samsvar med kravene i eForvaltningsforskriften. Det betyr at mottakere får beskjed når en ny melding venter.
 
 ### Fleksibel mottaksløsning
-En Altinn 3 Melding blir automatisk en dialog, og gjøres tilgjengelig gjennom Dialogporten i Altinn 3 Arbeidsflate. Mottakeren kan lese meldingen direkte i Arbeidsflate, eller integrere meldingen i sitt eget sak- og arkivsystem ved hjelp av Dialogportens API. Dette gir en smidig arbeidsflyt og full kontroll over informasjonsutvekslingen.
+En Altinn 3 Melding blir automatisk en dialog, og gjøres tilgjengelig gjennom Dialogporten i Altinn 3 Arbeidsflate. Mottakeren kan lese meldingen direkte i Arbeidsflate, eller integrere meldingen i sitt eget saks- og arkivsystem ved hjelp av Dialogportens API. Dette gir en smidig arbeidsflyt og full kontroll over informasjonsutvekslingen.
 
 ### Integrasjon med Altinn Melding
 Man kan bruke Altinn som tjenesteeier for å sende meldinger eller integrere seg mot Altinn som sluttbrukersystem for å vise meldinger:


### PR DESCRIPTION
Lagt til setning om at melding blir en dialog som vises i Arbeidsflate. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Overhauled “About Altinn Correspondence” (EN/NB) into structured sections covering purpose, security, access control, notifications, flexible reception, and Dialogporten API integration.
  * Updated wording to state Altinn 3 Correspondence/Melding becomes a dialog and is available via Dialogporten in Altinn 3 Arbeidsflate; aligned Norwegian content to the dialog-centric flow.
* **Bug Fixes**
  * Fixed duplicated word in the flexible message reception section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->