### PR TITLE
Warning about national identity numbers in signature records

### DIFF
--- a/content/altinn-studio/guides/development/signing/_index.en.md
+++ b/content/altinn-studio/guides/development/signing/_index.en.md
@@ -8,6 +8,8 @@ aliases:
   - /altinn-studio/guides/signing/
 ---
 
+{{% insert "content/altinn-studio/guides/development/signing/sensitive-data-warning.en.md" %}}
+
 {{% insert "content/altinn-studio/guides/development/signing/auth-requirements.en.md" %}}
 
 The different scenarios below can to some extent be combined with each other, but many services will only need one of them.

--- a/content/altinn-studio/guides/development/signing/_index.nb.md
+++ b/content/altinn-studio/guides/development/signing/_index.nb.md
@@ -8,6 +8,8 @@ aliases:
 - /nb/altinn-studio/guides/signing/
 ---
 
+{{% insert "content/altinn-studio/guides/development/signing/sensitive-data-warning.nb.md" %}}
+
 {{% insert "content/altinn-studio/guides/development/signing/auth-requirements.nb.md" %}}
 
 De ulike scenarioene nedenfor kan i noen grad kombineres med hverandre, men ofte trenger en tjeneste bare en av variantene.

--- a/content/altinn-studio/guides/development/signing/runtime-delegated-signing/_index.en.md
+++ b/content/altinn-studio/guides/development/signing/runtime-delegated-signing/_index.en.md
@@ -8,6 +8,10 @@ aliases:
   - /altinn-studio/guides/signing/runtime-delegated-signing
 ---
 
