### PR TITLE
Add guide for retrieving system user tokens

### DIFF
--- a/content/api/authentication/systemuserapi/_index.en.md
+++ b/content/api/authentication/systemuserapi/_index.en.md
@@ -11,3 +11,4 @@ The system user API provides different api methods such as
 - [API for the vendor to register their system with Altinn](systemregister)
 - [API for the vendor to create and process the system user request](systemuserrequest)
 - [API for the external to retrieve system user information](systemuser)
+- [Guide: Retrieve a system user token](guides/systembrukertoken/)

--- a/content/api/authentication/systemuserapi/_index.nb.md
+++ b/content/api/authentication/systemuserapi/_index.nb.md
@@ -11,3 +11,4 @@ Systembruker-API-et tilbyr ulike API-metoder, som
 - [API som lar leverandør registrere sitt system i Altinn](systemregister)
 - [API som lar leverandør opprette og behandle en systembrukerforespørsel](systemuserrequest)
 - [API som lar eksterne hente informasjon om systembruker](systemuser)
+- [Veiledning: Hent systembrukertoken](guides/systembrukertoken/)

--- a/content/api/authentication/systemuserapi/guides/systembrukertoken/_index.en.md
+++ b/content/api/authentication/systemuserapi/guides/systembrukertoken/_index.en.md
@@ -1,0 +1,200 @@
+---
+title: Retrieve a system user token from Maskinporten
+description: "How-to guide for creating system user requests and fetching Maskinporten tokens for standard and agent system users."
+linktitle: Retrieve system user token
+weight: 10
+toc: true
+tags: [maskinporten, systemuser, authentication]
+---
+
+## Introduction
+This guide explains how to retrieve a system user token from Maskinporten. It covers both standard (own) and agent system users, highlights the practical differences, and shows separate request and response examples.
+
+## Prerequisites
+- A Maskinporten client with the relevant scopes, for example `altinn:authentication/systemuser.request.write`, `altinn:authentication/systemuser.request.read`, and the scopes for the API you plan to call.
+- A registered system in Altinn and access to the system register and system user APIs.
+- Ability to sign JWTs with your Maskinporten client certificate.
+- For agent system users: Altinn roles that allow client delegations.
+
+## Step 1 – Choose the correct system user type
+| Type | When to use it | Key differences |
+| --- | --- | --- |
+| Standard (own) | The system only represents the organisation that owns the system. | May use both `rights` and `accessPackages`. No manual client delegation after approval. |
+| Agent | The system must act on behalf of multiple customer organisations. | Use `accessPackages` only. Requires the end user to delegate clients after approval. |
+
+{{% notice info %}}
+Pick the system user type before you create the request. It affects which fields the Maskinporten token contains and which steps the end user must complete.
+{{% /notice %}}
+
+## Step 2 – Create the request
+
+### Standard request (vendor)
+**Request**
+```http
+POST https://platform.tt02.altinn.no/authentication/api/v1/systemuser/request/vendor
+Authorization: Bearer <Maskinporten token with write scope>
+Content-Type: application/json
+
+{
+  "systemId": "123456789_my-system",
+  "partyOrgNo": "987654321",
+  "rights": [
+    {
+      "resource": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "ske-krav-og-betalinger"
+        }
+      ]
+    }
+  ],
+  "accessPackages": [
+    {
+      "urn": "urn:altinn:accesspackage:skattegrunnlag"
+    }
+  ],
+  "externalRef": "customer-987654321",
+  "redirectUrl": "https://vendor.example/systemuser/receipt"
+}
+```
+
+**Response**
+```json
+{
+  "id": "0c5c58ad-4fc1-4ef9-9c72-4a3376a0c3d0",
+  "externalRef": "customer-987654321",
+  "systemId": "123456789_my-system",
+  "partyOrgNo": "987654321",
+  "rights": [
+    {
+      "resource": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "ske-krav-og-betalinger"
+        }
+      ]
+    }
+  ],
+  "status": "New",
+  "redirectUrl": "https://vendor.example/systemuser/receipt",
+  "confirmUrl": "https://am.ui.tt02.altinn.no/accessmanagement/ui/systemuser/request?id=0c5c58ad-4fc1-4ef9-9c72-4a3376a0c3d0"
+}
+```
+
+### Agent request (vendor/agent)
+**Request**
+```http
+POST https://platform.tt02.altinn.no/authentication/api/v1/systemuser/request/vendor/agent
+Authorization: Bearer <Maskinporten token with write scope>
+Content-Type: application/json
+
+{
+  "systemId": "123456789_accounting",
+  "partyOrgNo": "912345678",
+  "accessPackages": [
+    {
+      "urn": "urn:altinn:accesspackage:regnskapsforer-med-signeringsrett"
+    }
+  ],
+  "externalRef": "customer-912345678",
+  "redirectUrl": "https://vendor.example/systemuser/receipt"
+}
+```
+
+**Response**
+```json
+{
+  "id": "78b6c716-9d1d-4ff4-9c92-55296e6bb4f6",
+  "externalRef": "customer-912345678",
+  "systemId": "123456789_accounting",
+  "partyOrgNo": "912345678",
+  "accessPackages": [
+    {
+      "urn": "urn:altinn:accesspackage:regnskapsforer-med-signeringsrett"
+    }
+  ],
+  "status": "New",
+  "redirectUrl": "https://vendor.example/systemuser/receipt",
+  "confirmUrl": "https://am.ui.tt02.altinn.no/accessmanagement/ui/systemuser/agentrequest?id=78b6c716-9d1d-4ff4-9c92-55296e6bb4f6"
+}
+```
+
+{{% notice warning %}}
+Keep request and response payloads separate. Several users have tried to post the response back to the API, which fails.
+{{% /notice %}}
+
+## Step 3 – Ask the end user to approve
+1. Send the `confirmUrl` from the response to the end user.
+2. The end user signs in to Altinn and approves the request.
+3. The API updates the status to `Accepted` or `Rejected`.
+4. Poll the status through `GET /authentication/api/v1/systemuser/request/vendor/{id}` (or the agent variant).
+
+## Step 4 – Delegate clients (agent only)
+Once the agent request is approved, the end user must delegate customer organisations to the agent system user.
+
+1. **List available clients**
+   ```http
+   GET https://platform.tt02.altinn.no/authentication/api/v1/enduser/systemuser/clients/available?agent={systemUserId}
+   ```
+2. **Add a client**
+   ```http
+   POST https://platform.tt02.altinn.no/authentication/api/v1/enduser/systemuser/clients/?agent={systemUserId}&client={clientId}
+   ```
+3. **Verify the delegation**
+   ```http
+   GET https://platform.tt02.altinn.no/authentication/api/v1/enduser/systemuser/clients/?agent={systemUserId}
+   ```
+
+## Step 5 – Retrieve the token from Maskinporten
+
+### 5.1 Prepare `authorization_details`
+```json
+{
+  "authorization_details": [
+    {
+      "type": "urn:altinn:systemuser",
+      "systemuser_org": {
+        "authority": "iso6523-actorid-upis",
+        "ID": "0192:987654321"
+      },
+      "externalRef": "customer-987654321"
+    }
+  ]
+}
+```
+- `systemuser_org.ID` is the organisation number of the customer that approved the request, prefixed with `0192:`.
+- `externalRef` is optional but recommended if you rely on your own identifiers.
+
+### 5.2 Sign the JWT
+Include the following claims when you sign the JWT with your Maskinporten client certificate:
+- `aud`: `https://maskinporten.no/token` (or the relevant environment)
+- `iss` and `sub`: your Maskinporten client ID
+- `scope`: at least one API scope you need (for example `altinn:maskinporten/systemuser.read`)
+- `exp`, `iat`, `jti`: standard time and identifier claims
+- `authorization_details`: the object from the previous step
+
+### 5.3 Call the Maskinporten token endpoint
+```http
+POST https://test.maskinporten.no/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<base64url-signed-jwt>
+```
+
+### 5.4 Inspect the response
+```json
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "token_type": "Bearer",
+  "expires_in": 599,
+  "scope": "altinn:maskinporten/systemuser.read"
+}
+```
+Decoding `access_token` reveals:
+- `authorization_details[0].system_id`: the approved system
+- `authorization_details[0].systemuser_id`: the UUID of the system user
+- `authorization_details[0].systemuser_org`: the organisation that owns the system user
+- `consumer`: the Maskinporten client that fetched the token
+
+## Next steps
+Send the `access_token` as a Bearer token when invoking APIs that rely on Altinn authorisation. Tokens typically expire after about 10 minutes, so plan to renew them frequently.

