### PR TITLE
update version selector texts

### DIFF
--- a/content/altinn-studio/v8/_index.en.md
+++ b/content/altinn-studio/v8/_index.en.md
@@ -1,5 +1,5 @@
 ---
-title: V8
+title: Altinn Studio
 linktitle: Altinn Studio
 breadcrumbText: Current (V8)
 description: Altinn Studio - Your tool for developing digital services for citizens and businesses

--- a/content/altinn-studio/v8/_index.nb.md
+++ b/content/altinn-studio/v8/_index.nb.md
@@ -1,5 +1,5 @@
 ---
-title: V8
+title: Altinn Studio
 linktitle: Altinn Studio
 breadcrumbText: Gjeldende (V8)
 description: Altinn Studio - Ditt verktøy for utvikling av digitale tjenester til innbyggere og næringsliv

--- a/themes/hugo-theme-altinn/layouts/partials/product-version-switcher.html
+++ b/themes/hugo-theme-altinn/layouts/partials/product-version-switcher.html
@@ -55,7 +55,7 @@
                 {{- range $currentProductRootPage.Sections -}}
                     {{- $folderName := path.Base .RelPermalink -}}
                     {{- if eq $folderName $currentVersion -}}
-                        {{ .Title }}
+                        {{ .Params.breadcrumbText }}
                     {{- end -}}
                 {{- end -}}
             {{- else -}}
@@ -77,7 +77,7 @@
                 role="option"
                 tabindex="-1"
                 aria-selected="{{if eq $folderName $currentVersion}}true{{else}}false{{end}}">
-                <span class="version-item">{{ .Title }}</span>
+                <span class="version-item">{{ .Params.breadcrumbText }}</span>
             </a>
             {{- end -}}
         </div>

--- a/themes/hugo-theme-altinn/layouts/partials/product-version-switcher.html
+++ b/themes/hugo-theme-altinn/layouts/partials/product-version-switcher.html
@@ -55,7 +55,7 @@
                 {{- range $currentProductRootPage.Sections -}}
                     {{- $folderName := path.Base .RelPermalink -}}
                     {{- if eq $folderName $currentVersion -}}
-                        {{ .Params.breadcrumbText }}
+                        {{ with .Params.breadcrumbText }}{{ . }}{{ else }}{{ .Title }}{{ end }}
                     {{- end -}}
                 {{- end -}}
             {{- else -}}
@@ -77,7 +77,7 @@
                 role="option"
                 tabindex="-1"
                 aria-selected="{{if eq $folderName $currentVersion}}true{{else}}false{{end}}">
-                <span class="version-item">{{ .Params.breadcrumbText }}</span>
+                <span class="version-item">{{ with .Params.breadcrumbText }}{{ . }}{{ else }}{{ .Title }}{{ end }}</span>
             </a>
             {{- end -}}
         </div>


### PR DESCRIPTION
Updated version selector for Altinn Studio docs to use `breadcrumbText` rather than title, so the page title does not have to be "V8" or "V9", but rather "Altinn Studio".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated the English and Norwegian Altinn Studio v8 landing page titles from “V8” to “Altinn Studio” for clearer labeling; page content unchanged.
- Style
  - Version switcher now displays breadcrumb labels where available (with a title fallback) for the current version and dropdown items, improving navigation clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->