### PR TITLE
fixing component-props.html

### DIFF
--- a/layouts/shortcodes/component-props.html
+++ b/layouts/shortcodes/component-props.html
@@ -1,35 +1,31 @@
 {{- $paramName := .Get 0 -}}
 {{- $schemaName := .Page.Params.schemaname -}}
-
 {{- if $paramName -}}
-    {{- template "getComponent" $paramName -}}
+{{- template "getComponent" $paramName -}}
 {{- else if $schemaName -}}
-    {{- template "getComponent" $schemaName -}}
+{{- template "getComponent" $schemaName -}}
 {{- else -}}
-    <em>Component name missing.</em>
+<em>Component name missing.</em>
 {{- end -}}
-
 {{- define "getComponent" -}}
-    {{- $componentName := . -}}
-
-    {{- $baseURL := "https://raw.githubusercontent.com/Altinn/app-frontend-react/chore/update-component-schemas/schemas/json/component/" -}}
-    {{- $fileExtension := ".schema.v1.json" -}}
-    {{- $URL := printf "%s%s%s" $baseURL $componentName $fileExtension -}}
-
-    {{- $jsonSchema := resources.GetRemote $URL | transform.Unmarshal -}}
-
-    {{- with $jsonSchema -}}
-        {{- $componentProps := index $jsonSchema "properties" -}}
-        {{- $requiredProps := index $jsonSchema "required" -}}
-        
-        <a href="{{- $URL -}}">JSON schema</a>
-
-        {{- with $requiredProps -}}
-            <p><strong>Required properties: </strong> {{- template "formatAsCode" $requiredProps -}}</p>
-        {{- end -}}
-
-        {{- template "properties-table" (dict "properties" $componentProps) -}}
-    {{- else -}}
-        <em>Failed to retrieve JSON schema for '{{- $componentName -}}'. Make sure the component schemaname is spelled correctly.</em>
-    {{- end -}}
+{{- $componentName := . -}}
+{{- $baseURL := "https://raw.githubusercontent.com/Altinn/app-frontend-react/main/schemas/json/component/" -}}
+{{- $fileExtension := ".schema.v1.json" -}}
+{{- $URL := printf "%s%s%s" $baseURL $componentName $fileExtension -}}
+{{- $resource := resources.GetRemote $URL -}}
+{{- $jsonSchema := "" -}}
+{{- if $resource -}}
+{{- $jsonSchema = $resource | transform.Unmarshal -}}
 {{- end -}}
+{{- with $jsonSchema -}}
+{{- $componentProps := index $jsonSchema "properties" -}}
+{{- $requiredProps := index $jsonSchema "required" -}}
+<a href="{{- $URL -}}">JSON schema</a>
+{{- with $requiredProps -}}
+<p><strong>Required properties: </strong> {{- template "formatAsCode" $requiredProps -}}</p>
+{{- end -}}
+{{- template "properties-table" (dict "properties" $componentProps) -}}
+{{- else -}}
+<em>JSON schema not yet available for '{{- $componentName -}}'. Component schemas are being migrated to the app-frontend-react repository.</em>
+{{- end -}}
+{{- end -}}%


### PR DESCRIPTION
We  are getting this error when trying to run docs:

```
Error: error building site: render: failed to render pages: render of "section" failed: "altinn-studio-docs\themes\hugo-theme-altinn\layouts\_default\list.html:3:3": execute of template failed: template: _default/list.html:3:3: executing "_default/list.html" at <.Content>: error calling Content: failed to render shortco
de: "altinn-studio-docs\content\altinn-studio\v8\reference\ux\components\Address\_index.nb.md:114:1": failed to render shortcode "component-props": failed to process shortcode: "altinn-studio-docs\layouts\shortcodes\component-props.html:19:59": execute of template failed: template: shortcodes/component-props.html:19:59: executing "getComponent" at <transform.Unmarshal>: error calling Unmarshal: no data to transform
```

This PR fixes the error, but Im not sure if its the right fix, or if this functionlaity should even be removed, please comment :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed component property documentation retrieval to use the correct repository source
  * Improved error messaging when component schemas are unavailable

* **Refactor**
  * Streamlined component schema data retrieval process for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->