### PR TITLE
chore: Studio - add Maskinporten scopes information to the runtime-delegated-signing guide

### DIFF
--- a/content/altinn-studio/v8/guides/development/signing/runtime-delegated-signing/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/signing/runtime-delegated-signing/_index.en.md
@@ -22,6 +22,16 @@ Available from [v8.6.0](https://github.com/Altinn/app-lib-dotnet/releases/tag/v8
 ### Maskinporten
 Maskinporten is required both for the [messaging service](#correspondence) and the interaction with [restricted data](/en/altinn-studio/v8/guides/development/restricted-data/).
 
+For runtime delegated signing, your Maskinporten client must have access to the following scopes:
+
+- `altinn:correspondence.read`
+- `altinn:correspondence.write`
+- `altinn:serviceowner/instances.read`
+- `altinn:serviceowner/instances.write`
+
+The correspondence-scopes are used when the app sends correspondence messages to signees as a call to action.
+The serviceowner scopes are used for internal state and bookkeeping in the app.
+
 If you need help setting up a Maskinporten integration for your app, you can find all the information you need in [this guide](/en/altinn-studio/v8/guides/integration/maskinporten/).
 
 ### Correspondence

--- a/content/altinn-studio/v8/guides/development/signing/runtime-delegated-signing/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/signing/runtime-delegated-signing/_index.nb.md
@@ -22,6 +22,16 @@ Tilgjengelig fra [v8.6.0](https://github.com/Altinn/app-lib-dotnet/releases/tag/
 ### Maskinporten
 Maskinporten kreves av både [meldingstjenesten](#meldingstjenesten) og for interaksjon med [beskyttede data](/nb/altinn-studio/v8/guides/development/restricted-data/).
 
+For brukerstyrt signering må Maskinporten-klienten din ha tilgang til følgende scopes:
+
+- `altinn:correspondence.read`
+- `altinn:correspondence.write`
+- `altinn:serviceowner/instances.read`
+- `altinn:serviceowner/instances.write`
+
+Scopes for correspondence brukes når appen sender meldinger til signatarer som et kall til handling.
+Tjenesteeier-scopes brukes for intern tilstands-føring i appen.
+
 Hvis du trenger hjelp med oppsett av Maskinporten i din app, finner du all informasjonen du trenger i [denne guiden](/nb/altinn-studio/v8/guides/integration/maskinporten/).
 
 ### Meldingstjenesten


### PR DESCRIPTION
We had a question from a serviceowner related to this on Slack



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated runtime delegated signing guides with required Maskinporten scopes and their usage for correspondence messaging and internal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->