### PR TITLE
1330 updated docs for custom recipients after changes with multiple notfications and sending notification to custom in addition to KoFuVi

### DIFF
--- a/content/correspondence/getting-started/developer-guides/notifications/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/notifications/_index.en.md
@@ -46,12 +46,14 @@ A notification order is made by adding the following when initializing a message
       "reminderEmailContentType": Plain(0) | Html(1),
       "reminderSmsBody": string?,
       "requestedSendTime": DateTimeOffset?,
-      "customRecipient": {
-        "organizationNumber": string?,
-        "nationalIdentityNumber": string?,
-        "mobileNumber": string?,
-        "emailAddress": string?
-      }
+      "customRecipients": [
+        {
+          "organizationNumber": string?,
+          "nationalIdentityNumber": string?,
+          "mobileNumber": string?,
+          "emailAddress": string?
+        }
+      ]
     }
   },
   "Recipients": [],
@@ -106,8 +108,8 @@ Supported notification channels:
 - **EmailPreferred:** Uses email as the main communication channel, and SMS as a fallback if email is not available.
 - **SmsPreferred:** Uses SMS as the main communication channel, and email as a fallback if SMS is not available.
 - **EmailAndSms:** Sends both email and SMS to the recipient simultaneously.
-The first notification and the reminder notification can use different notification channels. 
-For example, the first notification is sent by email, while the reminder notification seven days later is sent by SMS.
+  The first notification and the reminder notification can use different notification channels. 
+  For example, the first notification is sent by email, while the reminder notification seven days later is sent by SMS.
 
 ## Cancellation of Notification
 
@@ -123,11 +125,59 @@ Improvements are planned to provide feedback on this during the creation of a me
 ## Custom recipients for Notifications
 
 For all correspondences created with Notifications enabled, the notifications will be sent to the recipient specified in the creation of the correspondence.
-However, it is also possible to choose optional recipients of the notification that are not necessarily the recipient(s) of the correspondence. 
-In practice this means that custom recipients will override/replace the original recipient provided for the notification.
+However, it is also possible to choose additional recipients of the notification that are not necessarily the recipient(s) of the correspondence. 
+In practice this means that custom recipients will receive notifications **in addition to** the original correspondence recipient.
+
+### Using customRecipients (Recommended)
+The recommended approach is to use the `customRecipients` field under `notification` to specify multiple recipients:
+
+```json
+{
+  "notification": {
+    ...,
+    "customRecipients": [
+      {
+        "organizationNumber": "string",
+        "nationalIdentityNumber": "string",
+        "mobileNumber": "string",
+        "emailAddress": "string"
+      },
+      {
+        "organizationNumber": "string",
+        "nationalIdentityNumber": "string",
+        "mobileNumber": "string",
+        "emailAddress": "string"
+      }
+    ]
+  }
+}
+```
+
+**Note**: Notifications will be sent to both the default correspondence recipient AND all custom recipients listed above.
 
 {{% notice warning %}}
-⚠️ DEPRECATED: The `customNotificationRecipients` field is deprecated and will be removed in a future version. Please use `customRecipient` instead.
+⚠️ DEPRECATED: The `customRecipient` field is deprecated and will be removed in a future version. Please use `customRecipients` instead.
+{{% /notice %}}
+
+### Using customRecipient (Deprecated)
+For backward compatibility, you can still use the `customRecipient` field for a single recipient:
+
+```json
+{
+  "notification": {
+    ...,
+    "customRecipient": {
+      "organizationNumber": "string",
+      "nationalIdentityNumber": "string",
+      "mobileNumber": "string",
+      "emailAddress": "string"
+    }
+  }
+}
+```
+
+{{% notice warning %}}
+⚠️ DEPRECATED: The `customNotificationRecipients` field is deprecated and will be removed in a future version. Please use `customRecipients` instead.
 {{% /notice %}}
 
 ### Using customNotificationRecipients (Deprecated)
