### PR TITLE
Fix SubjectId for apiadmnuf in subjectoptions.json

### DIFF
--- a/content/authorization/architecture/resourceregistry/subjectoptions.json
+++ b/content/authorization/architecture/resourceregistry/subjectoptions.json
@@ -306,7 +306,7 @@
         "SubjectDescription": "Delegerbar rolle som gir  tilgang til å administrere tilgang til programmeringsgrensesnitt - API, på vegne av virksomheten."
     },
     {
-        "SubjectId": "apiadnuf",
+        "SubjectId": "apiadmnuf",
         "SubjectSource": "altinn:rolecode",
         "SubjectTitle": "Programmeringsgrensesnitt for NUF (API)",
         "SubjectDescription": "Delegerbar rolle som gir kontaktperson for norskregistrert utenlandsk foretak (NUF) tilgang til å administrere tilgang til programmeringsgrensesnitt - API, på vegne av virksomheten."


### PR DESCRIPTION
Fix typo in SubjectId for `apiadnuf` -> `apiadmnuf` in subjectoptions.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration identifier in authorization architecture settings to correct a resource reference value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->