### PR TITLE
Updated Dialogporten migration status

### DIFF
--- a/content/dialogporten/status-migration/_index.en.md
+++ b/content/dialogporten/status-migration/_index.en.md
@@ -70,7 +70,7 @@ Forms that are still being filled out are not migrated until they are archived.
 
 ## Changelog
 
-30.04.2026: Correspondence migrated back to october 2022. Further migration ongoing. Forms are migrated back to and including 2019. We are quality-assuring the migration of forms before continuing.
+30.04.2026: Correspondence migrated back to October 2022. Further migration ongoing. Forms are migrated back to and including 2019. We are quality-assuring the migration of forms before continuing.
 
 16.04.2026: Migration of forms for 2023 and 2022 completed.
 

--- a/content/dialogporten/status-migration/_index.en.md
+++ b/content/dialogporten/status-migration/_index.en.md
@@ -41,7 +41,7 @@ All changes made directly through Dialogporten's API are available immediately.
 Typically used where the service owner either has their own platform, or handle dialogs outside the default functionality of Altinn Correspondence or Altinn Studio/apps.
 
 ### ⚠ A2 Correspondence - Historic
-Currently migrated back to 1st of January 2024. Older correspondence will be migrated later.
+Currently migrated back to 8th of October 2022. Migration of older correspondence is ongoing.
 
 Manual process. Historic correspondence is migrated from Altinn 2 correspondence to Altinn 3 correspondence. The correspondences are then migrated to Dialogporten in a separate process.
 
@@ -62,7 +62,7 @@ Migrated back to 1st of January 2022. Older app instances will be migrated later
 New app instances created in Altinn 3 are available in Dialogporten immediately. Changes are synced in real-time.
 
 ### ⚠ A2 Archived forms - Historic
-Migrated back to 1st of January 2022. Older archived forms will be migrated later.
+Migrated back to 1st of January 2019. Older archived forms will be migrated later.
 
 ### ✔ A2 Archived forms - Live
 Newly archived app instances created in Altinn 2 are migrated in batches every 5 minutes.

--- a/content/dialogporten/status-migration/_index.en.md
+++ b/content/dialogporten/status-migration/_index.en.md
@@ -17,8 +17,10 @@ Live sync: All changes[^1] (forms, messages) show up in Dialogporten.
 
 | Source | Migrated back to |
 |----------|----------|
-| A2-Correspondence | 01.01.2024 |
-| A2 archived forms / A3-app instances | 01.01.2022 |
+| A2-Correspondence | 08.10.2022 |
+| A2 archived forms / A3-app instances | 01.01.2019[^2] |
+
+[^2]: We are quality-assuring the migration of forms before we continue migrating older data.
 
 ## Goals and plans
 
@@ -67,6 +69,8 @@ Newly archived app instances created in Altinn 2 are migrated in batches every 5
 Forms that are still being filled out are not migrated until they are archived.
 
 ## Changelog
+
+30.04.2026: Correspondence migrated back to october 2022. Further migration ongoing. Forms are migrated back to and including 2019. We are quality-assuring the migration of forms before continuing.
 
 16.04.2026: Migration of forms for 2023 and 2022 completed.
 

--- a/content/dialogporten/status-migration/_index.nb.md
+++ b/content/dialogporten/status-migration/_index.nb.md
@@ -17,8 +17,10 @@ Livesynkronisering: Alle endringer[^1] (skjema, meldinger) vises i Dialogporten.
 
 | Kilde | Migrert tilbake til |
 |----------|----------|
-| A2-Melding | 01.01.2024 |
-| A2 arkiverte skjema / A3-app-instanser | 01.01.2022 |
+| A2-Melding | 08.10.2022 |
+| A2 arkiverte skjema / A3-app-instanser | 01.01.2019[^2] |
+
+[^2]: Vi kvalitetssikrer migreringen av skjema før vi fortsetter å migrere eldre data.
 
 ## Mål og planer
 
@@ -68,6 +70,8 @@ Nylig arkiverte app-instanser opprettet i Altinn 2 migreres i puljer hvert 5. mi
 Skjema som er under utfylling blir ikke migrert før de er arkivert.
 
 ## Endringslogg
+30.04.2026: Meldinger migrert tilbake til oktober 2022. Videre migrering pågår. Skjema er migrert tilbake til og med 2019. Vi kvalitetssikrer migrering av skjema før vi fortsetter.
+
 16.04.2026: Migrering av arkiverte skjema for 2023 og 2022 fullført.
 
 11.03.2026: Tydeliggjort at skjema som fortsatt er under utfylling i Altinn 2 ikke migreres før de er arkivert.

--- a/content/dialogporten/status-migration/_index.nb.md
+++ b/content/dialogporten/status-migration/_index.nb.md
@@ -41,7 +41,7 @@ Alle endringer gjort direkte gjennom Dialogportens API er tilgjengelige umiddelb
 Brukes typisk der tjenesteeier enten har egen plattform, eller håndterer dialoger utenfor standardfunksjonaliteten til Altinn Melding eller Altinn Studio/apper.
 
 ### ⚠ A2 Melding - Historisk
-Foreløpig migrert tilbake til 1. januar 2024. Eldre meldinger vil bli migrert senere.
+Foreløpig migrert tilbake til 8. oktober 2022. Migrering av eldre meldinger pågår.
 
 Manuell prosess. Historiske meldinger migreres fra Altinn 2 Melding til Altinn 3 Melding. Meldingene migreres deretter til Dialogporten i en separat prosess.
 
@@ -57,13 +57,13 @@ Se [migrering av meldingsdata](https://docs.altinn.studio/nb/correspondence/tran
 Alle nye meldinger opprettet i Altinn 3 Melding er tilgjengelig i Dialogporten umiddelbart. Ingen migrering nødvendig.
 
 ### ⚠ A3 App-instanser - Historisk
-Foreløpig migrert tilbake til 1. januar 2022. Eldre app-instanser vil bli migrert senere.
+Foreløpig migrert tilbake til 1. januar 2019. Eldre app-instanser vil bli migrert senere.
 
 ### ✔ A3 App-instanser - Live
 Nye app-instanser opprettet i Altinn 3 er tilgjengelig i Dialogporten umiddelbart. Endringer synkroniseres i sanntid.
 
 ### ⚠ A2 Arkiverte skjema - Historisk
-Foreløpig migrert tilbake til 1. januar 2022. Eldre arkiverte skjema vil bli migrert senere.
+Foreløpig migrert tilbake til 1. januar 2019. Eldre arkiverte skjema vil bli migrert senere.
 
 ### ✔ A2 Arkiverte skjema - Live
 Nylig arkiverte app-instanser opprettet i Altinn 2 migreres i puljer hvert 5. minutt.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated historical migration status table with revised cutoff dates
  * Extended A2-Correspondence migration timeline to October 2022
  * Extended A2 archived forms/A3-app instances migration timeline to January 2019
  * Added notes on quality assurance processes for ongoing migration activities
  * Added new April 2026 changelog entry reflecting updated migration timelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->