@@ -154,63 +204,54 @@ This can be achieved by populating the `customNotificationRecipients` field unde
 }
 ```
 
-### Using customRecipient (Recommended)
-The recommended approach is to use the `customRecipient` field under `notification` as follows:
-
-```json
-{
-  "notification": {
-    ...,
-    "customRecipient": {
-      "organizationNumber": "string",
-      "nationalIdentityNumber": "string",
-      "mobileNumber": "string",
-      "emailAddress": "string"
-    }
-  }
-}
-```
-
 ### Validation Rules for Custom Recipients
 
 When using custom recipients, the following validation rules apply:
 
-1. **Single Recipient Only**: Custom recipients can only be used when the correspondence has exactly one recipient. Multiple recipients are not allowed.
+1. **Additional Recipients**: Custom recipients are sent notifications **in addition to** the default correspondence recipient, not instead of them.
 
-2. **Single Identifier Required**: The custom recipient must have exactly one identifier field populated:
+2. **Single Recipient Only**: If custom recipients are specified, the correspondence must have only one default recipient (not multiple recipients).
+
+3. **Single Identifier Required**: Each custom recipient must have exactly one identifier field populated:
    - `organizationNumber` (for organizations)
    - `nationalIdentityNumber` (for persons)
    - `emailAddress` (for direct email notifications)
    - `mobileNumber` (for direct SMS notifications)
 
-3. **Keyword Restrictions**: When using `emailAddress` or `mobileNumber`, the `$recipientName$` keyword cannot be used in any notification content (email subject, email body, SMS body, reminder fields) because name lookup is not available for direct contact information.
+4. **Keyword Restrictions**: When using `emailAddress` or `mobileNumber`, the `$recipientName$` keyword cannot be used in any notification content (email subject, email body, SMS body, reminder fields) because name lookup is not available for direct contact information.
 
-4. **Format Validation**:
+5. **Format Validation**:
    - **Email addresses**: Must be in valid email format (e.g., `user@example.com`)
    - **Mobile numbers**: Must adhere to E.164 standard and be valid phone numbers. Can start with `+` or `00` for international format. Norwegian numbers starting with 4 or 9 will automatically get `+47` prefix if no country code is provided.
-
-5. **Organization Numbers**: Must be in format `0192:organizationnumber` or `urn:altinn:organizationnumber:organizationnumber`
-
-6. **National Identity Numbers**: Must be valid 11-digit Norwegian social security numbers
+   - **Organization Numbers**: Must be in format `0192:organizationnumber` or `urn:altinn:organizationnumber:organizationnumber`
+   - **National Identity Numbers**: Must be valid 11-digit Norwegian social security numbers
 
 ### How to use it
-For deprecated approach:
+For recommended approach (multiple recipients):
+```
+correspondence.notification.customRecipients[0].organizationNumber
+correspondence.notification.customRecipients[0].nationalIdentityNumber
+correspondence.notification.customRecipients[0].mobileNumber
+correspondence.notification.customRecipients[0].emailAddress
+correspondence.notification.customRecipients[1].organizationNumber
+// ... additional recipients
+```
+
+For deprecated single recipient approach:
+```
+correspondence.notification.customRecipient.organizationNumber
+correspondence.notification.customRecipient.nationalIdentityNumber
+correspondence.notification.customRecipient.mobileNumber
+correspondence.notification.customRecipient.emailAddress
+```
+
+For deprecated multiple recipients approach:
 ```
 correspondence.notification.customNotificationRecipients[0].recipientToOverride
 correspondence.notification.customNotificationRecipients[0].recipients[0].organizationNumber
 correspondence.notification.customNotificationRecipients[0].recipients[0].nationalIdentityNumber
 correspondence.notification.customNotificationRecipients[0].recipients[0].mobileNumber
 correspondence.notification.customNotificationRecipients[0].recipients[0].emailAddress
