### PR TITLE
Add validation error codes documentation for Notifications API

### DIFF
--- a/content/notifications/reference/error-codes/_index.en.md
+++ b/content/notifications/reference/error-codes/_index.en.md
@@ -243,6 +243,8 @@ The following table shows all validation error codes that can be returned by the
 
 ### Dialogporten Validation
 
+These validations only check that the GUID format is correct. No verification is performed against Dialogporten to check whether the dialog or transmission actually exists.
+
 | Code | Description |
 |------|-------------|
 | `NOT.VLD-00100` | DialogId must be a valid non-empty GUID |

--- a/content/notifications/reference/error-codes/_index.en.md
+++ b/content/notifications/reference/error-codes/_index.en.md
@@ -10,9 +10,44 @@ This page provides a comprehensive reference for all specific error codes return
 
 ## Error Code Format
 
-Altinn Notifications API uses unique error codes in the format `NOT-XXXXX` where `NOT` stands for Notifications and `XXXXX` is a five-digit number.
+Altinn Notifications API uses two types of error codes:
 
-These error codes are returned in the `code` field of the problem details response. The `code` field is an extension member as defined by [RFC 7807](https://tools.ietf.org/html/rfc7807) (Problem Details for HTTP APIs), providing machine-readable error identification.
+### Business Errors
+Format: `NOT-XXXXX` where `NOT` stands for Notifications and `XXXXX` is a five-digit number.
+
+These error codes are returned in the `code` field of the problem details response for business logic errors (e.g., missing contact information, resource not found).
+
+### Validation Errors
+Format: `NOT.VLD-XXXXX` where `VLD` indicates a validation error.
+
+Validation errors are returned when the request contains invalid data. The response contains:
+- A top-level `code` with value `STD-00000`
+- A `validationErrors` array with individual validation errors, each with its own `code`
+
+**Example validation error response:**
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "One or more validation errors occurred.",
+  "code": "STD-00000",
+  "validationErrors": [
+    {
+      "code": "NOT.VLD-00001",
+      "detail": "IdempotencyId cannot be null or empty.",
+      "paths": ["IdempotencyId"]
+    },
+    {
+      "code": "NOT.VLD-00010",
+      "detail": "The requested send time value must have specified a time zone.",
+      "paths": ["RequestedSendTime"]
+    }
+  ]
+}
+```
+
+These error codes are defined using [RFC 7807](https://tools.ietf.org/html/rfc7807) (Problem Details for HTTP APIs), providing machine-readable error identification.
 
 ## Error Codes
 
@@ -113,6 +148,105 @@ This error is not expected during normal operation. It indicates that the client
 - Ensure you are querying the correct environment (test or production)
 - Verify that the authenticated organization has access to the shipment
 - Check that the shipment was successfully created before attempting to retrieve it
+
+---
+
+## Validation Error Codes
+
+The following table shows all validation error codes that can be returned by the API. These are returned in the `validationErrors` array in the response.
+
+### Basic Request Validation
+
+| Code | Description |
+|------|-------------|
+| `NOT.VLD-00001` | IdempotencyId cannot be null or empty |
+
+### Send Time Validation
+
+| Code | Description |
+|------|-------------|
+| `NOT.VLD-00010` | The requested send time value must have specified a time zone |
+| `NOT.VLD-00011` | Send time cannot be in the past |
+
+### Condition Endpoint Validation
+
+| Code | Description |
+|------|-------------|
+| `NOT.VLD-00020` | ConditionEndpoint must be a valid absolute URI or null |
+| `NOT.VLD-00021` | ConditionEndpoint must use http or https scheme |
+
+### Recipient Validation
+
+| Code | Description |
+|------|-------------|
+| `NOT.VLD-00030` | Must have exactly one recipient |
+| `NOT.VLD-00031` | Recipient specification cannot be null |
+| `NOT.VLD-00032` | One or more recipient is required |
+| `NOT.VLD-00033` | Invalid email address format |
+| `NOT.VLD-00034` | Invalid sender email address format |
+| `NOT.VLD-00035` | Mobile number can contain only '+' and numeric characters, and must adhere to E.164 standard |
+| `NOT.VLD-00036` | National identity number must be 11 digits |
+| `NOT.VLD-00037` | Organization number must be 9 digits |
+| `NOT.VLD-00038` | OrgNumber cannot be null or empty |
+| `NOT.VLD-00039` | ResourceId must have valid syntax |
+| `NOT.VLD-00040` | National identity number cannot be combined with other identifiers |
+| `NOT.VLD-00041` | Organization number cannot be combined with other identifiers |
+| `NOT.VLD-00042` | Recipient missing contact information for preferred channel |
+| `NOT.VLD-00043` | Recipient missing contact information for SMS channel |
+| `NOT.VLD-00044` | Recipient missing contact information for email channel |
+
+### Email Settings Validation
+
+| Code | Description |
+|------|-------------|
+| `NOT.VLD-00050` | Email sending options cannot be null |
+| `NOT.VLD-00051` | Email subject cannot be empty |
+| `NOT.VLD-00052` | Email body cannot be empty |
+| `NOT.VLD-00053` | Email content type must be either Plain or HTML |
+| `NOT.VLD-00054` | Email only supports send time policy "Anytime" |
+
+### SMS Settings Validation
+
+| Code | Description |
+|------|-------------|
+| `NOT.VLD-00060` | SMS body cannot be null or empty |
+| `NOT.VLD-00061` | SMS only supports send time policy "Daytime" and "Anytime" |
+
+### Reminder Validation
+
+| Code | Description |
+|------|-------------|
+| `NOT.VLD-00070` | Either DelayDays or RequestedSendTime must be defined, but not both |
+| `NOT.VLD-00071` | DelayDays must be at least 1 day |
+| `NOT.VLD-00072` | RequestedSendTime must be null when DelayDays is set |
+| `NOT.VLD-00073` | DelayDays must be null when RequestedSendTime is set |
+| `NOT.VLD-00074` | Reminder send time must have a time zone specified |
+| `NOT.VLD-00075` | Reminder send time cannot be in the past |
+
+### Channel Schema Validation
+
+| Code | Description |
+|------|-------------|
+| `NOT.VLD-00080` | Invalid channel schema value |
+| `NOT.VLD-00081` | EmailSettings must be set when ChannelSchema is EmailAndSms |
+| `NOT.VLD-00082` | SmsSettings must be set when ChannelSchema is EmailAndSms |
+| `NOT.VLD-00083` | EmailSettings must be set when ChannelSchema is SmsPreferred or EmailPreferred |
+| `NOT.VLD-00084` | SmsSettings must be set when ChannelSchema is SmsPreferred or EmailPreferred |
+| `NOT.VLD-00085` | SmsSettings must be set when ChannelSchema is Sms |
+| `NOT.VLD-00086` | EmailSettings must be set when ChannelSchema is Email |
+
+### Status Feed Validation
+
+| Code | Description |
+|------|-------------|
+| `NOT.VLD-00090` | Sequence number cannot be less than 0 |
+
+### Dialogporten Validation
+
+| Code | Description |
+|------|-------------|
+| `NOT.VLD-00100` | DialogId must be a valid non-empty GUID |
+| `NOT.VLD-00101` | TransmissionId must be a valid non-empty GUID |
 
 ---
 

--- a/content/notifications/reference/error-codes/_index.nb.md
+++ b/content/notifications/reference/error-codes/_index.nb.md
@@ -242,6 +242,8 @@ Følgende tabell viser alle valideringsfeilkoder som kan returneres av API-et. D
 
 ### Dialogporten-validering
 
+Disse valideringene kontrollerer kun at GUID-formatet er korrekt. Det gjøres ingen verifisering mot Dialogporten for å sjekke om dialogen eller forsendelsen faktisk eksisterer.
+
 | Kode | Beskrivelse |
 |------|-------------|
 | `NOT.VLD-00100` | DialogId må være en gyldig ikke-tom GUID |

--- a/content/notifications/reference/error-codes/_index.nb.md
+++ b/content/notifications/reference/error-codes/_index.nb.md
@@ -10,9 +10,44 @@ Denne siden gir en omfattende referanse for alle spesifikke feilkoder som return
 
 ## Feilkodeformat
 
-Altinn Notifications API bruker unike feilkoder i formatet `NOT-XXXXX` hvor `NOT` står for Notifications og `XXXXX` er et femsifret nummer.
+Altinn Notifications API bruker to typer feilkoder:
 
-Disse feilkodene returneres i `code`-feltet i problemdetaljrespons. `code`-feltet er et utvidelsesmedlem som definert av [RFC 7807](https://tools.ietf.org/html/rfc7807) (Problem Details for HTTP APIs), som gir maskinlesbar feilidentifikasjon.
+### Forretningsfeil
+Format: `NOT-XXXXX` hvor `NOT` står for Notifications og `XXXXX` er et femsifret nummer.
+
+Disse feilkodene returneres i `code`-feltet i problemdetaljrespons for forretningslogikkfeil (f.eks. manglende kontaktinformasjon, ressurs ikke funnet).
+
+### Valideringsfeil
+Format: `NOT.VLD-XXXXX` hvor `VLD` indikerer en valideringsfeil.
+
+Valideringsfeil returneres når forespørselen inneholder ugyldig data. Responsen inneholder:
+- En overordnet `code` med verdi `STD-00000`
+- Et `validationErrors`-array med individuelle valideringsfeil, hver med sin egen `code`
+
+**Eksempelrespons for valideringsfeil:**
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "One or more validation errors occurred.",
+  "code": "STD-00000",
+  "validationErrors": [
+    {
+      "code": "NOT.VLD-00001",
+      "detail": "IdempotencyId cannot be null or empty.",
+      "paths": ["IdempotencyId"]
+    },
+    {
+      "code": "NOT.VLD-00010",
+      "detail": "The requested send time value must have specified a time zone.",
+      "paths": ["RequestedSendTime"]
+    }
+  ]
+}
+```
+
+Disse feilkodene er definert ved hjelp av [RFC 7807](https://tools.ietf.org/html/rfc7807) (Problem Details for HTTP APIs), som gir maskinlesbar feilidentifikasjon.
 
 ## Feilkoder
 
@@ -112,6 +147,105 @@ Denne feilen er ikke forventet under normal drift. Feilen indikerer at klienten 
 - Forsikre deg om at du spør i riktig miljø (test eller produksjon)
 - Verifiser at den autentiserte organisasjonen har tilgang til forsendelsen
 - Sjekk at forsendelsen ble vellykket opprettet før du prøver å hente den
+
+---
+
+## Valideringsfeilkoder
+
+Følgende tabell viser alle valideringsfeilkoder som kan returneres av API-et. Disse returneres i `validationErrors`-arrayet i responsen.
+
+### Grunnleggende forespørselsvalidering
+
+| Kode | Beskrivelse |
+|------|-------------|
+| `NOT.VLD-00001` | IdempotencyId kan ikke være null eller tom |
+
+### Sendetidsvalidering
+
+| Kode | Beskrivelse |
+|------|-------------|
+| `NOT.VLD-00010` | Ønsket sendetid må ha spesifisert tidssone |
+| `NOT.VLD-00011` | Sendetid kan ikke være i fortiden |
+
+### Betingelsesendepunkt-validering
+
+| Kode | Beskrivelse |
+|------|-------------|
+| `NOT.VLD-00020` | ConditionEndpoint må være en gyldig absolutt URI eller null |
+| `NOT.VLD-00021` | ConditionEndpoint må bruke http eller https-skjema |
+
+### Mottakervalidering
+
+| Kode | Beskrivelse |
+|------|-------------|
+| `NOT.VLD-00030` | Må ha nøyaktig én mottaker |
+| `NOT.VLD-00031` | Mottakerspesifikasjon kan ikke være null |
+| `NOT.VLD-00032` | Én eller flere mottakere er påkrevd |
+| `NOT.VLD-00033` | Ugyldig e-postadresseformat |
+| `NOT.VLD-00034` | Ugyldig avsender-e-postadresseformat |
+| `NOT.VLD-00035` | Mobilnummer kan kun inneholde '+' og numeriske tegn, og må følge E.164-standarden |
+| `NOT.VLD-00036` | Fødselsnummer må være 11 siffer |
+| `NOT.VLD-00037` | Organisasjonsnummer må være 9 siffer |
+| `NOT.VLD-00038` | OrgNumber kan ikke være null eller tom |
+| `NOT.VLD-00039` | ResourceId må ha gyldig syntaks |
+| `NOT.VLD-00040` | Fødselsnummer kan ikke kombineres med andre identifikatorer |
+| `NOT.VLD-00041` | Organisasjonsnummer kan ikke kombineres med andre identifikatorer |
+| `NOT.VLD-00042` | Mottaker mangler kontaktinformasjon for foretrukket kanal |
+| `NOT.VLD-00043` | Mottaker mangler kontaktinformasjon for SMS-kanal |
+| `NOT.VLD-00044` | Mottaker mangler kontaktinformasjon for e-postkanal |
+
+### E-postinnstillinger-validering
+
+| Kode | Beskrivelse |
+|------|-------------|
+| `NOT.VLD-00050` | E-postsendingsalternativer kan ikke være null |
+| `NOT.VLD-00051` | E-postemne kan ikke være tomt |
+| `NOT.VLD-00052` | E-postinnhold kan ikke være tomt |
+| `NOT.VLD-00053` | E-postinnholdstype må være enten Plain eller HTML |
+| `NOT.VLD-00054` | E-post støtter kun sendetidspolicy «Anytime» |
+
+### SMS-innstillinger-validering
+
+| Kode | Beskrivelse |
+|------|-------------|
+| `NOT.VLD-00060` | SMS-innhold kan ikke være null eller tomt |
+| `NOT.VLD-00061` | SMS støtter kun sendetidspolicy «Daytime» og «Anytime» |
+
+### Påminnelsesvalidering
+
+| Kode | Beskrivelse |
+|------|-------------|
+| `NOT.VLD-00070` | Enten DelayDays eller RequestedSendTime må være definert, men ikke begge |
+| `NOT.VLD-00071` | DelayDays må være minst 1 dag |
+| `NOT.VLD-00072` | RequestedSendTime må være null når DelayDays er satt |
+| `NOT.VLD-00073` | DelayDays må være null når RequestedSendTime er satt |
+| `NOT.VLD-00074` | Påminnelsens sendetid må ha spesifisert tidssone |
+| `NOT.VLD-00075` | Påminnelsens sendetid kan ikke være i fortiden |
+
+### Kanalskjema-validering
+
+| Kode | Beskrivelse |
+|------|-------------|
+| `NOT.VLD-00080` | Ugyldig kanalskjemaverdi |
+| `NOT.VLD-00081` | EmailSettings må settes når ChannelSchema er EmailAndSms |
+| `NOT.VLD-00082` | SmsSettings må settes når ChannelSchema er EmailAndSms |
+| `NOT.VLD-00083` | EmailSettings må settes når ChannelSchema er SmsPreferred eller EmailPreferred |
+| `NOT.VLD-00084` | SmsSettings må settes når ChannelSchema er SmsPreferred eller EmailPreferred |
+| `NOT.VLD-00085` | SmsSettings må settes når ChannelSchema er Sms |
+| `NOT.VLD-00086` | EmailSettings må settes når ChannelSchema er Email |
+
+### Statusfeed-validering
+
+| Kode | Beskrivelse |
+|------|-------------|
+| `NOT.VLD-00090` | Sekvensnummer kan ikke være mindre enn 0 |
+
+### Dialogporten-validering
+
+| Kode | Beskrivelse |
+|------|-------------|
+| `NOT.VLD-00100` | DialogId må være en gyldig ikke-tom GUID |
+| `NOT.VLD-00101` | TransmissionId må være en gyldig ikke-tom GUID |
 
 ---
 


### PR DESCRIPTION
## Summary
Updates the Notifications API error codes reference documentation to include the new validation error codes.

## Changes
- Adds explanation of two error code formats:
  - Business errors: `NOT-XXXXX`
  - Validation errors: `NOT.VLD-XXXXX`
- Adds example response showing the `validationErrors` array format
- Documents all 30+ validation error codes in organized tables by category

## Related
- Implementation PR: Altinn/altinn-notifications#1259
- Issue: Altinn/altinn-notifications#1189

## Test plan
- [ ] Preview documentation renders correctly
- [ ] Tables are properly formatted
- [ ] Code examples are correctly displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

- Restructured error code reference documentation for improved clarity and usability
- Introduced explicit separation between business error codes (NOT-XXXXX) and validation error codes (NOT.VLD-XXXXX) formats
- Added comprehensive validation error code reference with organized categories (request validation, timing, endpoints, recipients, email/SMS settings, reminders, channel schema, status feed, integration validation)
- Enhanced documentation with JSON example responses demonstrating validation error handling and machine-readable error identification

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->