### PR TITLE
Updated correspondence doc with html support and step to test content layout

### DIFF
--- a/content/correspondence/getting-started/developer-guides/serviceowner/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/serviceowner/_index.en.md
@@ -109,7 +109,7 @@ The Repo also contains a [Postman collection](https://github.com/Altinn/altinn-c
 
 Swagger for the correspondence API is hosted [here](https://docs.altinn.studio/api/correspondence/spec/).
 
-### 9. Test layout and formatting in Arbeidsflate and A2 inbox {#test-appearance-formatting}
+### 9. Test layout and formatting in Arbeidsflate and Altinn 2 inbox {#test-appearance-formatting}
 
 Before going live, verify that correspondences render as intended for recipients.
 
@@ -117,11 +117,11 @@ Before going live, verify that correspondences render as intended for recipients
 2. Verify in Arbeidsflate:
    - Log in with the test recipient in [af.tt.altinn.no](https://af.tt.altinn.no/).
    - Check that the test correspondence content is formatted as intended.
-3. Verify in Altinn 2 inbox (A2):
+3. Verify in Altinn 2 inbox:
    - Log in with the test recipient in [info.tt02.altinn.no](https://info.tt02.altinn.no/).
    - Check that the test correspondence content is formatted as intended.
 
-**Note**: Supported formatting tags (Markdown/HTML) is described here: [docs.altinn.studio/dialogporten/.../#markdown-and-html](https://docs.altinn.studio/dialogporten/reference/front-end/front-channel-embeds/#markdown-and-html)
+**Note**: Supported formatting tags (Markdown and HTML) are documented here: [Overview of allowed markdown and HTML tags](https://docs.altinn.studio/dialogporten/reference/front-end/front-channel-embeds/#markdown-and-html)
 
 ### 10. Set up Event subscriptions {#setup-event-subscriptions}
 

--- a/content/correspondence/getting-started/developer-guides/serviceowner/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/serviceowner/_index.en.md
@@ -109,7 +109,21 @@ The Repo also contains a [Postman collection](https://github.com/Altinn/altinn-c
 
 Swagger for the correspondence API is hosted [here](https://docs.altinn.studio/api/correspondence/spec/).
 
-### 9. Set up Event subscriptions {#setup-event-subscriptions}
+### 9. Test layout and formatting in Arbeidsflate and A2 inbox {#test-appearance-formatting}
+
+Before going live, verify that correspondences render as intended for recipients.
+
+1. Send a test correspondence to a test recipient using your preferred tool (Postman, SDK, or your integration).
+2. Verify in Arbeidsflate:
+   - Log in with the test recipient in [af.tt.altinn.no](https://af.tt.altinn.no/).
+   - Check that the test correspondence content is formatted as intended.
+3. Verify in Altinn 2 inbox (A2):
+   - Log in with the test recipient in [info.tt02.altinn.no](https://info.tt02.altinn.no/).
+   - Check that the test correspondence content is formatted as intended.
+
+**Note**: Supported formatting tags (Markdown/HTML) is described here: [docs.altinn.studio/dialogporten/.../#markdown-and-html](https://docs.altinn.studio/dialogporten/reference/front-end/front-channel-embeds/#markdown-and-html)
+
+### 10. Set up Event subscriptions {#setup-event-subscriptions}
 
 In order to use events/webhooks for a Correspondence resource, you need to set up a subscription for the given resource.
 

--- a/content/correspondence/getting-started/developer-guides/serviceowner/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/serviceowner/_index.nb.md
@@ -108,7 +108,21 @@ Repoet inneholder også en [Postman-samling](https://github.com/Altinn/altinn-co
 
 Swagger for meldings-APIet finner du [her](/api/correspondence/spec/).
 
-### 9. Sett opp hendelsesabonnementer {#set-up-event-subscriptions}
+### 9. Test oppsett og formatering i Arbeidsflate og A2-innboks {#test-appearance-formatting}
+
+Før produksjonssetting bør du verifisere at meldinger vises riktig for mottakere.
+
+1. Send en testmelding til en testmottaker via ønsket verktøy (Postman, SDK eller din integrasjon).
+2. Verifiser i Arbeidsflate:
+   - Logg inn med testmottaker i [af.tt.altinn.no](https://af.tt.altinn.no/).
+   - Sjekk at innholdet i testmeldingen er formatert som tiltenkt.
+3. Verifiser i Altinn 2-innboks (A2):
+   - Logg inn med testmottaker i [info.tt02.altinn.no](https://info.tt02.altinn.no/).
+   - Sjekk at innholdet i testmeldingen er formatert som tiltenkt.
+
+**Merk**: Støttede formateringstagger (Markdown/HTML) er beskrevet her: [docs.altinn.studio/dialogporten/.../#markdown-and-html](https://docs.altinn.studio/dialogporten/reference/front-end/front-channel-embeds/#markdown-and-html)
+
+### 10. Sett opp hendelsesabonnementer {#set-up-event-subscriptions}
 
 For å kunne motta varsler om endringer eller hendelser knyttet til dine meldingstjenester, må du sette opp et abonnement for den aktuelle tjenesten.
 Dette trinnet er spesielt viktig for deg som ønsker å få automatiserte varsler om hendelser fra meldingstjenesten. Hvis du ikke trenger varsler, kan du hoppe over dette trinnet.

--- a/content/correspondence/getting-started/developer-guides/serviceowner/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/serviceowner/_index.nb.md
@@ -108,19 +108,19 @@ Repoet inneholder også en [Postman-samling](https://github.com/Altinn/altinn-co
 
 Swagger for meldings-APIet finner du [her](/api/correspondence/spec/).
 
-### 9. Test oppsett og formatering i Arbeidsflate og A2-innboks {#test-appearance-formatting}
+### 9. Test oppsett og formatering i Arbeidsflate og Altinn 2-innboks {#test-appearance-formatting}
 
 Før produksjonssetting bør du verifisere at meldinger vises riktig for mottakere.
 
 1. Send en testmelding til en testmottaker via ønsket verktøy (Postman, SDK eller din integrasjon).
 2. Verifiser i Arbeidsflate:
-   - Logg inn med testmottaker i [af.tt.altinn.no](https://af.tt.altinn.no/).
+   - Logg inn som testmottaker på [af.tt.altinn.no](https://af.tt.altinn.no/).
    - Sjekk at innholdet i testmeldingen er formatert som tiltenkt.
-3. Verifiser i Altinn 2-innboks (A2):
-   - Logg inn med testmottaker i [info.tt02.altinn.no](https://info.tt02.altinn.no/).
+3. Verifiser i Altinn 2-innboks:
+   - Logg inn som testmottaker på [info.tt02.altinn.no](https://info.tt02.altinn.no/).
    - Sjekk at innholdet i testmeldingen er formatert som tiltenkt.
 
-**Merk**: Støttede formateringstagger (Markdown/HTML) er beskrevet her: [docs.altinn.studio/dialogporten/.../#markdown-and-html](https://docs.altinn.studio/dialogporten/reference/front-end/front-channel-embeds/#markdown-and-html)
+**Merk**: Støttede formateringstagger (Markdown og HTML) er dokumentert her: [Oversikt over tillatte markdown og HTML tagger](https://docs.altinn.studio/nb/dialogporten/reference/front-end/front-channel-embeds/#markdown-og-html)
 
 ### 10. Sett opp hendelsesabonnementer {#set-up-event-subscriptions}
 

--- a/content/correspondence/transition/differences/_index.en.md
+++ b/content/correspondence/transition/differences/_index.en.md
@@ -12,7 +12,7 @@ To simplify the transition from Altinn 2 to the Altinn 3 version of the Correspo
 ## Here are the main differences
 
 - Altinn 3 Correspondence largely has the same data model as Altinn 2 to enable mapping and migration.
-  - The fields for MessageBody and MessageSummary have changed from supporting only text or html to being stored as Markdown. If the content contains HTML it will be rejected.
+  - The MessageSummary field have changed from supporting HTML formatting to just supporting plain text.
   - ReplyOptions have been simplified to only be URL + descriptive text, as this is flexible enough to cover the needs that the separate types in Altinn 2 offered.
 - Attachments are uploaded streamed and in a separate step before creating the Correspondence.
   - Attachments can be shared across multiple messages to reduce data usage when mass sending the same attachment to many parties.

--- a/content/correspondence/transition/differences/_index.en.md
+++ b/content/correspondence/transition/differences/_index.en.md
@@ -12,7 +12,7 @@ To simplify the transition from Altinn 2 to the Altinn 3 version of the Correspo
 ## Here are the main differences
 
 - Altinn 3 Correspondence largely has the same data model as Altinn 2 to enable mapping and migration.
-  - The MessageSummary field have changed from supporting HTML formatting to just supporting plain text.
+  - The MessageSummary field has changed from supporting HTML formatting to supporting only plain text.
   - ReplyOptions have been simplified to only be URL + descriptive text, as this is flexible enough to cover the needs that the separate types in Altinn 2 offered.
 - Attachments are uploaded streamed and in a separate step before creating the Correspondence.
   - Attachments can be shared across multiple messages to reduce data usage when mass sending the same attachment to many parties.

--- a/content/correspondence/transition/differences/_index.nb.md
+++ b/content/correspondence/transition/differences/_index.nb.md
@@ -12,7 +12,7 @@ For å forenkle overgangen fra Altinn 2 til Altinn 3 versjon av Melding-produkte
 ## Her er de største differansene
 
 - Altinn 3 Melding har i stor grad lik datamodell som Altinn 2 for å muliggjøre mapping og migrering.
-  - Feltene for MessageBody og MessageSummary har blitt endret fra å støtte ren tekst eller html til å lagres som Markdown. Dersom man angir HTML vil opprettelsen av Meldingen feile.
+  - MessageSummary feltet har blitt endret fra å støtte HTML formatering til å bare støtte ren tekst.
   - ReplyOptions har blitt forenklet til å kun være URL+beskrivende tekst, da dette er fleksibelt nok til å dekke behovene de separate typene i Altinn 2 tilbød.
 - Vedlegg lastes opp strømmet og i et separat steg før man lager Meldingen.
   - Vedlegg kan deles på tvers av flere Meldinger for å redusere databruk ved masseforsendelse av samme vedlegg til mange parter.

--- a/content/correspondence/transition/differences/_index.nb.md
+++ b/content/correspondence/transition/differences/_index.nb.md
@@ -12,7 +12,7 @@ For å forenkle overgangen fra Altinn 2 til Altinn 3 versjon av Melding-produkte
 ## Her er de største differansene
 
 - Altinn 3 Melding har i stor grad lik datamodell som Altinn 2 for å muliggjøre mapping og migrering.
-  - MessageSummary feltet har blitt endret fra å støtte HTML formatering til å bare støtte ren tekst.
+  - MessageSummary-feltet har blitt endret fra å støtte HTML formatering til kun å støtte ren tekst.
   - ReplyOptions har blitt forenklet til å kun være URL+beskrivende tekst, da dette er fleksibelt nok til å dekke behovene de separate typene i Altinn 2 tilbød.
 - Vedlegg lastes opp strømmet og i et separat steg før man lager Meldingen.
   - Vedlegg kan deles på tvers av flere Meldinger for å redusere databruk ved masseforsendelse av samme vedlegg til mange parter.

--- a/content/correspondence/what-do-you-get/_index.en.md
+++ b/content/correspondence/what-do-you-get/_index.en.md
@@ -25,7 +25,7 @@ You can receive notifications about events related to submitted messaging servic
 The system offers advanced access control, ensuring that only authorized users can access specific file transfers.
 
 ### Support for Various Message Formats
-- Ability to send correspondences in Markdown or clean text.
+- Ability to send correspondences in Markdown, HTML or clean text.
 - Support for several attachments per correspondence, without limitation of type. PDF, XML and HTML will usually be the most common used.
 - Supports attachments up to 250 MB. 
 

--- a/content/correspondence/what-do-you-get/_index.nb.md
+++ b/content/correspondence/what-do-you-get/_index.nb.md
@@ -26,7 +26,7 @@ Du kan motta varsler om hendelser knyttet til sendte formidlingstjenester, ved �
 - Altinn Melding støtter ulike sikkerhetsnivåer (0–4) for å imøtekomme avsenders krav til meldingssikkerhet. 
 
 ### Støtte for ulike meldingsformater
-- Mulighet for å sende meldinger med Markdown eller ren tekst.
+- Mulighet for å sende meldinger med Markdown, HTML eller ren tekst.
 - Støtte for flere vedlegg per melding uten begrensing av type, der PDF, XML og HTML vil være de mest vanlige.
 - Støtte for vedlegg opp til 250 MB.
 


### PR DESCRIPTION
Updated correspondence documentation with these changes:
* Correspondence now supports html for content body. 
* Message summary only supports plain text. (not html or markdown)
* Added step for serviceowner to test they layout and formatting of correspondence content in af and a2 inbox, with link to supported formatting tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a pre-release checklist to test appearance and formatting in Arbeidsflate and Altinn 2 inbox (EN/NB).
  - Reorganized service owner guide: event subscription setup moved to the next section with a direct link to detailed guidance.
  - Updated transition differences: clarified MessageSummary notes, expanded attachments/mass sending details, and referenced Altinn-Notifications for advanced templates (EN/NB).
  - Expanded supported message formats to include HTML alongside Markdown and plain text (EN/NB).
  - Updated anchors and cross-references for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->