### PR TITLE
Fix formatting in Divider component documentation

### DIFF
--- a/content/altinn-studio/v8/reference/ux/components/Divider/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/components/Divider/_index.nb.md
@@ -140,7 +140,7 @@ App/ui/layouts/{page}.json
       "layout": [
         {
           "id": "myDivider",
-          "type": "Divider",
+          "type": "Divider"
         }
       ]
     }
@@ -194,6 +194,6 @@ App/ui/layouts/{page}.json
 ```json
   {
     "id": "myDivider",
-    "type": "Divider",
+    "type": "Divider"
   }
 ```


### PR DESCRIPTION
Fjernet komma etter "type": "Divider"




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed JSON formatting in Divider component documentation examples by removing unnecessary trailing commas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->