### PR TITLE
Updated outdated correspondence event subscribe docs

### DIFF
--- a/content/correspondence/getting-started/developer-guides/events/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/events/_index.en.md
@@ -32,19 +32,26 @@ All Events published by Altinn Correspondence follow the same pattern:
 
 This subscription is used to configure the endpoint where the events published by correspondence end up. [You can read more about how to setup an Events subscription in Altinn Events here](/en/events/subscribe-to-events/developer-guides/setup-subscription/).
 
-You are required to set up the following filters:
+**For service owners**, you are required to set up the following filter:
 
-- sourceFilter
-  - TT02: <https://platform.tt02.altinn.no/correspondence/api/v1/correspondence>
-  - PROD: <https://api.altinn.no/correspondence/api/v1/correspondence>
 - resourceFilter
   - "urn:altinn:resource:" + The Resource Id for the Correspondence Resource
-- alternativesubjectfilter
-  - "/organisation/(organisation number for your organisation) or /person/(SSN number)
 
-*Alternativesubjectfilter* is used to restrict the event to only the authorized sender or recipient for that particular event, this ensures security and reduces visibility.
+**For recipients**, you are required to set up the following filters:
 
-*Resourceinstance* will always be the same as the FileTransferId of the FileTransfer.
+- resourceFilter
+  - "urn:altinn:resource:" + The Resource Id for the Correspondence Resource
+- subjectFilter
+  - "urn:altinn:organization:identifier-no:{{recipient_orgnumber}}"
+
+*SubjectFilter* is used to restrict the event to only the authorized recipient for that particular event, this ensures security and reduces visibility.
+
+*Resourceinstance* will always be the same as the CorrespondenceId of the Correspondence.
+
+The *source* for events produced by Correspondence is:
+
+- TT02 (test): <https://platform.tt02.altinn.no/correspondence/api/v1/correspondence>
+- Production: <https://platform.altinn.no/correspondence/api/v1/correspondence>
 
 In addition you may wish to use filters for Type, so that you receive the event types you are interested in/can perform actions on.
 If you do not specify a Type Filter you will receive all the different types of events if you have access to them.

--- a/content/correspondence/getting-started/developer-guides/events/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/events/_index.nb.md
@@ -32,19 +32,26 @@ Alle hendelser publisert av Altinn Melding følger det samme mønsteret:
 
 Dette abonnementet brukes til å konfigurere endepunktet der hendelsene som publiseres av Atlinn Melding skal leveres. [Du kan lese mer om hvordan du setter opp et hendelsesabonnement i Altinn Events her](/nb/events/subscribe-to-events/developer-guides/setup-subscription/).
 
-Du må sette opp følgende filtre:
+**For tjeneste-eier** må du sette opp følgende filter:
 
-- sourceFilter
-  - TT02: <https://platform.tt02.altinn.no/correspondence/api/v1/correspondence>
-  - PROD: <https://api.altinn.no/correspondence/api/v1/correspondence>
 - resourceFilter
   - "urn:altinn:resource:" + Ressurs-IDen for meldingstjenesten
-- alternativesubjectfilter
-  - "/organisation/(organisasjonsnummer for din organisasjon) eller "/person/(personnummer)
 
-*Alternativesubjectfilter* brukes til å begrense Event til bare den autoriserte avsenderen eller mottakeren for den spesifikke hendelsen, dette sikrer innholdet og reduserer synlighet.
+**For mottakere** må du sette opp følgende filtre:
+
+- resourceFilter
+  - "urn:altinn:resource:" + Ressurs-IDen for meldingstjenesten
+- subjectFilter
+  - "urn:altinn:organization:identifier-no:{{recipient_orgnumber}}"
+
+*SubjectFilter* brukes til å begrense hendelsen til bare den autoriserte mottakeren for den spesifikke hendelsen, dette sikrer innholdet og reduserer synlighet.
 
 *Resourceinstance* vil alltid være det samme som CorrespondenceId for Meldingen.
+
+*Source* for hendelser som produseres av Melding er:
+
+- TT02 (test): <https://platform.tt02.altinn.no/correspondence/api/v1/correspondence>
+- Produksjon: <https://platform.altinn.no/correspondence/api/v1/correspondence>
 
 I tillegg kan du ønske å bruke *typeFilter*, slik at du mottar hendelsestypene du er interessert i/kan utføre handlinger på.
 Hvis du ikke spesifiserer et *typeFilter*, vil du motta alle forskjellige typer hendelser, gitt at du har tilgang til dem.


### PR DESCRIPTION
Det er ikke støttet å opprette et abonoment på events med sourcefilter eller alternativesubjectfilter for meldingstjenester. Oppdaterte meldings dokumentasjonen hvor det står et man trengte disse filtrene for å sette opp abonoment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated event subscription guidance with clearer filter requirements for service owners and recipients
  * Expanded documentation with specific endpoint URLs for TT02 and production environments
  * Enhanced explanations of subject and resource filter functionality, including security and visibility aspects
  * Improved filter format specifications with detailed examples for better implementation clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->