### PR TITLE
fix: set correct required value for summary content type

### DIFF
--- a/content/dialogporten/reference/content-types/_index.en.md
+++ b/content/dialogporten/reference/content-types/_index.en.md
@@ -37,9 +37,9 @@ For information on how to use these, see the [creating dialogs user guide](/en/d
 ### Summary
 
 | Attribute              |        Value |
-| ---------------------- | ------------:|
+| ---------------------- |-------------:|
 | Field name             |    `summary` |
-| Required               |          Yes |
+| Required               |           No |
 | Max length             |          255 |
 | Allowed formats        | `text/plain` |
 | Used in list?          |          Yes |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for the Summary field to indicate it is no longer required.
  * Improved formatting in content type reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->