### PR TITLE
added docs for OverrideRegisteredContactInformation

### DIFF
--- a/content/correspondence/getting-started/developer-guides/notifications/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/notifications/_index.en.md
@@ -53,7 +53,8 @@ A notification order is made by adding the following when initializing a message
           "mobileNumber": string?,
           "emailAddress": string?
         }
-      ]
+      ],
+      "overrideRegisteredContactInformation": boolean
     }
   },
   "Recipients": [],
@@ -263,5 +264,65 @@ Both `notificationTemplate` and `notificationChannel` are applicable when using 
 
 Further details are provided [here](#notification-templates).
 {{% /panel %}}
+
+## Override Default Recipient Behavior
+
+By default, when using custom recipients, notifications are sent to both the default correspondence recipient AND all custom recipients. However, you can override this behavior using the `overrideRegisteredContactInformation` flag.
+
+### Using overrideRegisteredContactInformation
+
+The `overrideRegisteredContactInformation` flag allows you to control whether the default correspondence recipient should be included in notifications:
+
+```json
+{
+  "notification": {
+    ...,
+    "customRecipients": [
+      {
+        "organizationNumber": "string",
+        "nationalIdentityNumber": "string",
+        "mobileNumber": "string",
+        "emailAddress": "string"
+      }
+    ],
+    "overrideRegisteredContactInformation": true
+  }
+}
+```
+
+### Behavior
+
+- **`overrideRegisteredContactInformation: false` (default)**: Notifications are sent to the default correspondence recipient AND all custom recipients
+- **`overrideRegisteredContactInformation: true`**: Notifications are sent ONLY to custom recipients (default correspondence recipient is excluded)
+
+### Validation Rules
+
+1. **Custom Recipients Required**: The `overrideRegisteredContactInformation` flag can only be set to `true` when `customRecipients` is provided and not empty
+2. **V2 API Only**: This feature only works with the V2 notification API (which is used internally)
+3. **Default Value**: If not specified, `overrideRegisteredContactInformation` defaults to `false`
+
+### Example Use Cases
+
+**Scenario 1: Additional Recipients (Default Behavior)**
+```json
+{
+  "notification": {
+    "customRecipients": [{"organizationNumber": "123456789"}],
+    "overrideRegisteredContactInformation": false
+  }
+}
+```
+Result: Notifications sent to both the default correspondence recipient AND the custom organization
+
+**Scenario 2: Override Default Recipient**
+```json
+{
+  "notification": {
+    "customRecipients": [{"organizationNumber": "123456789"}],
+    "overrideRegisteredContactInformation": true
+  }
+}
+```
+Result: Notifications sent ONLY to the custom organization (default correspondence recipient excluded)
 
 

--- a/content/correspondence/getting-started/developer-guides/notifications/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/notifications/_index.en.md
@@ -62,9 +62,7 @@ A notification order is made by adding the following when initializing a message
 }
 ```
 
-{{% notice info %}}
-Note: The notification service uses a V2 API internally. The notification order will be automatically converted to the V2 format when processed.
-{{% /notice %}}
+
 
 ## Keyword support
 
@@ -298,8 +296,7 @@ The `overrideRegisteredContactInformation` flag allows you to control whether th
 ### Validation Rules
 
 1. **Custom Recipients Required**: The `overrideRegisteredContactInformation` flag can only be set to `true` when `customRecipients` is provided and not empty
-2. **V2 API Only**: This feature only works with the V2 notification API (which is used internally)
-3. **Default Value**: If not specified, `overrideRegisteredContactInformation` defaults to `false`
+2. **Default Value**: If not specified, `overrideRegisteredContactInformation` defaults to `false`
 
 ### Example Use Cases
 

--- a/content/correspondence/getting-started/developer-guides/notifications/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/notifications/_index.nb.md
@@ -61,9 +61,6 @@ En varslingsbestilling gjøres ved å legge til følgende når du initialiserer 
 }
 ```
 
-{{% notice info %}}
-Merk: Varslingstjenesten bruker et V2 API internt. Varslingsbestillingen vil automatisk bli konvertert til V2-format når den behandles.
-{{% /notice %}}
 
 ## Keyword støtte
 
