### PR TITLE
Add `disableMarkCompletedWhenConfirmed` setting to syncAdapter config

### DIFF
--- a/content/dialogporten/reference/front-end/altinn-apps/_index.en.md
+++ b/content/dialogporten/reference/front-end/altinn-apps/_index.en.md
@@ -14,22 +14,23 @@ These settings, along with other, can be defined in the file  `App/config/applic
 Set any of the properties below under `syncAdapterSettings` to `true` to override the
 automatic synchronization:
 
-| Setting                                   | Description                                                       |
-|-------------------------------------------|-------------------------------------------------------------------|
-| `disableSync`                             | Disable all dialog synchronization. Overrides all other settings. |
-| `disableCreate`                           | Disable creation of dialogs when app instances are created.       |
-| `disableDelete`                           | Disable deletion of dialogs when app instances are deleted.       |
-| `disableAddActivities`                    | Disable adding activities.                                        |
-| `disableAddTransmissions`                 | Disable adding transmissions.                                     |
-| `disableSyncDueAt`                        | Disable synchronizing the due at date.                            |
-| `disableSyncStatus`                       | Disable synchronizing the status.                                 |
-| `disableSyncContentTitle`                 | Disable synchronizing the title.                                  |
-| `disableSyncContentSummary`               | Disable synchronizing the summary.                                |
-| `disableSyncContentAdditionalInformation` | Disable synchronizing the additional information.                 |
-| `disableSyncContentExtendedStatus`        | Disable synchronizing the extented status.                        |
-| `disableSyncAttachments`                  | Disable synchronizing dialog attachments (only recognized IDs).   |
-| `disableSyncApiActions`                   | Disable synchronizing API actions (only recognized IDs).          |
-| `disableSyncGuiActions`                   | Disable synchronizing GUI actions (only recognized IDs).          |
+| Setting                                   | Description                                                                        |
+|-------------------------------------------|------------------------------------------------------------------------------------|
+| `disableSync`                             | Disable all dialog synchronization. Overrides all other settings.                  |
+| `disableCreate`                           | Disable creation of dialogs when app instances are created.                        |
+| `disableDelete`                           | Disable deletion of dialogs when app instances are deleted.                        |
+| `disableAddActivities`                    | Disable adding activities.                                                         |
+| `disableAddTransmissions`                 | Disable adding transmissions.                                                      |
+| `disableSyncDueAt`                        | Disable synchronizing the due at date.                                             |
+| `disableSyncStatus`                       | Disable synchronizing the status.                                                  |
+| `disableSyncContentTitle`                 | Disable synchronizing the title.                                                   |
+| `disableSyncContentSummary`               | Disable synchronizing the summary.                                                 |
+| `disableSyncContentAdditionalInformation` | Disable synchronizing the additional information.                                  |
+| `disableSyncContentExtendedStatus`        | Disable synchronizing the extented status.                                         |
+| `disableSyncAttachments`                  | Disable synchronizing dialog attachments (only recognized IDs).                    |
+| `disableSyncApiActions`                   | Disable synchronizing API actions (only recognized IDs).                           |
+| `disableSyncGuiActions`                   | Disable synchronizing GUI actions (only recognized IDs).                           |
+| `disableMarkCompletedWhenConfirmed`       | Disable setting dialog status to completed when app instance is ArchivedConfirmed. |
 
 ### Example
 
@@ -52,9 +53,12 @@ This shows the default syncAdapterSettings. Set any to `true` to override. Chang
         "disableSyncStatus": false,
         "disableSyncContentTitle": false,
         "disableSyncContentSummary": false,
+        "disableSyncContentAdditionalInformation": false,
+        "disableSyncContentExtendedStatus": false,
         "disableSyncAttachments": false,
         "disableSyncApiActions": false,
-        "disableSyncGuiActions": false
+        "disableSyncGuiActions": false,
+        "disableMarkCompletedWhenConfirmed": false
     }
   }
 }

--- a/content/dialogporten/reference/front-end/altinn-apps/_index.en.md
+++ b/content/dialogporten/reference/front-end/altinn-apps/_index.en.md
@@ -26,7 +26,7 @@ automatic synchronization:
 | `disableSyncContentTitle`                 | Disable synchronizing the title.                                                   |
 | `disableSyncContentSummary`               | Disable synchronizing the summary.                                                 |
 | `disableSyncContentAdditionalInformation` | Disable synchronizing the additional information.                                  |
-| `disableSyncContentExtendedStatus`        | Disable synchronizing the extented status.                                         |
+| `disableSyncContentExtendedStatus`        | Disable synchronizing the extended status.                                         |
 | `disableSyncAttachments`                  | Disable synchronizing dialog attachments (only recognized IDs).                    |
 | `disableSyncApiActions`                   | Disable synchronizing API actions (only recognized IDs).                           |
 | `disableSyncGuiActions`                   | Disable synchronizing GUI actions (only recognized IDs).                           |

--- a/content/dialogporten/reference/front-end/altinn-apps/_index.nb.md
+++ b/content/dialogporten/reference/front-end/altinn-apps/_index.nb.md
@@ -14,22 +14,23 @@ Disse innstillingene, sammen med andre, kan defineres i filen `App/config/applic
 Sett hvilken som helst av egenskapene nedenfor under `syncAdapterSettings` til `true` for å overstyre den
 automatiske synkroniseringen:
 
