### PR TITLE
Add documentation for status change api for consent

### DIFF
--- a/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.en.md
+++ b/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.en.md
@@ -1,0 +1,75 @@
+---
+title: List latest status changes for consent
+linktitle: List latest status changes for consent
+weight: 10
+toc: false
+---
+
+### Prerequisites
+
+1. The data consumer must have a registered Maskinporten client.
+2. The data consumer must have been delegated the consent scope from Digdir. (altinn:consentrequests.read)
+3. The necessary scopes must be added to the Maskinporten client.
+
+### API Endpoint
+
+Returns a paginated list of consent requests that have had recent status changes for the authenticated enterprise. 
+Results are ordered by the latest status change, newest first. The pagesize is defaulted to 100 if not specified.
+This endpoint uses cursor-based pagination, so call the endpoint without a ContinuationToken to get the first page.
+- **Test**: `GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
+- **Production**: `GET https://platform.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
+
+### Request/Response Example
+**First page**
+`GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
+Authorization: Bearer <maskinporten_token>
+
+```jsonc
+{
+  "links": {
+    "next": "https://<host>/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D&pageSize=50"
+  },
+  "data": [
+    {
+      "consentRequestId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "eventType": "accepted",
+      "changedDate": "2025-05-04T10:30:00+02:00"
+    }
+  ]
+}
+```
+
+**Next Page**
+`GET /accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D&pageSize=50`
+Authorization: Bearer <maskinporten_token>
+
+```jsonc
+{
+  "links": {
+    "next": "https://<host>/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D&pageSize=50"
+  },
+  "data": [
+    {
+      "consentRequestId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "eventType": "accepted",
+      "changedDate": "2025-05-04T10:30:00+02:00"
+    }
+  ]
+}
+```
+
+| Response Field | Description |
+|----------------|-------------|
+|links.Next|URL to fetch the next page. null if there are no more results.|
+|data[].consentRequestId|Unique identifier of the consent request.|
+|data[].eventType|the type of status event f.eks accepted, rejected, revoked, deleted, used. Event created will not be listed as it is not a status change.|
+|data[].changedDate| the timestamp of when the status change occured|
+
+
+**Error Responses**
+| StatusCode | Description |
+|------------|-------------|
+|401 Unauthorized|Missing or invalid authentication token.|
+|403 Forbidden|Authenticated party is not authorized to access this resource.|
+|400 Bad Request|Invalid query parameters. See the ProblemDetails body for details.|
+|500 Internal Server Error|Unexpected server-side error.|

--- a/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.en.md
+++ b/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.en.md
@@ -14,7 +14,7 @@ toc: false
 ## API Endpoint
 
 Returns a paginated list of consent requests that have had recent status changes for the authenticated enterprise. 
-Results are ordered by the latest status change, newest first.
+Results are ordered by the latest status change, newest first. By default, the API returns up to 100 changes per request.
 This endpoint uses cursor-based pagination, so call the endpoint without a ContinuationToken to get the first page.
 - **Test**: `GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 - **Production**: `GET https://platform.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
@@ -22,7 +22,8 @@ This endpoint uses cursor-based pagination, so call the endpoint without a Conti
 ## Request/Response Example
 **First page**
 `GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