+{{%notice info%}}
+Available from [v8.6.0](https://github.com/Altinn/app-lib-dotnet/releases/tag/v8.6.0)
+{{%/notice%}}
+
 ## What does runtime delegated signing mean?
 
 {{% insert "content/altinn-studio/guides/development/signing/runtime-delegated-signing/intro.en.md" %}}

--- a/content/altinn-studio/guides/development/signing/runtime-delegated-signing/_index.nb.md
+++ b/content/altinn-studio/guides/development/signing/runtime-delegated-signing/_index.nb.md
@@ -8,6 +8,10 @@ aliases:
   - /nb/altinn-studio/guides/signing/runtime-delegated-signing
 ---
 
+{{%notice info%}}
+Tilgjengelig fra [v8.6.0](https://github.com/Altinn/app-lib-dotnet/releases/tag/v8.6.0)
+{{%/notice%}}
+
 ## Hva betyr brukerstyrt signering?
 
 {{% insert "content/altinn-studio/guides/development/signing/runtime-delegated-signing/intro.nb.md" %}}

--- a/content/altinn-studio/guides/development/signing/runtime-delegated-signing/intro.en.md
+++ b/content/altinn-studio/guides/development/signing/runtime-delegated-signing/intro.en.md
@@ -2,10 +2,6 @@
 hidden: true
 ---
 
-{{%notice info%}}
-Runtime delegated signing requires minimum version 8.6.0 av Altinn nugets.
-{{%/notice%}}
-
 By runtime delegated signing, we mean an app where those who need to sign are granted rights during the form-filling process.
 
 Typically, the app will ask the form owner to provide the social security number and last name of the individuals who need to sign, or alternatively, the organization number if someone with signing authority within a company needs to sign.

--- a/content/altinn-studio/guides/development/signing/runtime-delegated-signing/intro.nb.md
+++ b/content/altinn-studio/guides/development/signing/runtime-delegated-signing/intro.nb.md
@@ -2,10 +2,6 @@
 hidden: true
 ---
 
-{{%notice info%}}
-Brukerstyrt signering krever versjon 8.6.0 av Altinn nugets, eller høyere.
-{{%/notice%}}
-
 Med brukerstyrt signering mener vi en app der de som skal signere får rettigheter til å signere mens de fyller ut skjemaet.
 
 Appen kan for eksempel be skjemaeieren om å oppgi fødselsnummer og etternavn for personer som skal signere, eller organisasjonsnummer hvis det er noen som skal ha rett til å signere på vegne av en virksomhet.

--- a/content/altinn-studio/guides/development/signing/sensitive-data-warning.en.md
+++ b/content/altinn-studio/guides/development/signing/sensitive-data-warning.en.md
@@ -3,5 +3,5 @@ hidden: true
 ---
 
 {{% notice warning %}}
-Signature records may contain national identity numbers. If you wish to restrict access to these records, please consider implementing [extra data restrictions](/altinn-studio/guides/development/restricted-data). Available from [v8.7.2](https://github.com/Altinn/app-lib-dotnet/releases/tag/v8.7.2).
+Signature records can be read by anyone with access to an instance and may contain sensitive information such as national identity numbers. You can restrict access to these records by using [extra data restrictions](/altinn-studio/guides/development/restricted-data). Available from [v8.7.2](https://github.com/Altinn/app-lib-dotnet/releases/tag/v8.7.2).
 {{% /notice %}}

--- a/content/altinn-studio/guides/development/signing/sensitive-data-warning.en.md
+++ b/content/altinn-studio/guides/development/signing/sensitive-data-warning.en.md
@@ -1,0 +1,7 @@
+---
+hidden: true
+---
+
+{{% notice warning %}}
+Signature records may contain national identity numbers. If you wish to restrict access to these records, please consider implementing [extra data restrictions](/altinn-studio/guides/development/restricted-data). Available from [v8.7.2](https://github.com/Altinn/app-lib-dotnet/releases/tag/v8.7.2).
+{{% /notice %}}

--- a/content/altinn-studio/guides/development/signing/sensitive-data-warning.nb.md
+++ b/content/altinn-studio/guides/development/signing/sensitive-data-warning.nb.md
@@ -3,5 +3,5 @@ hidden: true
 ---
 
 {{% notice warning %}}
-Signaturdokumenter kan inneholde fødselsnummer. Hvis du ønsker å begrense tilgangen til disse dokumentene, bør du vurdere å implementere [ekstra databeskyttelse](/nb/altinn-studio/guides/development/restricted-data). Tilgjengelig fra [v8.7.2](https://github.com/Altinn/app-lib-dotnet/releases/tag/v8.7.2).
+Signaturdokumenter kan leses av alle med tilgang til en instans og kan inneholde sensitiv informasjon som fødselsnummer. Du kan begrense tilgangen disse dokumentene ved bruk av [ekstra databeskyttelse](/nb/altinn-studio/guides/development/restricted-data). Tilgjengelig fra [v8.7.2](https://github.com/Altinn/app-lib-dotnet/releases/tag/v8.7.2).
 {{% /notice %}}

--- a/content/altinn-studio/guides/development/signing/sensitive-data-warning.nb.md
+++ b/content/altinn-studio/guides/development/signing/sensitive-data-warning.nb.md
@@ -1,0 +1,7 @@
+---
+hidden: true
+---
+
+{{% notice warning %}}
+Signaturdokumenter kan inneholde fødselsnummer. Hvis du ønsker å begrense tilgangen til disse dokumentene, bør du vurdere å implementere [ekstra databeskyttelse](/nb/altinn-studio/guides/development/restricted-data). Tilgjengelig fra [v8.7.2](https://github.com/Altinn/app-lib-dotnet/releases/tag/v8.7.2).
+{{% /notice %}}


### PR DESCRIPTION
## Description
Adds warning related to potentially sensitive data contained in signature records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added a sensitive-data warning to signing guides (EN/NO), noting signature records may contain national ID numbers and linking to restricted-data guidance; marked hidden and available from v8.7.2.
  - Added reusable hidden warning partials for documentation.
  - Added info notices on runtime delegated signing overview pages (EN/NO) stating availability from v8.6.0.
  - Removed duplicate version notices from runtime delegated signing intro pages (EN/NO).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->