### PR TITLE
updated swagger json for authentication

### DIFF
--- a/static/swagger/altinn-platform-authentication-v1.json
+++ b/static/swagger/altinn-platform-authentication-v1.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.4",
   "info": {
     "title": "Altinn Platform Authentication",
-    "version": "1.0"
+    "version": "v1"
   },
   "paths": {
     "/authentication": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Authentication API’s OpenAPI documentation to use version label “v1” instead of “1.0”. This aligns version naming across the docs and UI, improving clarity for developers browsing the API. No functional changes to endpoints, request/response schemas, or behaviors—only the displayed version string in the Swagger documentation has been updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->