-Authorization: Bearer <maskinporten_token>
+
+`Authorization: Bearer <maskinporten_token>`
 
 ```jsonc
 {
@@ -41,7 +42,8 @@ Authorization: Bearer <maskinporten_token>
 
 **Next Page**
 `GET /accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D`
-Authorization: Bearer <maskinporten_token>
+
+`Authorization: Bearer <maskinporten_token>`
 
 ```jsonc
 {

--- a/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.en.md
+++ b/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.en.md
@@ -5,13 +5,13 @@ weight: 10
 toc: false
 ---
 
-### Prerequisites
+## Prerequisites
 
 1. The data consumer must have a registered Maskinporten client.
 2. The data consumer must have been delegated the consent scope from Digdir. (altinn:consentrequests.read)
 3. The necessary scopes must be added to the Maskinporten client.
 
-### API Endpoint
+## API Endpoint
 
 Returns a paginated list of consent requests that have had recent status changes for the authenticated enterprise. 
 Results are ordered by the latest status change, newest first. The pagesize is defaulted to 100 if not specified.
@@ -19,7 +19,7 @@ This endpoint uses cursor-based pagination, so call the endpoint without a Conti
 - **Test**: `GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 - **Production**: `GET https://platform.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 
-### Request/Response Example
+## Request/Response Example
 **First page**
 `GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 Authorization: Bearer <maskinporten_token>
@@ -62,14 +62,15 @@ Authorization: Bearer <maskinporten_token>
 |----------------|-------------|
 |links.Next|URL to fetch the next page. null if there are no more results.|
 |data[].consentRequestId|Unique identifier of the consent request.|
-|data[].eventType|the type of status event f.eks accepted, rejected, revoked, deleted, used. Event created will not be listed as it is not a status change.|
+|data[].eventType|the type of status event. Events: accepted, rejected, revoked, deleted, used. Event created/expired will not be listed as it is not a status change.|
 |data[].changedDate| the timestamp of when the status change occured|
 
 
-**Error Responses**
+## Error Responses
+
 | StatusCode | Description |
 |------------|-------------|
 |401 Unauthorized|Missing or invalid authentication token.|
-|403 Forbidden|Authenticated party is not authorized to access this resource.|
+|403 Forbidden|Authenticated party is not authorized.|
 |400 Bad Request|Invalid query parameters. See the ProblemDetails body for details.|
 |500 Internal Server Error|Unexpected server-side error.|

--- a/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.en.md
+++ b/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.en.md
@@ -21,7 +21,7 @@ This endpoint uses cursor-based pagination, so call the endpoint without a Conti
 
 ## Request/Response Example
 **First page**
-`GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
+`GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?pageSize=50`
 Authorization: Bearer <maskinporten_token>
 
 ```jsonc

--- a/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.en.md
+++ b/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.en.md
@@ -62,10 +62,10 @@ This endpoint uses cursor-based pagination, so call the endpoint without a Conti
 
 | Response Field | Description |
 |----------------|-------------|
-|links.Next|URL to fetch the next page. null if there are no more results.|
+|links.next|URL to fetch the next page. null if there are no more results.|
 |data[].consentRequestId|Unique identifier of the consent request.|
 |data[].eventType|the type of status event. Events: accepted, rejected, revoked, deleted, used. Event created/expired will not be listed as it is not a status change.|
-|data[].changedDate| the timestamp of when the status change occured|
+|data[].changedDate|the timestamp of when the status change occured.|
 
 
 ## Error Responses

--- a/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.en.md
+++ b/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.en.md
@@ -14,20 +14,20 @@ toc: false
 ## API Endpoint
 
 Returns a paginated list of consent requests that have had recent status changes for the authenticated enterprise. 
-Results are ordered by the latest status change, newest first. The pagesize is defaulted to 100 if not specified.
+Results are ordered by the latest status change, newest first.
 This endpoint uses cursor-based pagination, so call the endpoint without a ContinuationToken to get the first page.
 - **Test**: `GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 - **Production**: `GET https://platform.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 
 ## Request/Response Example
 **First page**
-`GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?pageSize=50`
+`GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 Authorization: Bearer <maskinporten_token>
 
 ```jsonc
 {
   "links": {
-    "next": "https://<host>/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D&pageSize=50"
+    "next": "https://<host>/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D"
   },
   "data": [
     {
@@ -40,13 +40,13 @@ Authorization: Bearer <maskinporten_token>
 ```
 
 **Next Page**
-`GET /accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D&pageSize=50`
+`GET /accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D`
 Authorization: Bearer <maskinporten_token>
 
 ```jsonc
 {
   "links": {
-    "next": "https://<host>/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D&pageSize=50"
+    "next": "https://<host>/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D"
   },
   "data": [
     {

--- a/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.nb.md
+++ b/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.nb.md
@@ -1,0 +1,76 @@
+---
+title: Oversikt over de nyeste statusendringene knyttet til samtykke
+linktitle: Oversikt over de nyeste statusendringene knyttet til samtykke
+weight: 10
+toc: false
+---
+
+## Forutsetning
+
+1. Datakonsumenten må ha en registrert Maskinporten-klient.
+2. Datakonsumenten må ha fått delegert samtykkescope fra Digdir (altinn:consentrequests.read).
+3. De nødvendige scopene må legges til Maskinporten-klienten.
+
+## API Endepunkt
+
+Returnerer en paginert liste over samtykkeforspørsler som nylig har hatt statusendringer for den autentiserte virksomheten.
+Resultatene sorteres etter siste statusendring, med nyeste først. Standardsidestørrelse er 100 hvis ikke annet er spesifisert.
+Dette endepunktet bruker kursormbasert paginering, så kall endepunktet uten en ContinuationToken for å hente den første siden.
+- **Test**: `GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
+- **Produksjon**: `GET https://platform.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
+
+## Request/Response Eksempel
+**Første side**
+`GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
+Authorization: Bearer <maskinporten_token>
+
+```jsonc
+{
+  "links": {
+    "next": "https://<host>/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D&pageSize=50"
+  },
+  "data": [
+    {
+      "consentRequestId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "eventType": "accepted",
+      "changedDate": "2025-05-04T10:30:00+02:00"
+    }
+  ]
+}
+```
+
+**Neste side**
+`GET /accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D&pageSize=50`
+Authorization: Bearer <maskinporten_token>
+
+```jsonc
+{
+  "links": {
+    "next": "https://<host>/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D&pageSize=50"
+  },
+  "data": [
+    {
+      "consentRequestId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "eventType": "accepted",
+      "changedDate": "2025-05-04T10:30:00+02:00"
+    }
+  ]
+}
+```
+
+| Respons Felt | Beskrivelse |
+|----------------|-------------|
+|links.Next|URL for å hente neste side. null hvis det ikke finnes flere resultater.|
+|data[].consentRequestId|Unik identifikator for samtykkeforspørselen.|
+|data[].eventType|Type statushendelse. Hendelser: accepted, rejected, revoked, deleted, used. Hendelsen ‘created/expired’ listes ikke, da dette ikke er en statusendring.|
+|data[].changedDate| Tidsstempel for når statusendringen skjedde.|
+
+
+## Error Responses
+
+| Statuskode | Beskrivelse |
+|------------|-------------|
+|401 Unauthorized|Manglende eller ugyldig autentiseringstoken.|
+|403 Forbidden|Den autentiserte parten har ikke tilgang|
+|400 Bad Request|Spørringsparametere er ugyldige. Se innholdet i ProblemDetails for detaljer.|
+|500 Internal Server Error|Uventet feil på serversiden.|

--- a/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.nb.md
+++ b/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.nb.md
@@ -15,7 +15,7 @@ toc: false
 
 Returnerer en paginert liste over samtykkeforspørsler som nylig har hatt statusendringer for den autentiserte virksomheten.
 Resultatene sorteres etter siste statusendring, med nyeste først. Som standard returnerer API-et opptil 100 endringer per forespørsel.
-Dette endepunktet bruker kursormbasert paginering, så kall endepunktet uten en ContinuationToken for å hente den første siden.
+Dette endepunktet bruker kursorbasert paginering, så kall endepunktet uten en ContinuationToken for å hente den første siden.
 - **Test**: `GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 - **Produksjon**: `GET https://platform.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 
@@ -62,10 +62,10 @@ Dette endepunktet bruker kursormbasert paginering, så kall endepunktet uten en 
 
 | Respons Felt | Beskrivelse |
 |----------------|-------------|
-|links.Next|URL for å hente neste side. null hvis det ikke finnes flere resultater.|
+|links.next|URL for å hente neste side. null hvis det ikke finnes flere resultater.|
 |data[].consentRequestId|Unik identifikator for samtykkeforspørselen.|
 |data[].eventType|Type statushendelse. Hendelser: accepted, rejected, revoked, deleted, used. Hendelsen ‘created/expired’ listes ikke, da dette ikke er en statusendring.|
-|data[].changedDate| Tidsstempel for når statusendringen skjedde.|
+|data[].changedDate|Tidsstempel for når statusendringen skjedde.|
 
 
 ## Error Responses
@@ -73,6 +73,6 @@ Dette endepunktet bruker kursormbasert paginering, så kall endepunktet uten en 
 | Statuskode | Beskrivelse |
 |------------|-------------|
 |401 Unauthorized|Manglende eller ugyldig autentiseringstoken.|
-|403 Forbidden|Den autentiserte parten har ikke tilgang|
+|403 Forbidden|Den autentiserte parten har ikke tilgang.|
 |400 Bad Request|Spørringsparametere er ugyldige. Se innholdet i ProblemDetails for detaljer.|
 |500 Internal Server Error|Uventet feil på serversiden.|

--- a/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.nb.md
+++ b/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.nb.md
@@ -14,20 +14,20 @@ toc: false
 ## API Endepunkt
 
 Returnerer en paginert liste over samtykkeforspørsler som nylig har hatt statusendringer for den autentiserte virksomheten.
-Resultatene sorteres etter siste statusendring, med nyeste først. Standardsidestørrelse er 100 hvis ikke annet er spesifisert.
+Resultatene sorteres etter siste statusendring, med nyeste først. 
 Dette endepunktet bruker kursormbasert paginering, så kall endepunktet uten en ContinuationToken for å hente den første siden.
 - **Test**: `GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 - **Produksjon**: `GET https://platform.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 
 ## Request/Response Eksempel
 **Første side**
-`GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?pageSize=50`
+`GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 Authorization: Bearer <maskinporten_token>
 
 ```jsonc
 {
   "links": {
-    "next": "https://<host>/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D&pageSize=50"
+    "next": "https://<host>/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D"
   },
   "data": [
     {
@@ -40,13 +40,13 @@ Authorization: Bearer <maskinporten_token>
 ```
 
 **Neste side**
-`GET /accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D&pageSize=50`
+`GET /accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D`
 Authorization: Bearer <maskinporten_token>
 
 ```jsonc
 {
   "links": {
-    "next": "https://<host>/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D&pageSize=50"
+    "next": "https://<host>/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D"
   },
   "data": [
     {

--- a/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.nb.md
+++ b/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.nb.md
@@ -21,7 +21,7 @@ Dette endepunktet bruker kursormbasert paginering, så kall endepunktet uten en 
 
 ## Request/Response Eksempel
 **Første side**
-`GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
+`GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges?pageSize=50`
 Authorization: Bearer <maskinporten_token>
 
 ```jsonc

--- a/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.nb.md
+++ b/content/authorization/guides/system-vendor/consent/liststatuschanges/_index.nb.md
@@ -14,7 +14,7 @@ toc: false
 ## API Endepunkt
 
 Returnerer en paginert liste over samtykkeforspørsler som nylig har hatt statusendringer for den autentiserte virksomheten.
-Resultatene sorteres etter siste statusendring, med nyeste først. 
+Resultatene sorteres etter siste statusendring, med nyeste først. Som standard returnerer API-et opptil 100 endringer per forespørsel.
 Dette endepunktet bruker kursormbasert paginering, så kall endepunktet uten en ContinuationToken for å hente den første siden.
 - **Test**: `GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
 - **Produksjon**: `GET https://platform.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
@@ -22,7 +22,8 @@ Dette endepunktet bruker kursormbasert paginering, så kall endepunktet uten en 
 ## Request/Response Eksempel
 **Første side**
 `GET https://platform.tt02.altinn.no/accessmanagement/api/v1/enterprise/consentrequests/latestchanges`
-Authorization: Bearer <maskinporten_token>
+
+`Authorization: Bearer <maskinporten_token>`
 
 ```jsonc
 {
@@ -41,7 +42,8 @@ Authorization: Bearer <maskinporten_token>
 
 **Neste side**
 `GET /accessmanagement/api/v1/enterprise/consentrequests/latestchanges?continuationToken=MjAyNS0wNS0wNFQxMDozMDowMCswMjowMHwzZmE4NWY2NC01NzE3LTQ1NjItYjNmYy0yYzk2M2Y2NmFmYTY%3D`
-Authorization: Bearer <maskinporten_token>
+
+`Authorization: Bearer <maskinporten_token>`
 
 ```jsonc
 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added English and Norwegian guides describing how to list the latest consent status changes.
  * Documents prerequisites, API behavior (newest-first, cursor-based pagination using ContinuationToken), test and production base URLs, example first/next page requests with sample JSON (including links.next), response fields (links.next, consentRequestId, eventType, changedDate) and enumerated error responses (401, 403, 400, 500).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->