-| Setting                                   | Beskrivelse                                                              |
-|-------------------------------------------|--------------------------------------------------------------------------|
-| `disableSync`                             | Deaktiver all dialogsynkronisering. Overstyrer alle andre innstillinger. |
-| `disableCreate`                           | Deaktiver opprettelse av dialoger når applikasjonsinstanser opprettes.   |
-| `disableDelete`                           | Deaktiver sletting av dialoger når applikasjonsinstanser slettes.        |
-| `disableAddActivities`                    | Deaktiver å legge til aktiviteter.                                       |
-| `disableAddTransmissions`                 | Deaktiver å legge til forsendelser.                                      |
-| `disableSyncDueAt`                        | Deaktiver synkronisering av forfallsdato.                                |
-| `disableSyncStatus`                       | Deaktiver synkronisering av status.                                      |
-| `disableSyncContentTitle`                 | Deaktiver synkronisering av tittel.                                      |
-| `disableSyncContentSummary`               | Deaktiver synkronisering av sammendrag.                                  |
-| `disableSyncContentAdditionalInformation` | Deaktiver synkronisering av tilleggsinformasjon.                         |
-| `disableSyncContentExtendedStatus`        | Deaktiver synkronisering av utvidet status.                              |
-| `disableSyncAttachments`                  | Deaktiver synkronisering av dialogvedlegg (kun gjenkjente ID-er).        |
-| `disableSyncApiActions`                   | Deaktiver synkronisering av API-handlinger (kun gjenkjente ID-er).       |
-| `disableSyncGuiActions`                   | Deaktiver synkronisering av GUI-handlinger (kun gjenkjente ID-er).       |
+| Setting                                   | Beskrivelse                                                                          |
+|-------------------------------------------|--------------------------------------------------------------------------------------|
+| `disableSync`                             | Deaktiver all dialogsynkronisering. Overstyrer alle andre innstillinger.             |
+| `disableCreate`                           | Deaktiver opprettelse av dialoger når applikasjonsinstanser opprettes.               |
+| `disableDelete`                           | Deaktiver sletting av dialoger når applikasjonsinstanser slettes.                    |
+| `disableAddActivities`                    | Deaktiver å legge til aktiviteter.                                                   |
+| `disableAddTransmissions`                 | Deaktiver å legge til forsendelser.                                                  |
+| `disableSyncDueAt`                        | Deaktiver synkronisering av forfallsdato.                                            |
+| `disableSyncStatus`                       | Deaktiver synkronisering av status.                                                  |
+| `disableSyncContentTitle`                 | Deaktiver synkronisering av tittel.                                                  |
+| `disableSyncContentSummary`               | Deaktiver synkronisering av sammendrag.                                              |
+| `disableSyncContentAdditionalInformation` | Deaktiver synkronisering av tilleggsinformasjon.                                     |
+| `disableSyncContentExtendedStatus`        | Deaktiver synkronisering av utvidet status.                                          |
+| `disableSyncAttachments`                  | Deaktiver synkronisering av dialogvedlegg (kun gjenkjente ID-er).                    |
+| `disableSyncApiActions`                   | Deaktiver synkronisering av API-handlinger (kun gjenkjente ID-er).                   |
+| `disableSyncGuiActions`                   | Deaktiver synkronisering av GUI-handlinger (kun gjenkjente ID-er).                   |
+| `disableMarkCompletedWhenConfirmed`       | Deaktiver å sette dialogstatus til Completed når app-instansen er ArchivedConfirmed. |
 
 ### Eksempel
 
@@ -52,9 +53,12 @@ Dette viser standard syncAdapterSettings. Sett hvilken som helst til `true` for 
         "disableSyncStatus": false,
         "disableSyncContentTitle": false,
         "disableSyncContentSummary": false,
+        "disableSyncContentAdditionalInformation": false,
+        "disableSyncContentExtendedStatus": false,
         "disableSyncAttachments": false,
         "disableSyncApiActions": false,
-        "disableSyncGuiActions": false
+        "disableSyncGuiActions": false,
+        "disableMarkCompletedWhenConfirmed": false
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Altinn Apps reference documentation with new `syncAdapterSettings` configuration options: `disableMarkCompletedWhenConfirmed`, `disableSyncContentAdditionalInformation`, and `disableSyncContentExtendedStatus`. These settings allow fine-grained control over dialog status updates and content synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->