@@ -296,8 +293,7 @@ Som standard, når du bruker valgfrie mottakere, sendes varsler til både standa
 ### Valideringsregler
 
 1. **Valgfrie mottakere påkrevd**: `overrideRegisteredContactInformation`-flagget kan kun settes til `true` når `customRecipients` er oppgitt og ikke tom
-2. **V2 API kun**: Denne funksjonen fungerer kun med V2 varslings-API (som brukes internt)
-3. **Standardverdi**: Hvis ikke spesifisert, standardiserer `overrideRegisteredContactInformation` til `false`
+2. **Standardverdi**: Hvis ikke spesifisert, standardiserer `overrideRegisteredContactInformation` til `false`
 
 ### Eksempel brukstilfeller
 

--- a/content/correspondence/getting-started/developer-guides/notifications/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/notifications/_index.nb.md
@@ -52,7 +52,8 @@ En varslingsbestilling gjøres ved å legge til følgende når du initialiserer 
           "mobileNumber": string?,
           "emailAddress": string?
         }
-      ]
+      ],
+      "overrideRegisteredContactInformation": boolean
     }
   },
   "Recipients": [],
@@ -261,5 +262,65 @@ Både `notificationTemplate` og `notificationChannel` er anvendelige når du bru
 
 Flere detaljer er gitt [her](#varslingsmaler).
 {{% /panel %}}
+
+## Overstyr standard mottaker oppførsel
+
+Som standard, når du bruker valgfrie mottakere, sendes varsler til både standard meldingsmottaker OG alle valgfrie mottakere. Du kan imidlertid overstyre denne oppførselen ved å bruke `overrideRegisteredContactInformation`-flagget.
+
+### Bruk av overrideRegisteredContactInformation
+
+`overrideRegisteredContactInformation`-flagget lar deg kontrollere om standard meldingsmottaker skal inkluderes i varsler:
+
+```json
+{
+  "notification": {
+    ...,
+    "customRecipients": [
+      {
+        "organizationNumber": "string",
+        "nationalIdentityNumber": "string",
+        "mobileNumber": "string",
+        "emailAddress": "string"
+      }
+    ],
+    "overrideRegisteredContactInformation": true
+  }
+}
+```
+
+### Oppførsel
+
+- **`overrideRegisteredContactInformation: false` (standard)**: Varsler sendes til standard meldingsmottaker OG alle valgfrie mottakere
+- **`overrideRegisteredContactInformation: true`**: Varsler sendes KUN til valgfrie mottakere (standard meldingsmottaker ekskluderes)
+
+### Valideringsregler
+
+1. **Valgfrie mottakere påkrevd**: `overrideRegisteredContactInformation`-flagget kan kun settes til `true` når `customRecipients` er oppgitt og ikke tom
+2. **V2 API kun**: Denne funksjonen fungerer kun med V2 varslings-API (som brukes internt)
+3. **Standardverdi**: Hvis ikke spesifisert, standardiserer `overrideRegisteredContactInformation` til `false`
+
+### Eksempel brukstilfeller
+
+**Scenario 1: Tilleggsmottakere (Standard oppførsel)**
+```json
+{
+  "notification": {
+    "customRecipients": [{"organizationNumber": "123456789"}],
+    "overrideRegisteredContactInformation": false
+  }
+}
+```
+Resultat: Varsler sendes til både standard meldingsmottaker OG den valgfrie organisasjonen
+
+**Scenario 2: Overstyr standard mottaker**
+```json
+{
+  "notification": {
+    "customRecipients": [{"organizationNumber": "123456789"}],
+    "overrideRegisteredContactInformation": true
+  }
+}
+```
+Resultat: Varsler sendes KUN til den valgfrie organisasjonen (standard meldingsmottaker ekskluderes)
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Added docs for a new notification payload flag: overrideRegisteredContactInformation (boolean).
  - Described behavior with customRecipients: false (default) includes default recipient plus custom recipients; true sends only custom recipients.
  - Documented validation rules (requires non-empty customRecipients, V2 API only, default=false) with JSON examples and use cases.
  - Updated English and Norwegian guides; Norwegian guide contains a duplicated section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->