--- a/content/api/authentication/systemuserapi/guides/systembrukertoken/_index.nb.md
+++ b/content/api/authentication/systemuserapi/guides/systembrukertoken/_index.nb.md
@@ -1,0 +1,200 @@
+---
+title: Hent systembrukertoken fra Maskinporten
+description: "Veiledning for å opprette systembrukerforespørsler og hente Maskinporten-token for standard og agent-systembrukere."
+linktitle: Hent systembrukertoken
+weight: 10
+toc: true
+tags: [maskinporten, systembruker, autentisering]
+---
+
+## Introduksjon
+Denne veiledningen viser hvordan du henter et systembrukertoken fra Maskinporten. Den dekker både standard (egen) og agent-systembrukere, forklarer hva som skiller dem, og viser hvordan du lager tydelige forespørsels- og responsobjekter.
+
+## Forutsetninger
+- Maskinporten-klient med relevante scopes, for eksempel `altinn:authentication/systemuser.request.write`, `altinn:authentication/systemuser.request.read` og scopes for API-et som skal kalles.
+- Registrert system i Altinn og tilgang til systemregister- og systembruker-API-et.
+- Mulighet til å signere JWT-er med klientsertifikatet ditt i Maskinporten.
+- For agent-systembrukere: Roller i Altinn som gir rett til å delegere klientorganisasjoner.
+
+## Trinn 1 – Velg riktig systembrukertype
+| Type | Når brukes den? | Viktige forskjeller |
+| --- | --- | --- |
+| Standard (egen) | Systemet representerer kun organisasjonen som eier systemet. | Kan bruke både `rights` og `accessPackages`. Ingen manuell klientdelegering etter godkjenning. |
+| Agent | Systemet skal handle på vegne av flere kundeorganisasjoner. | Bruk kun `accessPackages`. Krever at sluttbruker delegerer klienter etter godkjenning. |
+
+{{% notice info %}}
+Velg systembrukertype før du lager forespørselen. Det påvirker hvilke felt Maskinporten-tokenet inneholder og hvilke steg brukeren må gjennom.
+{{% /notice %}}
+
+## Trinn 2 – Opprett forespørselen
+
+### Standard-forespørsel (vendor)
+**Request**
+```http
+POST https://platform.tt02.altinn.no/authentication/api/v1/systemuser/request/vendor
+Authorization: Bearer <Maskinporten-token med write-scope>
+Content-Type: application/json
+
+{
+  "systemId": "123456789_mitt-system",
+  "partyOrgNo": "987654321",
+  "rights": [
+    {
+      "resource": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "ske-krav-og-betalinger"
+        }
+      ]
+    }
+  ],
+  "accessPackages": [
+    {
+      "urn": "urn:altinn:accesspackage:skattegrunnlag"
+    }
+  ],
+  "externalRef": "kunde-987654321",
+  "redirectUrl": "https://leverandor.no/systembruker/mottatt"
+}
+```
+
+**Response**
+```json
+{
+  "id": "0c5c58ad-4fc1-4ef9-9c72-4a3376a0c3d0",
+  "externalRef": "kunde-987654321",
+  "systemId": "123456789_mitt-system",
+  "partyOrgNo": "987654321",
+  "rights": [
+    {
+      "resource": [
+        {
+          "id": "urn:altinn:resource",
+          "value": "ske-krav-og-betalinger"
+        }
+      ]
+    }
+  ],
+  "status": "New",
+  "redirectUrl": "https://leverandor.no/systembruker/mottatt",
+  "confirmUrl": "https://am.ui.tt02.altinn.no/accessmanagement/ui/systemuser/request?id=0c5c58ad-4fc1-4ef9-9c72-4a3376a0c3d0"
+}
+```
+
+### Agent-forespørsel (vendor/agent)
+**Request**
+```http
+POST https://platform.tt02.altinn.no/authentication/api/v1/systemuser/request/vendor/agent
+Authorization: Bearer <Maskinporten-token med write-scope>
+Content-Type: application/json
+
+{
+  "systemId": "123456789_regnskapsfører",
+  "partyOrgNo": "912345678",
+  "accessPackages": [
+    {
+      "urn": "urn:altinn:accesspackage:regnskapsforer-med-signeringsrett"
+    }
+  ],
+  "externalRef": "kunde-912345678",
+  "redirectUrl": "https://leverandor.no/systembruker/mottatt"
+}
+```
+
+**Response**
+```json
+{
+  "id": "78b6c716-9d1d-4ff4-9c92-55296e6bb4f6",
+  "externalRef": "kunde-912345678",
+  "systemId": "123456789_regnskapsfører",
+  "partyOrgNo": "912345678",
+  "accessPackages": [
+    {
+      "urn": "urn:altinn:accesspackage:regnskapsforer-med-signeringsrett"
+    }
+  ],
+  "status": "New",
+  "redirectUrl": "https://leverandor.no/systembruker/mottatt",
+  "confirmUrl": "https://am.ui.tt02.altinn.no/accessmanagement/ui/systemuser/agentrequest?id=78b6c716-9d1d-4ff4-9c92-55296e6bb4f6"
+}
+```
+
+{{% notice warning %}}
+Hold forespørsler (request) og responser adskilt. Flere brukere har forsøkt å sende responsobjektet tilbake til API-et, noe som feiler.
+{{% /notice %}}
+
+## Trinn 3 – Be sluttbruker godkjenne
+1. Send `confirmUrl` til sluttbrukeren.
+2. Sluttbrukeren logger inn i Altinn og godkjenner forespørselen.
+3. API-et oppdaterer status til `Accepted` eller `Rejected`.
+4. Du kan sjekke status via `GET /authentication/api/v1/systemuser/request/vendor/{id}` eller agent-varianten.
+
+## Trinn 4 – Delegere klienter (kun agent)
+Når forespørselen er godkjent må sluttbruker delegere hvilke kundeorganisasjoner agenten skal håndtere.
+
+1. **List tilgjengelige klienter**
+   ```http
+   GET https://platform.tt02.altinn.no/authentication/api/v1/enduser/systemuser/clients/available?agent={systemUserId}
+   ```
+2. **Legg til klient**
+   ```http
+   POST https://platform.tt02.altinn.no/authentication/api/v1/enduser/systemuser/clients/?agent={systemUserId}&client={clientId}
+   ```
+3. **Bekreft delegering**
+   ```http
+   GET https://platform.tt02.altinn.no/authentication/api/v1/enduser/systemuser/clients/?agent={systemUserId}
+   ```
+
+## Trinn 5 – Hent token fra Maskinporten
+
+### 5.1 Lag `authorization_details`
+```json
+{
+  "authorization_details": [
+    {
+      "type": "urn:altinn:systemuser",
+      "systemuser_org": {
+        "authority": "iso6523-actorid-upis",
+        "ID": "0192:987654321"
+      },
+      "externalRef": "kunde-987654321"
+    }
+  ]
+}
+```
+- `systemuser_org.ID` er organisasjonsnummeret til kunden som godkjente forespørselen, med prefiks `0192:`.
+- `externalRef` er valgfri, men anbefales hvis du bruker egne referanser.
+
+### 5.2 Signer JWT-en
+Inkluder følgende claims når du signerer JWT-en med Maskinporten-klientsertifikatet:
+- `aud`: `https://maskinporten.no/token` (eller test-endepunktet)
+- `iss` og `sub`: klient-ID-en i Maskinporten
+- `scope`: minst ett API-scope du trenger (for eksempel `altinn:maskinporten/systemuser.read`)
+- `exp`, `iat`, `jti`: standard tids- og identifikasjonsfelt
+- `authorization_details`: objektet fra forrige steg
+
+### 5.3 Send forespørselen til Maskinporten
+```http
+POST https://test.maskinporten.no/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=<base64url-signert-jwt>
+```
+
+### 5.4 Les responsen
+```json
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "token_type": "Bearer",
+  "expires_in": 599,
+  "scope": "altinn:maskinporten/systemuser.read"
+}
+```
+Dekoder du `access_token` finner du:
+- `authorization_details[0].system_id`: systemet som ble godkjent
+- `authorization_details[0].systemuser_id`: UUID-en til systembrukeren
+- `authorization_details[0].systemuser_org`: organisasjonen som eier systembrukeren
+- `consumer`: Maskinporten-klienten som hentet tokenet
+
+## Neste steg
+Bruk `access_token` som `Bearer`-token når du kaller API-er som forutsetter Altinn-autorisasjon. Tokenet er vanligvis gyldig i rundt 10 minutter, så planlegg for fornyelse.


### PR DESCRIPTION
## Summary
- add bilingual how-to guide for fetching Maskinporten system user tokens
- document differences between standard and agent system users
- link the new guide from the system user API landing page
- note that the guide was authored with AI assistance 

## Testing
- python utils/pii-check/pii-check.py --root-folder content/api/authentication/systemuserapi/guides/systembrukertoken --config-file utils/pii-check/permitted-data.config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for retrieving system user tokens from Maskinporten. Documentation covers prerequisites, step-by-step instructions, example requests and responses, and token usage information for both standard and agent system users.
  * Updated System User API documentation index with direct links to the new token retrieval guides in both English and Norwegian.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->