### PR TITLE
docs: added docs for edit/delete layout buttons

### DIFF
--- a/content/altinn-studio/v10/develop-a-service/look-and-feel/components/RepeatingGroup.md
+++ b/content/altinn-studio/v10/develop-a-service/look-and-feel/components/RepeatingGroup.md
@@ -91,6 +91,7 @@ draft: true
 | `saveAndNextButton` | Expression or boolean indicating whether to show the "Save and next" button when editing a repeating group row. This button will save the current row and open the next row for editing. |  |
 | `alwaysShowAddButton` | If set to true, the "Add" button will always be shown, even if the user is currently editing another row |  |
 | `compactButtons` | If true, edit and delete buttons in the table only show icons when the row is not in edit mode. Text will still be shown when the row is in edit mode. |  |
+| `buttonLayout` | Controls how `Edit` and `Delete` are laid out in desktop table view. `"horizontal"` (default) uses two columns side by side. `"vertical"` uses one column with Edit above Delete to save horizontal space. Does not apply to mobile/tablet layout. | `"horizontal"`, `"vertical"` |
 
 ## Pagination (`pagination`)
 

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/edit/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/edit/_index.en.md
@@ -78,7 +78,7 @@ Example:
 ```
 
 ## Layout for edit and delete buttons
-A new opt-in property `buttonLayout` in the RepeatingGroup component’s `edit` configuration controls how the`Edit` and `Delete` buttons are arranged in desktop table view. Use `buttonLayout`: `"vertical"` to place them in one column instead of the default horizontal layout. This saves horizontal space when the table has many columns. Mobile/tablet layout is unchanged.
+A new opt-in property `buttonLayout` in the RepeatingGroup component’s `edit` configuration controls how the `Edit` and `Delete` buttons are arranged in desktop table view. Use `buttonLayout`: `"vertical"` to place them in one column instead of the default horizontal layout. This saves horizontal space when the table has many columns. Mobile/tablet layout is unchanged.
 Default is `"horizontal"` if you omit the property.
 
 You can add `buttonLayout` to the `edit` property of your RepeatingGroup configuration in the layout JSON.
@@ -97,7 +97,6 @@ Example:
 You can also combine it with `compactButtons` to hide the text of the button, for example:
 
 ```json
