### PR TITLE
Update OpenAPI doc for Notifications

### DIFF
--- a/static/swagger/altinn-notifications-v1.json
+++ b/static/swagger/altinn-notifications-v1.json
@@ -1952,7 +1952,7 @@
           "resourceId": {
             "pattern": "^urn:altinn:resource:.+$",
             "type": "string",
-            "description": "An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource' is required.",
+            "description": "An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource:' is required.",
             "nullable": true,
             "example": "urn:altinn:resource:org_example_app"
           },
@@ -2030,7 +2030,7 @@
           "resourceId": {
             "pattern": "^urn:altinn:resource:.+$",
             "type": "string",
-            "description": "An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource' is required.",
+            "description": "An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource:' is required.",
             "nullable": true,
             "example": "urn:altinn:resource:org_example_app"
           },
@@ -2075,7 +2075,7 @@
           "resourceId": {
             "pattern": "^urn:altinn:resource:.+$",
             "type": "string",
-            "description": "An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource' is required.",
+            "description": "An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource:' is required.",
             "nullable": true,
             "example": "urn:altinn:resource:org_example_app"
           },

--- a/static/swagger/altinn-notifications-v1.json
+++ b/static/swagger/altinn-notifications-v1.json
@@ -195,7 +195,7 @@
     "/future/orders/instant": {
       "post": {
         "tags": [
-          "Instant Orders"
+          "Deprecated"
         ],
         "summary": "Creates and sends an instant SMS notification to a single recipient (deprecated - use /sms endpoint instead).",
         "requestBody": {

--- a/static/swagger/altinn-notifications-v1.json
+++ b/static/swagger/altinn-notifications-v1.json
@@ -121,7 +121,7 @@
           "Order"
         ],
         "summary": "Creates a new notification order with zero or more reminders",
-        "description": "The API will accept the request after some basic validation of the request.\nThe system will also attempt to verify that it will be possible to fulfill the order.",
+        "description": "The API will accept the request after some basic validation of the request.\r\nThe system will also attempt to verify that it will be possible to fulfill the order.",
         "requestBody": {
           "description": "The notification order request",
           "content": {
@@ -254,9 +254,6 @@
                 }
               }
             }
-          },
-          "500": {
-            "description": "An internal server error occurred while processing the notification order"
           }
         },
         "deprecated": true
@@ -324,9 +321,6 @@
                 }
               }
             }
-          },
-          "500": {
-            "description": "An internal server error occurred while processing the SMS notification order"
           }
         }
       }
@@ -393,9 +387,6 @@
                 }
               }
             }
-          },
-          "500": {
-            "description": "An internal server error occurred while processing the email notification order"
           }
         }
       }
@@ -582,7 +573,7 @@
     "/orders/{id}/cancel": {
       "put": {
         "tags": [
-          "Order"
+          "Deprecated"
         ],
         "summary": "Cancel a notification order.",
         "description": "Endpoint for stopping the sending of a registered notification order.",
@@ -621,7 +612,8 @@
           "409": {
             "description": "The order cannot be cancelled due to current processing status."
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/future/shipment/{id}": {
@@ -882,7 +874,7 @@
             "nullable": true
           }
         },
-        "additionalProperties": { }
+        "additionalProperties": {}
       },
       "DialogportenIdentifiersExt": {
         "type": "object",
@@ -1424,7 +1416,7 @@
           }
         },
         "additionalProperties": false,
-        "description": "Represents the root tracking entity for a notification shipment that\ncan be sent to multiple recipients through various communication channels."
+        "description": "Represents the root tracking entity for a notification shipment that\r\ncan be sent to multiple recipients through various communication channels."
       },
       "NotificationOrderChainReceiptExt": {
         "required": [
@@ -1498,7 +1490,7 @@
           }
         },
         "additionalProperties": false,
-        "description": "Represents a contract between API clients and the server, defining the structure of notification order\nrequests with reminders that can be submitted to the system.\nInherits the scheduling options from Altinn.Notifications.Models.NotificationOrderBaseExt."
+        "description": "Represents a contract between API clients and the server, defining the structure of notification order\r\nrequests with reminders that can be submitted to the system.\r\nInherits the scheduling options from Altinn.Notifications.Models.NotificationOrderBaseExt."
       },
       "NotificationOrderChainResponseExt": {
         "required": [
@@ -1959,8 +1951,9 @@
           },
           "resourceId": {
             "type": "string",
-            "description": "Gets or sets an optional resource identifier for authorization and auditing purposes.",
-            "nullable": true
+            "description": "An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource' is required.",
+            "nullable": true,
+            "example": "urn:altinn:resource:org_example_app"
           },
           "resourceAction": {
             "type": "string",
@@ -2035,8 +2028,9 @@
           },
           "resourceId": {
             "type": "string",
-            "description": "Gets or sets an optional resource identifier for authorization and auditing purposes.",
-            "nullable": true
+            "description": "An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource' is required.",
+            "nullable": true,
+            "example": "urn:altinn:resource:org_example_app"
           },
           "resourceAction": {
             "type": "string",
@@ -2078,8 +2072,9 @@
           },
           "resourceId": {
             "type": "string",
-            "description": "Gets or sets an optional resource identifier for authorization and auditing purposes.",
-            "nullable": true
+            "description": "An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource' is required.",
+            "nullable": true,
+            "example": "urn:altinn:resource:org_example_app"
           },
           "resourceAction": {
             "type": "string",

--- a/static/swagger/altinn-notifications-v1.json
+++ b/static/swagger/altinn-notifications-v1.json
@@ -1950,6 +1950,7 @@
             "$ref": "#/components/schemas/SmsSendingOptionsExt"
           },
           "resourceId": {
+            "pattern": "^urn:altinn:resource:.+$",
             "type": "string",
             "description": "An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource' is required.",
             "nullable": true,
@@ -2027,6 +2028,7 @@
             "$ref": "#/components/schemas/SmsSendingOptionsExt"
           },
           "resourceId": {
+            "pattern": "^urn:altinn:resource:.+$",
             "type": "string",
             "description": "An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource' is required.",
             "nullable": true,
@@ -2071,6 +2073,7 @@
             "$ref": "#/components/schemas/SmsSendingOptionsExt"
           },
           "resourceId": {
+            "pattern": "^urn:altinn:resource:.+$",
             "type": "string",
             "description": "An optional URN-formatted resource identifier for authorization and auditing purposes. Prefix 'urn:altinn:resource' is required.",
             "nullable": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecated Features**
  * The order cancellation endpoint is now deprecated and scheduled for future removal.

* **API Changes**
  * Recipient resource identifiers must now follow the URN format `urn:altinn:resource:[resource-name]` for external identity, organization, and person recipient types.
  * Removed 500 error response documentation from instant notification endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->