### PR TITLE
Add troubleshooting for incorrect system user organization

### DIFF
--- a/content/authorization/guides/system-vendor/system-user/troubleshooting/errors/mp-303-error/_index.en.md
+++ b/content/authorization/guides/system-vendor/system-user/troubleshooting/errors/mp-303-error/_index.en.md
@@ -24,3 +24,9 @@ Maskinporten token request does not include externalRef. This is an optional ref
 
 #### Solution:
 Verify whether the system user request was created with an `externalRef` value. If yes, include the value in the Maskinporten token request. Please refer to the [Maskinporten documentation](https://docs.digdir.no/docs/Maskinporten/maskinporten_func_systembruker.html#foresp%C3%B8rsel).
+
+### Problem 3: Incorrect systemuser_org for the system user
+The organization number set in `systemuser_org.ID` must be the organization number of the business that owns the system user. If the system user is an agent system user, you should **not** use the organization number of a client that is connected to the system user to retrieve a token.
+
+#### Solution:
+Verify that the organization number in `systemuser_org.ID` is set to the organization number of the business that owns the system user.

--- a/content/authorization/guides/system-vendor/system-user/troubleshooting/errors/mp-303-error/_index.nb.md
+++ b/content/authorization/guides/system-vendor/system-user/troubleshooting/errors/mp-303-error/_index.nb.md
@@ -22,3 +22,9 @@ Maskinportentoken forespørselen mangler externalRef. Dette er en valgfri refera
 
 #### Løsning:
 Verifiser om systembruker forespørselen var opprettet med "externalef". Hvis ja, inkluder den verdien i maskinportentoken forespørselen. Vennligst se på [dokumentasjon for maskinporten](https://docs.digdir.no/docs/Maskinporten/maskinporten_func_systembruker.html#foresp%C3%B8rsel)
+
+### Problem 3: Feil `systemuser_org` for systembrukeren
+Organisasjonsnummeret som settes i `systemuser_org.ID` må være organisasjonsnummert til virksomheten som eier systembrukeren. Dersom systembrukeren er en agent-systembruker, skal man **ikke** bruke organisasjonsnummeret til en klient som er koblet til systembrukeren for å hente ut token.
+
+#### Løsning:
+Verifiser om organisasjonsnummeret i `systemuser_org.ID` er satt til organisasjonsnummert til virksomheten som eier systembrukeren.

--- a/content/authorization/guides/system-vendor/system-user/troubleshooting/errors/mp-303-error/_index.nb.md
+++ b/content/authorization/guides/system-vendor/system-user/troubleshooting/errors/mp-303-error/_index.nb.md
@@ -24,7 +24,7 @@ Maskinportentoken forespørselen mangler externalRef. Dette er en valgfri refera
 Verifiser om systembruker forespørselen var opprettet med "externalef". Hvis ja, inkluder den verdien i maskinportentoken forespørselen. Vennligst se på [dokumentasjon for maskinporten](https://docs.digdir.no/docs/Maskinporten/maskinporten_func_systembruker.html#foresp%C3%B8rsel)
 
 ### Problem 3: Feil `systemuser_org` for systembrukeren
-Organisasjonsnummeret som settes i `systemuser_org.ID` må være organisasjonsnummert til virksomheten som eier systembrukeren. Dersom systembrukeren er en agent-systembruker, skal man **ikke** bruke organisasjonsnummeret til en klient som er koblet til systembrukeren for å hente ut token.
+Organisasjonsnummeret som settes i `systemuser_org.ID` må være organisasjonsnummeret til virksomheten som eier systembrukeren. Dersom systembrukeren er en agent-systembruker, skal man **ikke** bruke organisasjonsnummeret til en klient som er koblet til systembrukeren for å hente ut token.
 
 #### Løsning:
-Verifiser om organisasjonsnummeret i `systemuser_org.ID` er satt til organisasjonsnummert til virksomheten som eier systembrukeren.
+Verifiser om organisasjonsnummeret i `systemuser_org.ID` er satt til organisasjonsnummeret til virksomheten som eier systembrukeren.


### PR DESCRIPTION
Added a new problem and solution regarding the `systemuser_org` for system users, clarifying the organizational number requirements.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a troubleshooting section explaining that the system user’s organization ID must match the owning business’s organization number and agent system users must not use a connected client’s organization number when retrieving tokens.
  * Minor formatting and documentation link encoding updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->