-
 {
   ...
   "edit": {

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/edit/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/edit/_index.en.md
@@ -77,6 +77,36 @@ Example:
 }
 ```
 
+## Layout for edit and delete buttons
+A new opt-in property `buttonLayout` in the RepeatingGroup component’s `edit` configuration controls how the`Edit` and `Delete` buttons are arranged in desktop table view. Use `buttonLayout`: `"vertical"` to place them in one column instead of the default horizontal layout. This saves horizontal space when the table has many columns. Mobile/tablet layout is unchanged.
+Default is `"horizontal"` if you omit the property.
+
+You can add `buttonLayout` to the `edit` property of your RepeatingGroup configuration in the layout JSON.
+
+Example:
+
+```json
+{
+  ...
+  "edit": {
+    "buttonLayout": "vertical"
+  }
+}
+```
+
+You can also combine it with `compactButtons` to hide the text of the button, for example:
+
+```json
+
+{
+  ...
+  "edit": {
+    "compactButtons": true,
+    "buttonLayout": "vertical"
+  }
+}
+```
+
 ## multiPage
 
 Editing/filling out pages can be performed over multiple "pages"/displays. Requires more setup to work,

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/edit/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/edit/_index.nb.md
@@ -76,8 +76,8 @@ Eksempel:
 }
 ```
 
-## Layout for rediger og slett knapper
-En ny valgfri egenskap `buttonLayout`  i `edit`-konfigurasjonen til RepeatingGroup styrer hvordan handlingene `Rediger` og `Slett` plasseres i skrivebordsvisning av tabellen. Bruk `buttonLayout` : `"vertical"`  for å legge dem i én kolonne i stedet for standard horisontalt oppsett. Dette sparer horisontal plass når tabellen har mange kolonner. Oppsett på mobil/nettbrett er uendret.
+## Layout for knappene Endre og Slett
+En ny valgfri egenskap `buttonLayout`  i `edit`-konfigurasjonen til RepeatingGroup styrer hvordan handlingene `Endre` og `Slett` plasseres i skrivebordsvisning av tabellen. Bruk `buttonLayout` : `"vertical"`  for å legge dem i én kolonne i stedet for i standard horisontalt oppsett. Dette sparer horisontal plass når tabellen har mange kolonner. Oppsett på mobil/nettbrett er uendret.
 Standard er `"horizontal"`  hvis du utelater egenskapen.
 
 Du kan legge til `buttonLayout`  i `edit` delen av RepeatingGroup-konfigurasjonen i layout-JSON.

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/edit/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/edit/_index.nb.md
@@ -77,7 +77,7 @@ Eksempel:
 ```
 
 ## Layout for rediger og slett knapper
-En ny valgfri egenskap `buttonLayout`  i `edit`-konfigurasjonen til RepeatingGroup styrer hvordan handlingene `Rediger` og `Slett` plasseres i tabellvisning på skrivebord. Bruk `buttonLayout` : `"vertical"`  for å legge dem i én kolonne i stedet for standard horisontalt oppsett (to kolonner ved siden av hverandre). Dette sparer horisontal plass når tabellen har mange kolonner. Oppsett på mobil/nettbrett er uendret.
+En ny valgfri egenskap `buttonLayout`  i `edit`-konfigurasjonen til RepeatingGroup styrer hvordan handlingene `Rediger` og `Slett` plasseres i skrivebordsvisning av tabellen. Bruk `buttonLayout` : `"vertical"`  for å legge dem i én kolonne i stedet for standard horisontalt oppsett. Dette sparer horisontal plass når tabellen har mange kolonner. Oppsett på mobil/nettbrett er uendret.
 Standard er `"horizontal"`  hvis du utelater egenskapen.
 
 Du kan legge til `buttonLayout`  i `edit` delen av RepeatingGroup-konfigurasjonen i layout-JSON.
@@ -93,7 +93,7 @@ Eksempel:
 }
 ```
 
-Du kan også kombinere den med `compactButtons` for å skjule text på knapper, for eksempel:
+Du kan også kombinere den med `compactButtons` for å skjule tekst på knapper, for eksempel:
 
 ```json
 {

--- a/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/edit/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/fields/grouping/repeating/edit/_index.nb.md
@@ -76,6 +76,35 @@ Eksempel:
 }
 ```
 
+## Layout for rediger og slett knapper
+En ny valgfri egenskap `buttonLayout`  i `edit`-konfigurasjonen til RepeatingGroup styrer hvordan handlingene `Rediger` og `Slett` plasseres i tabellvisning på skrivebord. Bruk `buttonLayout` : `"vertical"`  for å legge dem i én kolonne i stedet for standard horisontalt oppsett (to kolonner ved siden av hverandre). Dette sparer horisontal plass når tabellen har mange kolonner. Oppsett på mobil/nettbrett er uendret.
+Standard er `"horizontal"`  hvis du utelater egenskapen.
+
+Du kan legge til `buttonLayout`  i `edit` delen av RepeatingGroup-konfigurasjonen i layout-JSON.
+
+Eksempel:
+
+```json
+{
+  ...
+  "edit": {
+    "buttonLayout": "vertical"
+  }
+}
+```
+
+Du kan også kombinere den med `compactButtons` for å skjule text på knapper, for eksempel:
+
+```json
+{
+  ...
+  "edit": {
+    "compactButtons": true,
+    "buttonLayout": "vertical"
+  }
+}
+```
+
 ## multiPage
 
 Sier at redigering/utfylling av gruppe kan gjøres over flere "sider"/visninger. Krever mer oppsett for å fungere,


### PR DESCRIPTION
Added documents for layout buttons edit and delete 

<img width="946" height="211" alt="Screenshot 2026-05-07 at 09 39 15" src="https://github.com/user-attachments/assets/8deb6ada-4437-4092-ad6e-04da63618547" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated RepeatingGroup component documentation with new `buttonLayout` property for configuring Edit and Delete button arrangement in desktop table view. Supports "horizontal" (default) and "vertical" options. Mobile and tablet layouts remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->