### PR TITLE
Rettet skrivefeil

### DIFF
--- a/content/authorization/what-do-you-get/consent/_index.nb.md
+++ b/content/authorization/what-do-you-get/consent/_index.nb.md
@@ -27,13 +27,13 @@ I Altinn 3 utstedes kun ett Maskinporten-token per samtykke. Dette tokenet ident
 {
     "authorization_details": [
         {
-            "type": "urn:altinn:concent",
+            "type": "urn:altinn:consent",
             "id": "b55b0a8c-46db-4239-a417-a89daabfabba",
             "from": "urn:altinn:person:identifier-no:01039012345",
             "to": "urn:altinn:organization:identifier-no:984851006",
-            "concented": "2024-06-01T00:00:00Z",
+            "consented": "2024-06-01T00:00:00Z",
             "validTo": "2024-12-10T00:00:00Z",
-            "concentrights": [
+            "consentrights": [
                 {
                     "action": ["read", "write"],
                     "resource": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated consent token schema terminology for accuracy: corrected URN for the “type” field to “urn:altinn:consent.”
  - Standardized field names to match current schema: “concented” → “consented” and “concentrights” → “consentrights.”
  - Improved clarity and consistency across consent-related documentation.
  - Performed minor formatting cleanup (added trailing newline).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->