-
-```
-
-For recommended approach:
-```
-correspondence.notification.customRecipient.organizationNumber
-correspondence.notification.customRecipient.nationalIdentityNumber
-correspondence.notification.customRecipient.mobileNumber
-correspondence.notification.customRecipient.emailAddress
-
 ```
 
 {{% panel theme="warning" %}}

--- a/content/correspondence/getting-started/developer-guides/notifications/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/notifications/_index.nb.md
@@ -45,12 +45,14 @@ En varslingsbestilling gjøres ved å legge til følgende når du initialiserer 
       "reminderEmailContentType": Plain(0) | Html(1),
       "reminderSmsBody": string?,
       "requestedSendTime": DateTimeOffset?,
-      "customRecipient": {
-        "organizationNumber": string?,
-        "nationalIdentityNumber": string?,
-        "mobileNumber": string?,
-        "emailAddress": string?
-      }
+      "customRecipients": [
+        {
+          "organizationNumber": string?,
+          "nationalIdentityNumber": string?,
+          "mobileNumber": string?,
+          "emailAddress": string?
+        }
+      ]
     }
   },
   "Recipients": [],
@@ -121,11 +123,59 @@ Det er planlagt forbedringer for å gi tilbakemelding omkring dette under oppret
 ## Valgfri mottakere for varsling
 
 For meldinger som er opprettet med varsling aktivert vil mottakeren av varslingen være den samme som mottakeren av meldingen.
-Det er også mulig å legge til valgfrie mottakere av varselet som ikke nødvendigvis er mottaker(e) av meldingen. 
-I praksis betyr dette at valgfrie mottakere vil overstyre/erstatte den opprinnelige mottakeren som er angitt for varselet.
+Det er derimot mulig benytte valgfrie mottakere av varsling, som ikke nødvendigvis er mottaker av meldingen.
+I praksis betyr dette at valgfrie mottakere vil motta varsler **i tillegg til** den opprinnelige meldingsmottakeren.
+
+### Bruk av customRecipients (Anbefalt)
+Den anbefalte måten er å bruke `customRecipients`-feltet under `notification` for å spesifisere flere mottakere:
+
+```json
+{
+  "notification": {
+    ...,
+    "customRecipients": [
+      {
+        "organizationNumber": "string",
+        "nationalIdentityNumber": "string",
+        "mobileNumber": "string",
+        "emailAddress": "string"
+      },
+      {
+        "organizationNumber": "string",
+        "nationalIdentityNumber": "string",
+        "mobileNumber": "string",
+        "emailAddress": "string"
+      }
+    ]
+  }
+}
+```
+
+**Merk**: Varsler vil bli sendt til både standard meldingsmottaker OG alle valgfrie mottakere som er listet ovenfor.
 
 {{% notice warning %}}
-⚠️ UTGÅTT: Feltet `customNotificationRecipients` er utgått og vil bli fjernet i en fremtidig versjon. Vennligst bruk `customRecipient` i stedet.
+⚠️ UTGÅTT: Feltet `customRecipient` er utgått og vil bli fjernet i en fremtidig versjon. Vennligst bruk `customRecipients` i stedet.
+{{% /notice %}}
+
+### Bruk av customRecipient (Utgått)
+For bakoverkompatibilitet kan du fortsatt bruke `customRecipient`-feltet for en enkelt mottaker:
+
+```json
+{
+  "notification": {
+    ...,
+    "customRecipient": {
+      "organizationNumber": "string",
+      "nationalIdentityNumber": "string",
+      "mobileNumber": "string",
+      "emailAddress": "string"
+    }
+  }
+}
+```
+
+{{% notice warning %}}
+⚠️ UTGÅTT: Feltet `customNotificationRecipients` er utgått og vil bli fjernet i en fremtidig versjon. Vennligst bruk `customRecipients` i stedet.
 {{% /notice %}}
 
 ### Bruk av customNotificationRecipients (Utgått)
@@ -152,61 +202,54 @@ Dette gjøres ved å fylle ut `customNotificationRecipients`-feltet under `notif
 }
 ```
 
-### Bruk av customRecipient (Anbefalt)
-Den anbefalte måten er å bruke `customRecipient`-feltet under `notification` slik:
-
-```json
-{
-  "notification": {
-    ...,
-    "customRecipient": {
-      "organizationNumber": "string",
-      "nationalIdentityNumber": "string",
-      "mobileNumber": "string",
-      "emailAddress": "string"
-    }
-  }
-}
-```
-
 ### Valideringsregler for valgfrie mottakere
 
 Når du bruker valgfrie mottakere, gjelder følgende valideringsregler:
 
-1. **Kun én mottaker**: Valgfrie mottakere kan kun brukes når meldingen har nøyaktig én mottaker. Flere mottakere er ikke tillatt.
+1. **Tilleggsmottakere**: Valgfrie mottakere får varsler **i tillegg til** standard meldingsmottaker, ikke i stedet for dem.
 
-2. **Kun én identifikator påkrevd**: Den valgfrie mottakeren må ha nøyaktig ett identifikatorfelt fylt ut:
+2. **Kun én mottaker**: Hvis valgfrie mottakere er spesifisert, må meldingen ha kun én standard mottaker (ikke flere mottakere).
+
+3. **Kun én identifikator påkrevd**: Hver valgfrie mottaker må ha nøyaktig ett identifikatorfelt fylt ut:
    - `organizationNumber` (for organisasjoner)
    - `nationalIdentityNumber` (for personer)
    - `emailAddress` (for direkte e-postvarsler)
    - `mobileNumber` (for direkte SMS-varsler)
 
-3. **Keyword-begrensninger**: Når du bruker `emailAddress` eller `mobileNumber`, kan ikke `$recipientName$`-keywordet brukes i noe varslingsinnhold (e-postemne, e-postinnhold, SMS-innhold, revarselfelt) fordi navneoppslag ikke er tilgjengelig for direkte kontaktinformasjon.
+4. **Keyword-begrensninger**: Når du bruker `emailAddress` eller `mobileNumber`, kan ikke `$recipientName$`-keywordet brukes i noe varslingsinnhold (e-postemne, e-postinnhold, SMS-innhold, revarselfelt) fordi navneoppslag ikke er tilgjengelig for direkte kontaktinformasjon.
 
-4. **Formatvalidering**:
+5. **Formatvalidering**:
    - **E-postadresser**: Må være i gyldig e-postformat (f.eks. `bruker@eksempel.com`)
    - **Mobilnumre**: Må følge E.164-standarden og være gyldige telefonnumre. Kan starte med `+` eller `00` for internasjonalt format. Norske numre som starter med 4 eller 9 får automatisk `+47`-prefiks hvis ingen landskode er oppgitt.
-
-5. **Organisasjonsnumre**: Må være i format `0192:organisasjonsnummer` eller `urn:altinn:organisasjonsnummer:organisasjonsnummer`
-
-6. **Fødselsnumre**: Må være gyldige 11-sifrede norske fødselsnumre
+   - **Organisasjonsnumre**: Må være i format `0192:organisasjonsnummer` eller `urn:altinn:organisasjonsnummer:organisasjonsnummer`
+   - **Fødselsnumre**: Må være gyldige 11-sifrede norske fødselsnumre
 
 ### Hvordan bruke valgfri mottaker
-For utgått tilnærming:
+For anbefalt tilnærming (flere mottakere):
+```
+correspondence.notification.customRecipients[0].organizationNumber
+correspondence.notification.customRecipients[0].nationalIdentityNumber
+correspondence.notification.customRecipients[0].mobileNumber
+correspondence.notification.customRecipients[0].emailAddress
+correspondence.notification.customRecipients[1].organizationNumber
+// ... ytterligere mottakere
+```
+
+For utgått enkelt mottaker tilnærming:
+```
+correspondence.notification.customRecipient.organizationNumber
+correspondence.notification.customRecipient.nationalIdentityNumber
+correspondence.notification.customRecipient.mobileNumber
+correspondence.notification.customRecipient.emailAddress
+```
+
+For utgått flere mottakere tilnærming:
 ```
 correspondence.notification.customNotificationRecipients[0].recipientToOverride
 correspondence.notification.customNotificationRecipients[0].recipients[0].organizationNumber
 correspondence.notification.customNotificationRecipients[0].recipients[0].nationalIdentityNumber
 correspondence.notification.customNotificationRecipients[0].recipients[0].mobileNumber
 correspondence.notification.customNotificationRecipients[0].recipients[0].emailAddress
-```
-
-For anbefalt tilnærming:
-```
-correspondence.notification.customRecipient.organizationNumber
-correspondence.notification.customRecipient.nationalIdentityNumber
-correspondence.notification.customRecipient.mobileNumber
-correspondence.notification.customRecipient.emailAddress
 ```
 
 {{% panel theme="warning" %}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support multiple custom recipients in notifications via a new array, allowing organizations, persons, or direct contacts. Custom recipients are additive to the default recipient.
- Deprecations
  - Deprecated single-recipient and nested multi-recipient approaches; migration guidance provided. Backward compatibility retained for now.
- Documentation
  - Updated EN and NO guides with new examples, indices, and paths.
  - Rewritten validation rules and added warnings about template/channel behavior for direct email/mobile.
  - Clear sections for recommended usage vs deprecated paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->