### PR TITLE
Studio signing and supported authentication methods

### DIFF
--- a/content/altinn-studio/guides/development/signing/_index.en.md
+++ b/content/altinn-studio/guides/development/signing/_index.en.md
@@ -8,6 +8,8 @@ aliases:
   - /altinn-studio/guides/signing/
 ---
 
+{{% insert "content/altinn-studio/guides/development/signing/auth-requirements.en.md" %}}
+
 The different scenarios below can to some extent be combined with each other, but many services will only need one of them.
 
 ## Runtime delegated signing

--- a/content/altinn-studio/guides/development/signing/_index.nb.md
+++ b/content/altinn-studio/guides/development/signing/_index.nb.md
@@ -8,6 +8,8 @@ aliases:
 - /nb/altinn-studio/guides/signing/
 ---
 
+{{% insert "content/altinn-studio/guides/development/signing/auth-requirements.nb.md" %}}
+
 De ulike scenarioene nedenfor kan i noen grad kombineres med hverandre, men ofte trenger en tjeneste bare en av variantene.
 
 ## Brukerstyrt

--- a/content/altinn-studio/guides/development/signing/auth-requirements.en.md
+++ b/content/altinn-studio/guides/development/signing/auth-requirements.en.md
@@ -1,0 +1,7 @@
+---
+hidden: true
+---
+
+{{%notice info%}}
+Signing is only available to users and system users. Service owners and other authentication types cannot sign.
+{{%/notice%}}

--- a/content/altinn-studio/guides/development/signing/auth-requirements.nb.md
+++ b/content/altinn-studio/guides/development/signing/auth-requirements.nb.md
@@ -1,0 +1,7 @@
+---
+hidden: true
+---
+
+{{%notice info%}}
+Signering er kun tilgjengelig for brukere og systembrukere. Tjenesteeiere og andre autentiseringstyper kan ikke signere.
+{{%/notice%}}

--- a/content/altinn-studio/reference/process/tasks/signing/_index.en.md
+++ b/content/altinn-studio/reference/process/tasks/signing/_index.en.md
@@ -9,6 +9,8 @@ toc: true
 ⚠️ Signing task require version 8.0.0 or newer of app-libs
 {{% /panel %}}
 
+{{% insert "content/altinn-studio/guides/development/signing/auth-requirements.en.md" %}}
+
 Setting up a signing task in the process file requires a bit more work than a regular data, confirm or feedback task.
 
 This page will walk you through what you need to configure and how that is connected to other parts of the configuration.

--- a/content/altinn-studio/reference/process/tasks/signing/_index.nb.md
+++ b/content/altinn-studio/reference/process/tasks/signing/_index.nb.md
@@ -9,6 +9,8 @@ toc: true
 ⚠️ Signing task krever versjon 8.0.0 eller nyere av app-libs
 {{% /panel %}}
 
+{{% insert "content/altinn-studio/guides/development/signing/auth-requirements.nb.md" %}}
+
 Oppsett av en signeringoppgave i prosessfilen krever litt mer arbeid enn en vanlig data-, bekreftelses- eller tilbakemeldingsoppgave.
 
 Denne siden vil veilede deg gjennom hva du trenger å konfigurere og hvordan det er koblet til andre deler av konfigurasjonen.


### PR DESCRIPTION
Describes that only users and systemusers can sign

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Introduced an “Authentication requirements for signing” notice in English and Norwegian across Signing guides and Signing task reference pages.
  - Clarifies availability: signing is limited to users and system users; service owners and other authentication types cannot sign.
  - Added hidden reference pages to centralize the notice and ensure consistent inclusion across related documentation.
  - No functional or behavioral changes to the product; content-only update to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->