### PR TITLE
Update deletion instructions for system user

### DIFF
--- a/content/authorization/guides/end-user/system-user/delete-system-user/_index.nb.md
+++ b/content/authorization/guides/end-user/system-user/delete-system-user/_index.nb.md
@@ -7,7 +7,7 @@ weight: 3
 
 # Sletting av systembruker
 
-En systembruker kan kun slettes av en sluttbrukersystemleverandør. Ved sletting fjernes alle tilknyttede delegeringer automatisk. Per i dag er sletting av systembruker kun mulig via Altinn-portalen. Brukeren med rollen tilgangsstyrer i sluttbrukervirksomheten må logge inn i Altinn-portalen for å gjennomføre slettingen. Leverandør kan ikke slette systembruker på vegne av kunden.
+Det er kun sluttbrukeren selv (med rollen tilgangsstyrer) som kan slette systembrukeren. Ved sletting fjernes alle tilknyttede delegeringer automatisk. Per i dag er sletting av systembruker kun mulig via Altinn-portalen. Brukeren med rollen tilgangsstyrer i sluttbrukervirksomheten må logge inn i Altinn-portalen for å gjennomføre slettingen.
 
 ## Slik sletter du systembruker
 


### PR DESCRIPTION
Clarified that only the end user with the role of access manager can delete the system user.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system user deletion authorization guidelines. Only the end user with appropriate access permissions can now delete system users through the Altinn portal. Linked delegations are automatically removed upon deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->