### PR TITLE
added docs for colSpan and hidden kolonner

### DIFF
--- a/content/altinn-studio/v8/reference/ux/components/grid/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/components/grid/_index.en.md
@@ -246,7 +246,7 @@ be displayed when the component is displayed outside of a Grid - such as on [sma
 
 The Grid component supports both column spanning (`colSpan`) and column hiding (`hidden`).
 
-- `colSpan` lets a cell cover multiple columns. It can be configured either via `gridColumnOptions.colSpan` or a top‑level `colSpan` on the cell.
+- `colSpan` lets a cell cover multiple columns. It can be configured via `gridColumnOptions.colSpan`.
 - `hidden` hides an entire column. It applies at the column level (header + the corresponding cells in the rows below), and it can be configured only via `columnOptions.hidden`.
 
 Example with `colSpan`:

--- a/content/altinn-studio/v8/reference/ux/components/grid/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/components/grid/_index.en.md
@@ -242,13 +242,12 @@ text resources should still be set on the component, as they will be used for ac
 be displayed when the component is displayed outside of a Grid - such as on [smaller screens](#mobile-support) and in
 [a Summary](/en/altinn-studio/v8/reference/ux/pages/summary/).
 
-### Column span and hidden columns
+### Column spanning and column hiding
 
-The Grid component supports both column span (`colSpan`) and column-level hiding (`hidden`) for each cell.
+The Grid component supports both column spanning (`colSpan`) and column hiding (`hidden`).
 
-- `colSpan` lets a cell span across multiple columns.
-- `hidden` hides a column.
-- Values can be set directly on the cell or via `gridColumnOptions`.
+- `colSpan` lets a cell cover multiple columns. It can be configured either via `gridColumnOptions.colSpan` or a top‑level `colSpan` on the cell.
+- `hidden` hides an entire column. It applies at the column level (header + the corresponding cells in the rows below), and it can be configured only via `columnOptions.hidden`.
 
 Example with `colSpan`:
 ```json
@@ -267,13 +266,15 @@ Example with `hidden`:
   "header": true,
   "cells": [
     { "text": "Column A" },
-    { "text": "Column B", "gridColumnOptions": { "hidden": true } },
+    { "text": "Column B", "columnOptions": { "hidden": true } },
     { "text": "Column C" }
   ]
 }
 ```
-`hidden` applies to the column level (header + corresponding cells in rows below).
-Note: When you use  `colSpan`, cells covered by the span should be removed or set to `null`, otherwise the table layout may become unpredictable.
+
+Note: _When using `colSpan`, you must remove the cells covered by the column span or set them to `null`, otherwise the table layout may become unpredictable._
+
+Note: _If you configure a cell so its `colSpan` covers one or more columns that are also hidden, the table still renders, but the layout may not match what you expect. In development, the app logs a short warning in the browser console that describes which cell spans how many columns and that it overlaps hidden column(s), and that this may cause unexpected layout. Avoid combining a `colSpan` with hidden columns if you need a predictable table._
 
 ### Widths, text and alignment
 

--- a/content/altinn-studio/v8/reference/ux/components/grid/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/components/grid/_index.en.md
@@ -246,7 +246,7 @@ be displayed when the component is displayed outside of a Grid - such as on [sma
 
 The Grid component supports both column spanning (`colSpan`) and column hiding (`hidden`).
 
-- `colSpan` lets a cell cover multiple columns. It can be configured via `gridColumnOptions.colSpan`.
+- `colSpan` lets a cell cover multiple columns. It can be configured via `cellStyle.colSpan`.
 - `hidden` hides an entire column. It applies at the column level (header + the corresponding cells in the rows below), and it can be configured only via `columnOptions.hidden`.
 
 Example with `colSpan`:
@@ -254,7 +254,7 @@ Example with `colSpan`:
 {
   "header": true,
   "cells": [
-    { "text": "All changes", "gridColumnOptions": { "colSpan": 2 } },
+    { "text": "All changes", "cellStyle": { "colSpan": 2 } },
     null
   ]
 }

--- a/content/altinn-studio/v8/reference/ux/components/grid/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/components/grid/_index.en.md
@@ -244,7 +244,7 @@ be displayed when the component is displayed outside of a Grid - such as on [sma
 
 ### Column span and hidden columns
 
-Grid supports both column span (`colSpan`) and column-level hiding (`hidden`) per cell.
+The Grid component supports both column span (`colSpan`) and column-level hiding (`hidden`) for each cell.
 
 - `colSpan` lets a cell span across multiple columns.
 - `hidden` hides a column.
@@ -256,7 +256,7 @@ Example with `colSpan`:
   "header": true,
   "cells": [
     { "text": "All changes", "gridColumnOptions": { "colSpan": 2 } },
-    { "text": "These changes" }
+    null
   ]
 }
 ```
@@ -272,12 +272,12 @@ Example with `hidden`:
   ]
 }
 ```
-`hidden` applies at column level (header + corresponding cells in rows below).
-Note: When using `colSpan`, cells covered by the span should be removed or set to `null`, otherwise table layout may become unpredictable.
+`hidden` applies to the column level (header + corresponding cells in rows below).
+Note: When you use  `colSpan`, cells covered by the span should be removed or set to `null`, otherwise the table layout may become unpredictable.
 
 ### Widths, text and alignment
 
-There ar multiple properties on a cell that can be used to control the width, text and alignment of a cell, and how
+There ar multiple properties in a cell that can be used to control the width, text and alignment of a cell, and how
 much text is displayed before it is truncated. These options are:
 
 - `width` - The width of the column. The value can contain a percentage, for example `"25%"`, or `"auto"` (default).

--- a/content/altinn-studio/v8/reference/ux/components/grid/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/components/grid/_index.en.md
@@ -242,6 +242,39 @@ text resources should still be set on the component, as they will be used for ac
 be displayed when the component is displayed outside of a Grid - such as on [smaller screens](#mobile-support) and in
 [a Summary](/en/altinn-studio/v8/reference/ux/pages/summary/).
 
+### Column span and hidden columns
+
+Grid supports both column span (`colSpan`) and column-level hiding (`hidden`) per cell.
+
+- `colSpan` lets a cell span across multiple columns.
+- `hidden` hides a column.
+- Values can be set directly on the cell or via `gridColumnOptions`.
+
+Example with `colSpan`:
+```json
+{
+  "header": true,
+  "cells": [
+    { "text": "All changes", "gridColumnOptions": { "colSpan": 2 } },
+    { "text": "These changes" }
+  ]
+}
+```
+
+Example with `hidden`:
+```json
+{
+  "header": true,
+  "cells": [
+    { "text": "Column A" },
+    { "text": "Column B", "gridColumnOptions": { "hidden": true } },
+    { "text": "Column C" }
+  ]
+}
+```
+`hidden` applies at column level (header + corresponding cells in rows below).
+Note: When using `colSpan`, cells covered by the span should be removed or set to `null`, otherwise table layout may become unpredictable.
+
 ### Widths, text and alignment
 
 There ar multiple properties on a cell that can be used to control the width, text and alignment of a cell, and how

--- a/content/altinn-studio/v8/reference/ux/components/grid/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/components/grid/_index.nb.md
@@ -252,11 +252,11 @@ vises utenfor en Grid - som på [mindre skjermer](#mobilvisning) og i [et sammen
 
 ### Kolonnespenn og skjuling av kolonner
 
-Grid-komponenten støtter både kolonnespenn (`colSpan`) og skjuling av kolonner (`hidden`) for hver celle.
+Grid-komponenten støtter både kolonnespenn (`colSpan`) og skjuling av kolonner (`hidden`).
 
-- `colSpan` lar en celle dekke flere kolonner.
-- `hidden` skjuler en kolonne.
-- Du kan sette verdier direkte på cellen eller med `gridColumnOptions`.
+- `colSpan` lar en celle dekke flere kolonner. Den kan konfigureres enten via `gridColumnOptions.colSpan` eller et toppnivå `colSpan` på cellen.
+- `hidden` skjuler en hel kolonne. Den gjelder på kolonnenivå (header + tilhørende celler i radene under), og den kan konfigureres kun via `columnOptions.hidden`.
+
 
 Eksempel med `colSpan`:
 ```json
@@ -275,14 +275,15 @@ Eksempel med `hidden`:
   "header": true,
   "cells": [
     { "text": "Kolonne A" },
-    { "text": "Kolonne B", "gridColumnOptions": { "hidden": true } },
+    { "text": "Kolonne B", "columnOptions": { "hidden": true } },
     { "text": "Kolonne C" }
   ]
 }
 ```
-`hidden` gjelder på kolonnenivå (header + tilhørende celler i radene under).
 
-Merk: Når du bruker `colSpan`, må du fjerne de cellene som kolonnespennet dekker eller sette dem til `null`, ellers kan tabell-layouten bli uforutsigbar.
+Merk: _Når du bruker `colSpan`, må du fjerne de cellene som kolonnespennet dekker eller sette dem til `null`, ellers kan tabell-layouten bli uforutsigbar._
+
+Merk : _Hvis du konfigurerer en celle slik at `colSpan` dekker én eller flere kolonner som også er skjulte, vil tabellen fortsatt rendres, men oppsettet stemmer kanskje ikke med det du forventer. Under utvikling logger appen en kort advarsel i nettleserkonsollen som beskriver hvilken celle som spenner over hvor mange kolonner og at den overlapper skjulte kolonne(r), og at dette kan føre til uventet oppsett. Unngå å kombinere en `colSpan` med skjulte kolonner hvis du trenger en forutsigbar tabell._
 
 ### Bredder, tekst og justering
 

--- a/content/altinn-studio/v8/reference/ux/components/grid/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/components/grid/_index.nb.md
@@ -254,7 +254,7 @@ vises utenfor en Grid - som på [mindre skjermer](#mobilvisning) og i [et sammen
 
 Grid-komponenten støtter både kolonnespenn (`colSpan`) og skjuling av kolonner (`hidden`).
 
-- `colSpan` lar en celle dekke flere kolonner. Den kan konfigureres enten via `gridColumnOptions.colSpan` eller et toppnivå `colSpan` på cellen.
+- `colSpan` lar en celle dekke flere kolonner. Den kan konfigureres gjennom `gridColumnOptions.colSpan`.
 - `hidden` skjuler en hel kolonne. Den gjelder på kolonnenivå (header + tilhørende celler i radene under), og den kan konfigureres kun via `columnOptions.hidden`.
 
 

--- a/content/altinn-studio/v8/reference/ux/components/grid/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/components/grid/_index.nb.md
@@ -250,6 +250,40 @@ Når komponenter vises i en tabell, vil de ikke vise `title`- og `description`-t
 bør likevel settes på komponenten, da de vil bli brukt for tilgjengelighet og vil fortsatt bli vist når komponenten
 vises utenfor en Grid - som på [mindre skjermer](#mobilvisning) og i [et sammendrag](/nb/altinn-studio/v8/reference/ux/pages/summary/).
 
+### Kolonnespenn og skjuling av kolonner
+
+Grid støtter både kolonnespenn (`colSpan`) og skjuling av kolonner (`hidden`) per celle.
+
+- `colSpan` lar en celle dekke flere kolonner.
+- `hidden` skjuler en kolonne.
+- Verdier kan settes direkte på cellen eller via `gridColumnOptions`.
+
+Eksempel med `colSpan`:
+```json
+{
+  "header": true,
+  "cells": [
+    { "text": "Alle endringer", "gridColumnOptions": { "colSpan": 2 } },
+    { "text": "Disse endringene" }
+  ]
+}
+```
+
+Eksempel med `hidden`:
+```json
+{
+  "header": true,
+  "cells": [
+    { "text": "Kolonne A" },
+    { "text": "Kolonne B", "gridColumnOptions": { "hidden": true } },
+    { "text": "Kolonne C" }
+  ]
+}
+```
+`hidden` gjelder på kolonnenivå (header + tilhørende celler i radene under).
+
+Merk: Når du bruker `colSpan`, må celler som dekkes av spennet fjernes eller settes til `null`, ellers kan tabell-layout bli uforutsigbar.
+
 ### Bredder, tekst og justering
 
 Det finnes flere opsjoner på en celle for å konfigurere bredde, tekst plassering, og

--- a/content/altinn-studio/v8/reference/ux/components/grid/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/components/grid/_index.nb.md
@@ -254,7 +254,7 @@ vises utenfor en Grid - som på [mindre skjermer](#mobilvisning) og i [et sammen
 
 Grid-komponenten støtter både kolonnespenn (`colSpan`) og skjuling av kolonner (`hidden`).
 
-- `colSpan` lar en celle dekke flere kolonner. Den kan konfigureres gjennom `gridColumnOptions.colSpan`.
+- `colSpan` lar en celle dekke flere kolonner. Den kan konfigureres gjennom `cellStyle.colSpan`.
 - `hidden` skjuler en hel kolonne. Den gjelder på kolonnenivå (header + tilhørende celler i radene under), og den kan konfigureres kun via `columnOptions.hidden`.
 
 
@@ -263,7 +263,7 @@ Eksempel med `colSpan`:
 {
   "header": true,
   "cells": [
-    { "text": "Alle endringer", "gridColumnOptions": { "colSpan": 2 } },
+    { "text": "Alle endringer", "cellStyle": { "colSpan": 2 } },
     null
   ]
 }

--- a/content/altinn-studio/v8/reference/ux/components/grid/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/components/grid/_index.nb.md
@@ -252,11 +252,11 @@ vises utenfor en Grid - som på [mindre skjermer](#mobilvisning) og i [et sammen
 
 ### Kolonnespenn og skjuling av kolonner
 
-Grid støtter både kolonnespenn (`colSpan`) og skjuling av kolonner (`hidden`) per celle.
+Grid-komponenten støtter både kolonnespenn (`colSpan`) og skjuling av kolonner (`hidden`) for hver celle.
 
 - `colSpan` lar en celle dekke flere kolonner.
 - `hidden` skjuler en kolonne.
-- Verdier kan settes direkte på cellen eller via `gridColumnOptions`.
+- Du kan sette verdier direkte på cellen eller med `gridColumnOptions`.
 
 Eksempel med `colSpan`:
 ```json
@@ -264,7 +264,7 @@ Eksempel med `colSpan`:
   "header": true,
   "cells": [
     { "text": "Alle endringer", "gridColumnOptions": { "colSpan": 2 } },
-    { "text": "Disse endringene" }
+    null
   ]
 }
 ```
@@ -282,7 +282,7 @@ Eksempel med `hidden`:
 ```
 `hidden` gjelder på kolonnenivå (header + tilhørende celler i radene under).
 
-Merk: Når du bruker `colSpan`, må celler som dekkes av spennet fjernes eller settes til `null`, ellers kan tabell-layout bli uforutsigbar.
+Merk: Når du bruker `colSpan`, må du fjerne de cellene som kolonnespennet dekker eller sette dem til `null`, ellers kan tabell-layouten bli uforutsigbar.
 
 ### Bredder, tekst og justering
 

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.en.md
@@ -102,36 +102,39 @@ Below is a form with a repeating group that:
 ## rowsBefore/rowsAfter: colSpan and hidden columns
 
 `rowsBefore` and `rowsAfter` use the same grid row/cell structure as the Grid component.
-Cells in these rows support both `gridColumnOptions.colSpan` (column span) and `gridColumnOptions.hidden` (hide column).
+- Cells in these rows support `colSpan` (via `gridColumnOptions.colSpan` or a top‑level `colSpan` on the cell).
+- Column hiding is configured with `columnOptions.hidden` on cells in a header row.
+- To hide a column in `rowsBefore/rowsAfter`, set `columnOptions.hidden` on the corresponding cell in a header row ("header": true).
 
-To hide a column in `rowsBefore`/`rowsAfter`, set `hidden` on the corresponding cell in a header row (`"header": true`).
+Note: _When using `colSpan`, cells covered by the span must be removed or set to `null`._
 
-When using `colSpan`, cells covered by the span must be removed or set to `null`.
+Note: _If you configure a cell so its `colSpan` covers one or more columns that are also hidden, the table still renders, but the layout may not match what you expect. In development, the app logs a short warning in the browser console that describes which cell spans how many columns and that it overlaps hidden column(s), and that this may cause unexpected layout. Avoid combining a `colSpan` with hidden columns if you need a predictable table._
 
+Example `rowsBefore/rowsAfter` without overlap between `colSpan` and `hidden`:
 ```json
- "rowsBefore": [
-   {
-     "header": true,
-     "cells": [
-       {},
-       { "text": "Summary before", "gridColumnOptions": { "colSpan": 2 } },
-     null,
-       { "text": "Hidden before", "gridColumnOptions": { "hidden": true } }
-     ]
-   },
- ],
-
- "rowsAfter": [
-   {
-     "header": true,
-     "cells": [
-       {},
-       { "text": "All changes", "gridColumnOptions": { "colSpan": 2 } },
+"rowsBefore": [
+  {
+    "header": true,
+    "cells": [
+      {},
+      { "text": "Summary before", "gridColumnOptions": { "colSpan": 2 } },
       null,
-       { "text": "Hidden after", "gridColumnOptions": { "hidden": true } }
-     ]
-   },
- ]
+      { "text": "Hidden before", "columnOptions": { "hidden": true } }
+    ]
+  }
+],
+
+"rowsAfter": [
+  {
+    "header": true,
+    "cells": [
+      {},
+      { "text": "All changes", "gridColumnOptions": { "colSpan": 2 } },
+      null,
+      { "text": "Hidden after", "columnOptions": { "hidden": true } }
+    ]
+  }
+]
 ```
 
 ## textResourceBindings

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.en.md
@@ -102,11 +102,11 @@ Below is a form with a repeating group that:
 ## rowsBefore/rowsAfter: colSpan and hidden columns
 
 `rowsBefore` and `rowsAfter` use the same grid row/cell structure as the Grid component.
-- Cells in these rows support `colSpan` (via `gridColumnOptions.colSpan` or a top‑level `colSpan` on the cell).
+- Cells in these rows support `colSpan` via `gridColumnOptions.colSpan`.
 - Column hiding is configured with `columnOptions.hidden` on cells in a header row.
 - To hide a column in `rowsBefore/rowsAfter`, set `columnOptions.hidden` on the corresponding cell in a header row ("header": true).
 
-Note: _When using `colSpan`, cells covered by the span must be removed or set to `null`._
+Note: _When using `colSpan`, cells covered by the span must be removed or set to `null`._ 
 
 Note: _If you configure a cell so its `colSpan` covers one or more columns that are also hidden, the table still renders, but the layout may not match what you expect. In development, the app logs a short warning in the browser console that describes which cell spans how many columns and that it overlaps hidden column(s), and that this may cause unexpected layout. Avoid combining a `colSpan` with hidden columns if you need a predictable table._
 

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.en.md
@@ -102,7 +102,7 @@ Below is a form with a repeating group that:
 ## rowsBefore/rowsAfter: colSpan and hidden columns
 
 `rowsBefore` and `rowsAfter` use the same grid row/cell structure as the Grid component.
-- Cells in these rows support `colSpan` via `gridColumnOptions.colSpan`.
+- Cells in these rows support `colSpan` via `cellStyle.colSpan`.
 - Column hiding is configured with `columnOptions.hidden` on cells in a header row.
 - To hide a column in `rowsBefore/rowsAfter`, set `columnOptions.hidden` on the corresponding cell in a header row ("header": true).
 
@@ -117,7 +117,7 @@ Example `rowsBefore/rowsAfter` without overlap between `colSpan` and `hidden`:
     "header": true,
     "cells": [
       {},
-      { "text": "Summary before", "gridColumnOptions": { "colSpan": 2 } },
+      { "text": "Summary before", "cellStyle": { "colSpan": 2 } },
       null,
       { "text": "Hidden before", "columnOptions": { "hidden": true } }
     ]
@@ -129,7 +129,7 @@ Example `rowsBefore/rowsAfter` without overlap between `colSpan` and `hidden`:
     "header": true,
     "cells": [
       {},
-      { "text": "All changes", "gridColumnOptions": { "colSpan": 2 } },
+      { "text": "All changes", "cellStyle": { "colSpan": 2 } },
       null,
       { "text": "Hidden after", "columnOptions": { "hidden": true } }
     ]

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.en.md
@@ -99,6 +99,57 @@ Below is a form with a repeating group that:
 | [tableColumns](table/#widths-alignment-and-overflow-for-columns) | No       | Object containing column options for specified headers. If not specified, all columns will use default display settings.       |
 | [stickyHeaders](table/#sticky-table-headers)                     | No       | If set to `true`, the table headers will be sticky.                                                                            |
 
+## rowsBefore/rowsAfter: colSpan and hidden columns
+
+`rowsBefore` and `rowsAfter` use the same grid row/cell structure as the Grid component.
+Cells in these rows support both `gridColumnOptions.colSpan` (column span) and `gridColumnOptions.hidden` (hide column).
+
+To hide a column in `rowsBefore`/`rowsAfter`, set `hidden` on the corresponding cell in a header row (`"header": true`).
+
+When using `colSpan`, cells covered by the span must be removed or set to `null`.
+
+```json
+"rowsBefore": [
+  {
+    "header": true,
+    "cells": [
+      {},
+      { "text": "Summary before", "gridColumnOptions": { "colSpan": 2 } },
+      { "text": "Hidden before", "gridColumnOptions": { "hidden": true } }
+    ]
+  },
+  {
+    "readOnly": true,
+    "cells": [
+      { "text": "SUM before" },
+      { "component": "sum-before-all" },
+      { "component": "sum-before-selected" },
+      { "component": "sum-before-hidden-col" }
+    ]
+  }
+],
+
+"rowsAfter": [
+  {
+    "header": true,
+    "cells": [
+      {},
+      { "text": "All changes", "gridColumnOptions": { "colSpan": 2 } },
+      { "text": "Hidden after", "gridColumnOptions": { "hidden": true } }
+    ]
+  },
+  {
+    "readOnly": true,
+    "cells": [
+      { "text": "SUM after" },
+      { "component": "sum-all" },
+      { "component": "sum-above-limit" },
+      { "component": "sum-hidden-col" }
+    ]
+  }
+]
+```
+
 ## textResourceBindings
 
 It is possible to add different keys in textResourceBindings to overrule default texts.

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.en.md
@@ -109,45 +109,29 @@ To hide a column in `rowsBefore`/`rowsAfter`, set `hidden` on the corresponding 
 When using `colSpan`, cells covered by the span must be removed or set to `null`.
 
 ```json
-"rowsBefore": [
-  {
-    "header": true,
-    "cells": [
-      {},
-      { "text": "Summary before", "gridColumnOptions": { "colSpan": 2 } },
-      { "text": "Hidden before", "gridColumnOptions": { "hidden": true } }
-    ]
-  },
-  {
-    "readOnly": true,
-    "cells": [
-      { "text": "SUM before" },
-      { "component": "sum-before-all" },
-      { "component": "sum-before-selected" },
-      { "component": "sum-before-hidden-col" }
-    ]
-  }
-],
+ "rowsBefore": [
+   {
+     "header": true,
+     "cells": [
+       {},
+       { "text": "Summary before", "gridColumnOptions": { "colSpan": 2 } },
+     null,
+       { "text": "Hidden before", "gridColumnOptions": { "hidden": true } }
+     ]
+   },
+ ],
 
-"rowsAfter": [
-  {
-    "header": true,
-    "cells": [
-      {},
-      { "text": "All changes", "gridColumnOptions": { "colSpan": 2 } },
-      { "text": "Hidden after", "gridColumnOptions": { "hidden": true } }
-    ]
-  },
-  {
-    "readOnly": true,
-    "cells": [
-      { "text": "SUM after" },
-      { "component": "sum-all" },
-      { "component": "sum-above-limit" },
-      { "component": "sum-hidden-col" }
-    ]
-  }
-]
+ "rowsAfter": [
+   {
+     "header": true,
+     "cells": [
+       {},
+       { "text": "All changes", "gridColumnOptions": { "colSpan": 2 } },
+      null,
+       { "text": "Hidden after", "gridColumnOptions": { "hidden": true } }
+     ]
+   },
+ ]
 ```
 
 ## textResourceBindings

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.nb.md
@@ -99,39 +99,42 @@ Under vises et skjema med en repeterende gruppe som:
 | [tableColumns](table/#bredder-tekst-plassering-og-skjuling-av-overflødig-tekst) | Nei     | Objekt som inneholder egenskaper for kolonnene som vises i tabellen.                                                                                                |
 | [stickyHeaders](table/#sticky-tabell-headere)                                   | No      | Dersom satt til `true`, gjøres tabell headerene `sticky`.                                                                                                           |
 
-## rowsBefore/rowsAfter: kolonnespenn og skjuling av kolonner
-
+## rowsBefore/rowsAfter: colSpan og skjulte kolonner
 `rowsBefore` og `rowsAfter` bruker samme grid-rad/celle-struktur som Grid-komponenten.
-Celler i disse radene støtter både `gridColumnOptions.colSpan` (kolonnespenn) og `gridColumnOptions.hidden` (skjul kolonne).
 
-For å skjule en kolonne i `rowsBefore`/`rowsAfter`, sett `hidden` på tilsvarende celle i en header-rad (`"header": true`).
+Celler i disse radene støtter `colSpan` (via `gridColumnOptions.colSpan` eller et toppnivå `colSpan` på cellen).
+Skjuling av kolonner konfigureres med `columnOptions.hidden` på celler i en headerrad.
+For å skjule en kolonne i `rowsBefore`/`rowsAfter`, sett `columnOptions.hidden` på den tilsvarende cellen i en headerrad ("header": true).
 
-Hvis du bruker `colSpan`, må du fjerne cellene som kolonnespennet dekker, eller sette dem til `null`.
+Merk: _Når du bruker `colSpan`, må celler som dekkes av spennet fjernes eller settes til null._
 
+Merk: _Hvis du konfigurerer en celle slik at `colSpan` dekker én eller flere kolonner som også er skjulte, vil tabellen fortsatt rendres, men oppsettet stemmer kanskje ikke med det du forventer. Under utvikling logger appen en kort advarsel i nettleserkonsollen som beskriver hvilken celle som spenner over hvor mange kolonner og at den overlapper skjulte kolonne(r), og at dette kan føre til uventet oppsett. Unngå å kombinere `colSpan` med skjulte kolonner hvis du trenger en forutsigbar tabell._
+
+Eksempel `rowsBefore/rowsAfter` uten overlapp mellom `colSpan` og `hidden`:
 ```json
- "rowsBefore": [
-   {
-     "header": true,
-     "cells": [
-       {},
-       { "text": "Oppsummering før", "gridColumnOptions": { "colSpan": 2 } },
-     null,
-       { "text": "Skjules før", "gridColumnOptions": { "hidden": true } }
-     ]
-   },
- ],
-
- "rowsAfter": [
-   {
-     "header": true,
-     "cells": [
-       {},
-       { "text": "Alle endringer", "gridColumnOptions": { "colSpan": 2 } },
+"rowsBefore": [
+  {
+    "header": true,
+    "cells": [
+      {},
+      { "text": "Summary before", "gridColumnOptions": { "colSpan": 2 } },
       null,
-       { "text": "Skjules etter", "gridColumnOptions": { "hidden": true } }
-     ]
-   },
- ]
+      { "text": "Hidden before", "columnOptions": { "hidden": true } }
+    ]
+  }
+],
+
+"rowsAfter": [
+  {
+    "header": true,
+    "cells": [
+      {},
+      { "text": "All changes", "gridColumnOptions": { "colSpan": 2 } },
+      null,
+      { "text": "Hidden after", "columnOptions": { "hidden": true } }
+    ]
+  }
+]
 ```
 
 ## textResourceBindings

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.nb.md
@@ -106,48 +106,32 @@ Celler i disse radene støtter både `gridColumnOptions.colSpan` (kolonnespenn) 
 
 For å skjule en kolonne i `rowsBefore`/`rowsAfter`, sett `hidden` på tilsvarende celle i en header-rad (`"header": true`).
 
-Ved bruk av `colSpan` må celler som dekkes av spennet fjernes eller settes til `null`.
+Hvis du bruker `colSpan`, må du fjerne cellene som kolonnespennet dekker, eller sette dem til `null`.
 
 ```json
-"rowsBefore": [
-  {
-    "header": true,
-    "cells": [
-      {},
-      { "text": "Oppsummering før", "gridColumnOptions": { "colSpan": 2 } },
-      { "text": "Skjules før", "gridColumnOptions": { "hidden": true } }
-    ]
-  },
-  {
-    "readOnly": true,
-    "cells": [
-      { "text": "SUM før" },
-      { "component": "sum-before-all" },
-      { "component": "sum-before-selected" },
-      { "component": "sum-before-hidden-col" }
-    ]
-  }
-],
+ "rowsBefore": [
+   {
+     "header": true,
+     "cells": [
+       {},
+       { "text": "Oppsummering før", "gridColumnOptions": { "colSpan": 2 } },
+     null,
+       { "text": "Skjules før", "gridColumnOptions": { "hidden": true } }
+     ]
+   },
+ ],
 
-"rowsAfter": [
-  {
-    "header": true,
-    "cells": [
-      {},
-      { "text": "Alle endringer", "gridColumnOptions": { "colSpan": 2 } },
-      { "text": "Skjules etter", "gridColumnOptions": { "hidden": true } }
-    ]
-  },
-  {
-    "readOnly": true,
-    "cells": [
-      { "text": "SUM etter" },
-      { "component": "sum-all" },
-      { "component": "sum-above-limit" },
-      { "component": "sum-hidden-col" }
-    ]
-  }
-]
+ "rowsAfter": [
+   {
+     "header": true,
+     "cells": [
+       {},
+       { "text": "Alle endringer", "gridColumnOptions": { "colSpan": 2 } },
+      null,
+       { "text": "Skjules etter", "gridColumnOptions": { "hidden": true } }
+     ]
+   },
+ ]
 ```
 
 ## textResourceBindings

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.nb.md
@@ -99,6 +99,57 @@ Under vises et skjema med en repeterende gruppe som:
 | [tableColumns](table/#bredder-tekst-plassering-og-skjuling-av-overflødig-tekst) | Nei     | Objekt som inneholder egenskaper for kolonnene som vises i tabellen.                                                                                                |
 | [stickyHeaders](table/#sticky-tabell-headere)                                   | No      | Dersom satt til `true`, gjøres tabell headerene `sticky`.                                                                                                           |
 
+## rowsBefore/rowsAfter: kolonnespenn og skjuling av kolonner
+
+`rowsBefore` og `rowsAfter` bruker samme grid-rad/celle-struktur som Grid-komponenten.
+Celler i disse radene støtter både `gridColumnOptions.colSpan` (kolonnespenn) og `gridColumnOptions.hidden` (skjul kolonne).
+
+For å skjule en kolonne i `rowsBefore`/`rowsAfter`, sett `hidden` på tilsvarende celle i en header-rad (`"header": true`).
+
+Ved bruk av `colSpan` må celler som dekkes av spennet fjernes eller settes til `null`.
+
+```json
+"rowsBefore": [
+  {
+    "header": true,
+    "cells": [
+      {},
+      { "text": "Oppsummering før", "gridColumnOptions": { "colSpan": 2 } },
+      { "text": "Skjules før", "gridColumnOptions": { "hidden": true } }
+    ]
+  },
+  {
+    "readOnly": true,
+    "cells": [
+      { "text": "SUM før" },
+      { "component": "sum-before-all" },
+      { "component": "sum-before-selected" },
+      { "component": "sum-before-hidden-col" }
+    ]
+  }
+],
+
+"rowsAfter": [
+  {
+    "header": true,
+    "cells": [
+      {},
+      { "text": "Alle endringer", "gridColumnOptions": { "colSpan": 2 } },
+      { "text": "Skjules etter", "gridColumnOptions": { "hidden": true } }
+    ]
+  },
+  {
+    "readOnly": true,
+    "cells": [
+      { "text": "SUM etter" },
+      { "component": "sum-all" },
+      { "component": "sum-above-limit" },
+      { "component": "sum-hidden-col" }
+    ]
+  }
+]
+```
+
 ## textResourceBindings
 
 Det er mulig å legge til ulike nøkler i textResourceBindings for å overstyre standardtekster:

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.nb.md
@@ -102,9 +102,9 @@ Under vises et skjema med en repeterende gruppe som:
 ## rowsBefore/rowsAfter: colSpan og skjulte kolonner
 `rowsBefore` og `rowsAfter` bruker samme grid-rad/celle-struktur som Grid-komponenten.
 
-Celler i disse radene støtter `colSpan` (via `gridColumnOptions.colSpan` eller et toppnivå `colSpan` på cellen).
-Skjuling av kolonner konfigureres med `columnOptions.hidden` på celler i en headerrad.
-For å skjule en kolonne i `rowsBefore`/`rowsAfter`, sett `columnOptions.hidden` på den tilsvarende cellen i en headerrad ("header": true).
+- Celler i disse radene støtter `colSpan` gjennom `gridColumnOptions.colSpan`.
+- Skjuling av kolonner konfigureres med `columnOptions.hidden` på celler i en headerrad.
+- For å skjule en kolonne i `rowsBefore`/`rowsAfter`, sett `columnOptions.hidden` på den tilsvarende cellen i en headerrad ("header": true).
 
 Merk: _Når du bruker `colSpan`, må celler som dekkes av spennet fjernes eller settes til null._
 

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/_index.nb.md
@@ -102,7 +102,7 @@ Under vises et skjema med en repeterende gruppe som:
 ## rowsBefore/rowsAfter: colSpan og skjulte kolonner
 `rowsBefore` og `rowsAfter` bruker samme grid-rad/celle-struktur som Grid-komponenten.
 
-- Celler i disse radene støtter `colSpan` gjennom `gridColumnOptions.colSpan`.
+- Celler i disse radene støtter `colSpan` gjennom `cellStyle.colSpan`.
 - Skjuling av kolonner konfigureres med `columnOptions.hidden` på celler i en headerrad.
 - For å skjule en kolonne i `rowsBefore`/`rowsAfter`, sett `columnOptions.hidden` på den tilsvarende cellen i en headerrad ("header": true).
 
@@ -117,7 +117,7 @@ Eksempel `rowsBefore/rowsAfter` uten overlapp mellom `colSpan` og `hidden`:
     "header": true,
     "cells": [
       {},
-      { "text": "Summary before", "gridColumnOptions": { "colSpan": 2 } },
+      { "text": "Summary before", "cellStyle": { "colSpan": 2 } },
       null,
       { "text": "Hidden before", "columnOptions": { "hidden": true } }
     ]
@@ -129,7 +129,7 @@ Eksempel `rowsBefore/rowsAfter` uten overlapp mellom `colSpan` og `hidden`:
     "header": true,
     "cells": [
       {},
-      { "text": "All changes", "gridColumnOptions": { "colSpan": 2 } },
+      { "text": "All changes", "cellStyle": { "colSpan": 2 } },
       null,
       { "text": "Hidden after", "columnOptions": { "hidden": true } }
     ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Grid docs for per-cell column spanning (colSpan) and column hiding, with examples and guidance that covered cells must be removed or set to null.
  * Clarified that hidden hides an entire column (header and body) and documented behavior when colSpan overlaps hidden columns (renders but may be unexpected; dev console warns).
  * Documented rowsBefore/rowsAfter in repeating groups supporting the same span/hide rules and fixed a wording correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->