### PR TITLE
Added info about "migratedcorrespondence"

### DIFF
--- a/content/correspondence/getting-started/developer-guides/serviceowner/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/serviceowner/_index.en.md
@@ -32,6 +32,8 @@ See [Resource Management](https://docs.altinn.studio/authorization/getting-start
 ### 4. Create a Resource {#registeraresourceinaltinnresourceregistry}
 
 1. Log in to Altinn Studio and navigate to the resource dashboard.
+   
+   *Note: As part of Altinn's migration of existing messages, new resources are being created in your (service owner) resource dashboard. These message resources are intended only for use for Altinn II messages and must not be used for new correspondences. They can be identified by the inclusion of "migratedcorrespondence" in the resource ID. See [Transition Solution](https://docs.altinn.studio/en/correspondence/transition/) for more information.*
 2. Create a new resource, follow the guide, and fill in the necessary information and details about the service. See [Resource Registry](https://docs.altinn.studio/authorization/guides/resource-owner/create-resource-resource-admin/#step-1-create-resource) for a detailed instruction.
 3. Set policy rules for the resource. Your policy must be configured in such a way that they permit the actions:
    - "read" meant for recipients to open and read a message.

--- a/content/correspondence/getting-started/developer-guides/serviceowner/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/serviceowner/_index.nb.md
@@ -33,6 +33,8 @@ Se [Ressursadministrasjon](https://docs.altinn.studio/nb/authorization/getting-s
 ### 4. Opprett en ressurs {#registeraresourceinaltinnresourceregistry}
 
 1. Logg inn på Altinn Studio og naviger til ressursdashboardet.
+
+      *Obs. I forbindelse med Altinns migrering av eksisterende meldinger, opprettes det nye ressurser i deres (tjenesteeiers) ressursdashboard. Disse meldingsressursene er altså kun til bruk for Altinn II meldinger og skal ikke benyttes for nye utsendelser. Ressursene kjennes igjen ved at de inneholder "migratedcorrespondence" i ressurs-id. Se [Overgangsløsning](https://docs.altinn.studio/nb/correspondence/transition/) for mer informasjon.*
 2. Opprett ny ressurs, følg veiledningen og fyll inn nødvendig informasjon og detaljer om tjenesten. Se [Ressursregister](https://docs.altinn.studio/nb/authorization/guides/resource-owner/create-resource-resource-admin/#trinn-1-opprett-ressurs) for en detaljert veiledning.
 3. Opprett policy: her angis tilgangsregler for ressursen. Tilgangsregler for ressursen må konfigureres slik at de tillater følgende handlinger:
    - "read" ment for at mottakere skal kunne åpne og lese en melding.


### PR DESCRIPTION
New resources are being created in service owners resource dashboard by Altinn 2 team. 
Resource ID "xx_migratedcorrespondence".
Info added in 4. Create a Resource -> 1. Log in to Altinn Studio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified migration behavior in “Create a Resource”: during Altinn II correspondence migration, new resources may appear with “migratedcorrespondence” in the resource ID. These are only for migrated messages and must not be used for new correspondences. Added reference to the transition guide. Updates provided in both English and Norwegian service owner guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->