### PR TITLE
Infromasjon om dato for stenging av AII

### DIFF
--- a/content/broker/_index.en.md
+++ b/content/broker/_index.en.md
@@ -1,7 +1,7 @@
 ---
 title: Altinn 3 Broker
 linktitle: Broker
-description: Altinn 3 Broker offers managed file transfer with support for large files and advanced features for information security, status monitoring and quality of service.
+description: Altinn 3 Broker offers managed file transfer with support for large files and advanced features for information security, status monitoring and quality of service. Service owners with Broker services in Altinn II must migrate these services in Altinn 3 prior to June 19th 2026, when Altinn II will be decommissioned. 
 toc: false
 weight: 1
 cascade:

--- a/content/broker/_index.nb.md
+++ b/content/broker/_index.nb.md
@@ -1,7 +1,7 @@
 ---
 title: Altinn 3 Formidling
 linktitle: Formidling
-description: Altinn 3 Formidling ('Broker' på engelsk) tilbyr styrt filoverføring med støtte for store filer og avansert funksjonalitet for informasjonssikkerhet, statusmonitorering og tjenestekvalitet.   
+description: Altinn 3 Formidling ('Broker' på engelsk) tilbyr styrt filoverføring med støtte for store filer og avansert funksjonalitet for informasjonssikkerhet, statusmonitorering og tjenestekvalitet. Tjenesteeiere som har formidlingstjenester i Altinn II må reetablere disse i Altinn 3, i god tid før 19.juni 2026 når Altinn II slås av.  
 toc: false
 weight: 1
 aliases: 

--- a/content/correspondence/_index.en.md
+++ b/content/correspondence/_index.en.md
@@ -1,7 +1,7 @@
 ---
 title: Altinn 3 Correspondence
 linktitle: Correspondence
-description: Altinn 3 Correspondence is a messaging service, enabling the secure exchange of correspondence, such as official letters, notifications, and other documents, between public agencies and individuals or businesses.
+description: Altinn 3 Correspondence is a messaging service, enabling the secure exchange of correspondence, such as official letters, notifications, and other documents, between public agencies and individuals or businesses. Service owners with Correspondence services in Altinn II must migrate these services in Altinn 3 prior to June 19th 2026, when Altinn II will be decommissioned.
 toc: false
 weight: 1
 cascade:

--- a/content/correspondence/_index.nb.md
+++ b/content/correspondence/_index.nb.md
@@ -1,7 +1,7 @@
 ---
 title: Altinn 3 Melding
 linktitle: Melding
-description: Altinn 3 Melding ('Correspondence' på engelsk) er en meldingstjeneste for sikker utveksling av korrespondanse, som offisielle brev, varsler og andre dokumenter, mellom offentlige etater og enkeltpersoner eller bedrifter.
+description: Altinn 3 Melding ('Correspondence' på engelsk) er en meldingstjeneste for sikker utveksling av korrespondanse, som offisielle brev, varsler og andre dokumenter, mellom offentlige etater og enkeltpersoner eller bedrifter. Tjenesteeiere som har meldingstjenester i Altinn II må reetablere disse i Altinn 3, i god tid før 19.juni 2026 når Altinn II slås av.
 toc: false
 weight: 1
 aliases: 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added migration notice for Altinn II decommissioning on June 19, 2026 to Broker and Correspondence pages (English and Norwegian).
  - Informs service owners with existing Altinn II Broker or Correspondence services to migrate/reestablish in Altinn 3 before the deadline.
  - Clarifies that no functional changes were made; this is a content update to improve awareness and ensure timely transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->