### PR TITLE
Re-do Oversettelse

### DIFF
--- a/content/authorization/what-do-you-get/pdp/pip/_index.nb.md
+++ b/content/authorization/what-do-you-get/pdp/pip/_index.nb.md
@@ -5,16 +5,5 @@ description: Policy Informasjonspunkt(er) er ansvarlige for å gi nødvendig inf
 tags: [arkitektur, sikkerhet]
 weight: 1
 ---
-
-Uten denne informasjonen ville det vært umulig for PDP å evaluere kontekstforespørselen i mange scenarier.
-
-For Altinn-plattformen finnes det flere Policy Informasjonspunkt:
-
-- Altinn II Autorisasjon – Hent informasjon om hvilke roller en bruker eller et system har for en gitt aktør
-- Storage PIP – Hent attributter om ressursen i beslutningsforespørselen. (hvilken type app, hvem er rapporteringsansvarlig for dataene, hva er nåværende prosessstatus)
-
-Antallet PIP-er forventes å øke i fremtiden.
-
-### Implementasjonsdetaljer
-
-Se implementasjonsdetaljer i [konstruksjonskomponentene for PIP](/nb/authorization/reference/architecture/accesscontrol/#policy-information-point---roles).
+Side 1 av 0
+Side 1 av 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the Policy Information Points page content with a placeholder, removing previous detailed descriptions.
  * Users will now see a minimal placeholder text on that page; previous implementation details are no longer displayed.
  * Navigation and surrounding page structure remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->