### PR TITLE
oppdater listen over correspondence events

### DIFF
--- a/content/correspondence/getting-started/developer-guides/events/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/events/_index.en.md
@@ -51,11 +51,8 @@ If you do not specify a Type Filter you will receive all the different types of 
 
 **For service owner:**
 - `no.altinn.correspondence.attachmentinitialized`
-- `no.altinn.correspondence.attachmentuploadprocessing`
 - `no.altinn.correspondence.attachmentpublished`
 - `no.altinn.correspondence.attachmentuploadfailed`
-- `no.altinn.correspondence.attachmentpurged`
-- `no.altinn.correspondence.attachmentdownloaded`
 - `no.altinn.correspondence.attachmentexpired`
 
 - `no.altinn.correspondence.correspondenceinitialized`
@@ -64,9 +61,11 @@ If you do not specify a Type Filter you will receive all the different types of 
 - `no.altinn.correspondence.correspondencepublishfailed`
 - `no.altinn.correspondence.notificationcreated`
 - `no.altinn.correspondence.correspondencenotificationcreationfailed`
+- `no.altinn.correspondence.correspondencenotificationfailed`
 
 **For every recipient:**
 - `no.altinn.correspondence.correspondencepublished`
 - `no.altinn.correspondence.correspondencereceiverread`
 - `no.altinn.correspondence.correspondencereceiverconfirmed`
-- `no.altinn.correspondence.Correspondencereceiverreserved`
+- `no.altinn.correspondence.correspondencereceiverneverread`
+- `no.altinn.correspondence.correspondencereceiverneverconfirmed`

--- a/content/correspondence/getting-started/developer-guides/events/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/events/_index.nb.md
@@ -51,11 +51,8 @@ Hvis du ikke spesifiserer et *typeFilter*, vil du motta alle forskjellige typer 
 
 **For tjeneste-eier:**
 - `no.altinn.correspondence.attachmentinitialized`
-- `no.altinn.correspondence.attachmentuploadprocessing`
 - `no.altinn.correspondence.attachmentpublished`
 - `no.altinn.correspondence.attachmentuploadfailed`
-- `no.altinn.correspondence.attachmentpurged`
-- `no.altinn.correspondence.attachmentdownloaded`
 - `no.altinn.correspondence.attachmentexpired`
 
 - `no.altinn.correspondence.correspondenceinitialized`
@@ -64,9 +61,11 @@ Hvis du ikke spesifiserer et *typeFilter*, vil du motta alle forskjellige typer 
 - `no.altinn.correspondence.correspondencepublishfailed`
 - `no.altinn.correspondence.notificationcreated`
 - `no.altinn.correspondence.correspondencenotificationcreationfailed`
+- `no.altinn.correspondence.correspondencenotificationfailed`
 
 **For hver mottaker:**
 - `no.altinn.correspondence.correspondencepublished`
 - `no.altinn.correspondence.correspondencereceiverread`
 - `no.altinn.correspondence.correspondencereceiverconfirmed`
-- `no.altinn.correspondence.Correspondencereceiverreserved`
+- `no.altinn.correspondence.correspondencereceiverneverread`
+- `no.altinn.correspondence.correspondencereceiverneverconfirmed`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated event type filter examples in developer guides with newly supported event types, including notification failure and receiver-status events. Removed outdated attachment-related event type references. Updated in both English and Norwegian versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->