### PR TITLE
feat: change signing data elements ordering

### DIFF
--- a/content/altinn-studio/v8/reference/ux/components/SigningDocumentList/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/components/SigningDocumentList/_index.en.md
@@ -72,4 +72,4 @@ The component is added to a page layout as such:
 
 The attachment type of a document may be changed by adding one or more tags.
 
-The rows in the table are sorted first according to the order of the data types in `dataTypesToSign` in process.bpmn, and then by the documents' creation dates.
+From [v8.9.0](https://github.com/Altinn/app-lib-dotnet/releases/tag/v8.9.0), the rows in the table are sorted first according to the order of the data types in `dataTypesToSign` in process.bpmn, and then by the documents' creation dates.

--- a/content/altinn-studio/v8/reference/ux/components/SigningDocumentList/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/components/SigningDocumentList/_index.en.md
@@ -71,3 +71,5 @@ The component is added to a page layout as such:
       },
 
 The attachment type of a document may be changed by adding one or more tags.
+
+The rows in the table are sorted first according to the order of the data types in `dataTypesToSign` in process.bpmn, and then by the documents' creation dates.

--- a/content/altinn-studio/v8/reference/ux/components/SigningDocumentList/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/components/SigningDocumentList/_index.nb.md
@@ -72,4 +72,4 @@ Komponenten legges til i et side-layout slik:
 
 Vedleggstypen til et dokument kan endres ved å legge til en eller flere tags.
 
-Radene i tabellen sorteres først etter rekkefølgen av datatypene i `dataTypesToSign` i process.bpmn, og deretter etter dokumentenes opprettelsesdato.
+Fra [v8.9.0](https://github.com/Altinn/app-lib-dotnet/releases/tag/v8.9.0) sorteres radene i tabellen først etter rekkefølgen av datatypene i `dataTypesToSign` i process.bpmn, og deretter etter dokumentenes opprettelsesdato.

--- a/content/altinn-studio/v8/reference/ux/components/SigningDocumentList/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/components/SigningDocumentList/_index.nb.md
@@ -71,3 +71,5 @@ Komponenten legges til i et side-layout slik:
     },
 
 Vedleggstypen til et dokument kan endres ved å legge til en eller flere tags.
+
+Radene i tabellen sorteres først etter rekkefølgen av datatypene i `dataTypesToSign` i process.bpmn, og deretter etter dokumentenes opprettelsesdato.


### PR DESCRIPTION
Add documentation for the changes requested in Altinn/app-frontend-react#3367, implemented in Altinn/app-lib-dotnet#1511 and Altinn/app-frontend-react#3775.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Clarified SigningDocumentList table sorting: rows are ordered first by the configured dataTypesToSign order in the process, then by document creation date.
  - Updated English and Norwegian documentation pages to include the expanded sorting details.
  - Retained the existing note that the attachment type can still be changed via tags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio-docs/pull/2408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->