### PR TITLE
Fail Hugo build if the insert shortcode fails

### DIFF
--- a/content/altinn-studio/v8/_index.en.md
+++ b/content/altinn-studio/v8/_index.en.md
@@ -103,4 +103,4 @@ cascade:
 </div>
 
 ## News - upcoming
-{{% insert "content/altinn-studio/v8/news/upcoming/_index.en.md" %}}
+{{< insert "content/altinn-studio/v8/news/upcoming/_index.en.md" >}}

--- a/content/altinn-studio/v8/news/_index.en.md
+++ b/content/altinn-studio/v8/news/_index.en.md
@@ -5,8 +5,8 @@ weight: 60
 ---
 
 ## Upcoming
-{{% insert "content/altinn-studio/news/upcoming/_index.en.md" %}}
+{{% insert "content/altinn-studio/v8/news/upcoming/_index.en.md" %}}
 
 
 ## Recently delivered
-{{% insert "content/altinn-studio/news/delivered/_index.en.md" %}}
+{{% insert "content/altinn-studio/v8/news/delivered/_index.en.md" %}}

--- a/content/altinn-studio/v8/news/_index.nb.md
+++ b/content/altinn-studio/v8/news/_index.nb.md
@@ -5,10 +5,10 @@ weight: 60
 ---
 
 ## Kommende
-{{% insert "content/altinn-studio/news/upcoming/_index.nb.md" %}}
+{{% insert "content/altinn-studio/v8/news/upcoming/_index.nb.md" %}}
 
 
 ## Levert
-{{% insert "content/altinn-studio/news/delivered/_index.nb.md" %}}
+{{% insert "content/altinn-studio/v8/news/delivered/_index.nb.md" %}}
 
 

--- a/themes/hugo-theme-altinn/layouts/shortcodes/insert.html
+++ b/themes/hugo-theme-altinn/layouts/shortcodes/insert.html
@@ -28,5 +28,5 @@
   {{ $content | markdownify}}
 {{ end }}
 {{ else }}
-  Could not find section content. File does not exist: {{ $filePath }}
+  {{ errorf "Could not find section content to be inserted in %s. File does not exist: %s" .Page.RelPermalink $filePath }}
 {{ end }}


### PR DESCRIPTION
This change ensures that Hugo build fails if the usage of insert shortcode points to a non-existing file. Thus avoiding missing content on the site. When content is missing the link checker will not be able to verify links in that content since its not included in the first place.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer error message when included content is missing, showing the affected page and file path.
- Bug Fixes
  - v8 News pages now correctly display v8-specific “Upcoming” and “Recently delivered” content.
  - Fixed shortcode usage to ensure inserts render as expected.
- Documentation
  - Updated v8 landing and news pages to reference the correct v8 content sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->