### PR TITLE
Forsendelser og vedlegg blir sortert på ID

### DIFF
--- a/content/dialogporten/getting-started/dialogs/_index.en.md
+++ b/content/dialogporten/getting-started/dialogs/_index.en.md
@@ -31,7 +31,7 @@ Additionally, a dialog may contain a content reference called a [front channel e
 
 ## Transmissions
 
-A transmission is used to describe a single "communication" between the service owner and the party within a dialog Transmissions can typically be messages, pre-filled forms and receipts from the service provider, or submitted forms/messages from the party related to the dialog. The dialog may contain zero or more transmissions represented in a chronologically sorted list. Each transmission and the list of transmissions are immutable; it is only possible to append new tranmissions to the list, not change or delete transmissions.
+A transmission is used to describe a single "communication" between the service owner and the party within a dialog Transmissions can typically be messages, pre-filled forms and receipts from the service provider, or submitted forms/messages from the party related to the dialog. The dialog may contain zero or more transmissions represented in a list sorted by ID. This ID can both be set manual or be auto generated on creation. Each transmission and the list of transmissions are immutable; it is only possible to append new tranmissions to the list, not change or delete transmissions.
 
 A transmission contains some textual metadata (title, summary) that explains what the transmission is, including [front channel embeds](/en/dialogporten/getting-started/front-channel-embeds/). Additionally, a transmission may contain one or more [attachments](#attachments).
 
@@ -47,7 +47,7 @@ API actions and activity log entries may refer to single transmissions.
 
 Attachments are files referenced by one or more URLs, supporting various representations of the same logical resource (ie. various formats, such as PDF, XML, JSON etc), for either GUI-consumers (ie. end user in web browser) or API-consumers (structured formats for custom end user systems). In addition to the URLs, there are some describing metadata that can be used to identity what the attachment is.
 
-Attachments can be used on both transmission and dialog level.
+Attachments can be used on both transmission and dialog level. They are also sorted on ID which can be set manually or auto generated on creation
 
 **Read more**
 

--- a/content/dialogporten/getting-started/dialogs/_index.nb.md
+++ b/content/dialogporten/getting-started/dialogs/_index.nb.md
@@ -31,7 +31,7 @@ I tillegg kan en dialog inneholde en innholdsreferanse kalt en [front channel em
 
 ## Forsendelser
 
-En forsendelse brukes til å beskrive en enkelt "kommunikasjon" mellom tjenesteeieren og parten i en dialog. Forsendelser kan typisk være meldinger, forhåndsutfylte skjemaer og kvitteringer fra tjenesteleverandøren, eller innsendte skjemaer/meldinger fra parten knyttet til dialogen. Dialogen kan inneholde null eller flere forsendelser representert i en kronologisk sortert liste. Hver forsendelse og listen over forsendelser er uforanderlige; det er bare mulig å legge til nye forsendelser i listen, ikke endre eller slette forsendelser.
+En forsendelse brukes til å beskrive en enkelt "kommunikasjon" mellom tjenesteeieren og parten i en dialog. Forsendelser kan typisk være meldinger, forhåndsutfylte skjemaer og kvitteringer fra tjenesteleverandøren, eller innsendte skjemaer/meldinger fra parten knyttet til dialogen. Dialogen kan inneholde null eller flere forsendelser representert i en liste sortert etter ID. Denne IDen kan både settes manuelt, eller bli generert automatisk ved opprettelse av en ny forsendelse. Hver forsendelse og listen over forsendelser er uforanderlige; det er bare mulig å legge til nye forsendelser i listen, ikke endre eller slette forsendelser.
 
 En forsendelse inneholder noen tekstlige metadata (tittel, sammendrag) som forklarer hva forsendelsen er, inkludert [front channel embed](/nb/dialogporten/getting-started/front-channel-embeds/). I tillegg kan en forsendelse inneholde ett eller flere [vedlegg](#vedlegg).
 
@@ -47,7 +47,7 @@ API-handlinger og aktivitetsloggoppføringer kan referere til enkelte forsendels
 
 Vedlegg er filer referert av en eller flere URL-er, som støtter ulike representasjoner av den samme logiske ressursen (dvs. ulike formater, som PDF, XML, JSON osv.), for enten GUI-konsumenter (dvs. sluttbruker i nettleser) eller API-konsumenter (strukturerte formater for tilpassede sluttbrukersystemer). I tillegg til URL-ene er det noen beskrivende metadata som kan brukes til å identifisere hva vedlegget er.
 
-Vedlegg kan brukes både på forsendelse- og dialognivå.
+Vedlegg kan brukes både på forsendelse- og dialognivå. De er også sortert på ID som kan settes manuelt eller bli generert automatisk ved opprettelse.
 
 **Les mer**
 


### PR DESCRIPTION
La til informasjon om at forsendelser og vedlegg blir sortert på ID.
ID kan settes manuelt eller auto genereres ved opprettelse




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify sorting behavior for transmissions and attachments
  * Clarified that both are sorted by ID rather than chronologically
  * Noted that IDs can be manually set or automatically generated during creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->