### PR TITLE
docs: document studioctl local development

### DIFF
--- a/content/altinn-studio/shared/studioctl/install-clone.en.md
+++ b/content/altinn-studio/shared/studioctl/install-clone.en.md
@@ -1,0 +1,36 @@
+---
+headless: true
+hidden: true
+---
+
+### Supported platforms
+
+`studioctl` can be used on Windows, Linux and macOS.
+To run the local test platform, you need a container runtime.
+Use Docker, Podman or Colima.
+
+Install `studioctl`:
+
+```bash
+curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
+```
+
+On Windows, install from PowerShell:
+
+```powershell
+iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
+```
+
+Log in and clone the app:
+
+```bash
+studioctl auth login
+studioctl app clone <org>/<app-name>
+cd <app-name>
+```
+
+For automation and CI, pass an existing Studio/Designer API key through standard input from an environment variable:
+
+```bash
+printf '%s' "$STUDIO_DESIGNER_API_KEY" | studioctl auth login --with-token
+```

--- a/content/altinn-studio/shared/studioctl/install-clone.nb.md
+++ b/content/altinn-studio/shared/studioctl/install-clone.nb.md
@@ -1,0 +1,36 @@
+---
+headless: true
+hidden: true
+---
+
+### Støttede plattformer
+
+`studioctl` kan brukes på Windows, Linux og macOS.
+For å kjøre lokal testplattform trenger du en container runtime.
+Bruk Docker, Podman eller Colima.
+
+Installer `studioctl`:
+
+```bash
+curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
+```
+
+På Windows kan du installere fra PowerShell:
+
+```powershell
+iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
+```
+
+Logg inn og klon appen:
+
+```bash
+studioctl auth login
+studioctl app clone <org>/<app-name>
+cd <app-name>
+```
+
+For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input fra en miljøvariabel:
+
+```bash
+printf '%s' "$STUDIO_DESIGNER_API_KEY" | studioctl auth login --with-token
+```

--- a/content/altinn-studio/shared/studioctl/legacy-app-localtest.en.md
+++ b/content/altinn-studio/shared/studioctl/legacy-app-localtest.en.md
@@ -1,0 +1,14 @@
+---
+headless: true
+hidden: true
+---
+
+The old workflow uses the `app-localtest` repository directly.
+This method can still be useful when troubleshooting an old setup, but the recommended local workflow is `studioctl`.
+
+1. **Download and start LocalTest** by following the steps [described on GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (includes starting the app, which is also explained below).
+2. **Run your application within LocalTest**: Open a new terminal window and go to the subfolder *App* in your application (`<app-name>/App`). Start the app with the command `dotnet run` and wait for confirmation in the terminal.
+3. **Preview and test the application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user]({0}).
+
+Stop the application by pressing `ctrl+C` in the terminal window where you started it.
+Stop LocalTest by going to the `app-localtest` folder in the terminal and running the command `docker compose down`.

--- a/content/altinn-studio/shared/studioctl/legacy-app-localtest.nb.md
+++ b/content/altinn-studio/shared/studioctl/legacy-app-localtest.nb.md
@@ -1,0 +1,14 @@
+---
+headless: true
+hidden: true
+---
+
+Den gamle arbeidsflyten bruker `app-localtest`-repoet direkte.
+Denne metoden kan fortsatt være nyttig ved feilsøking av et gammelt oppsett, men den anbefalte lokale arbeidsflyten er `studioctl`.
+
+1. **Last ned og start LocalTest** ved å følge stegene [beskrevet på GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (inkluderer start av appen, som også er forklart under).
+2. **Kjør applikasjonen i LocalTest**: Åpne et nytt terminalvindu og gå til undermappen *App* i applikasjonen din (`<app-name>/App`). Start appen med kommandoen `dotnet run` og vent på bekreftelse i terminalen.
+3. **Forhåndsvis og test applikasjonen**: Gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn med en [testbruker]({0}).
+
+Stopp applikasjonen ved å trykke `ctrl+C` i terminalvinduet der du startet den.
+Stopp LocalTest ved å gå til mappen `app-localtest` i terminalen og kjøre kommandoen `docker compose down`.

--- a/content/altinn-studio/shared/studioctl/local-development-intro.en.md
+++ b/content/altinn-studio/shared/studioctl/local-development-intro.en.md
@@ -1,0 +1,7 @@
+---
+headless: true
+hidden: true
+---
+
+`studioctl` is the recommended command-line tool for local development of Altinn Studio apps.
+It logs in to Altinn Studio, clones the app repository and configures Git authentication for you.

--- a/content/altinn-studio/shared/studioctl/local-development-intro.nb.md
+++ b/content/altinn-studio/shared/studioctl/local-development-intro.nb.md
@@ -1,0 +1,7 @@
+---
+headless: true
+hidden: true
+---
+
+`studioctl` er et anbefalt kommandolinjeverktøy for lokal utvikling av Altinn Studio-apper.
+Verktøyet logger inn mot Altinn Studio, kloner app-repoet og setter opp Git-autentisering for deg.

--- a/content/altinn-studio/shared/studioctl/local-test-workflow.en.md
+++ b/content/altinn-studio/shared/studioctl/local-test-workflow.en.md
@@ -1,0 +1,23 @@
+---
+headless: true
+hidden: true
+---
+
+You can preview the changes you make when working locally.
+`studioctl` starts the local test platform, runs the app and connects the app to local.altinn.cloud on port `8000`.
+You need a container runtime, such as Docker, Podman or Colima, and the .NET SDK to run the app as a local process.
+Run `studioctl doctor` to check that your machine has the required tools.
+
+<div class="notices info"><strong>NOTE</strong>
+To run the app in LocalTest, the application must have an associated <a href="{0}">data model</a>.</div>
+
+1. **Start the local test platform**: Go to the app repository in a terminal and run `studioctl env up`.
+2. **Run your application within LocalTest**: Run `studioctl run` from the app repository. The command detects the app directory and starts the app with the correct local settings.
+3. **Preview and test the application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user]({1}).
+
+You can also open the browser when the test platform starts:
+
+```bash
+studioctl env up --open
+studioctl run
+```

--- a/content/altinn-studio/shared/studioctl/local-test-workflow.nb.md
+++ b/content/altinn-studio/shared/studioctl/local-test-workflow.nb.md
@@ -1,0 +1,23 @@
+---
+headless: true
+hidden: true
+---
+
+Du kan forhåndsvise endringene du gjør når du jobber lokalt.
+`studioctl` starter lokal testplattform, kjører appen og kobler appen til local.altinn.cloud på port `8000`.
+Du trenger en container runtime, for eksempel Docker, Podman eller Colima, og .NET SDK for å kjøre appen som en lokal prosess.
+Kjør `studioctl doctor` for å sjekke at maskinen din har verktøyene som trengs.
+
+<div class="notices info"><strong>MERK</strong>
+For å kunne kjøre appen i LocalTest må applikasjonen ha en tilknyttet <a href="{0}">datamodell</a>.</div>
+
+1. **Start lokal testplattform**: Gå til app-repoet i terminalen og kjør `studioctl env up`.
+2. **Kjør applikasjonen i LocalTest**: Kjør `studioctl run` fra app-repoet. Kommandoen finner appmappen automatisk og starter appen med riktige lokale innstillinger.
+3. **Forhåndsvis og test applikasjonen**: Gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn med en [testbruker]({1}).
+
+Du kan også åpne nettleseren direkte når testplattformen starter:
+
+```bash
+studioctl env up --open
+studioctl run
+```

--- a/content/altinn-studio/shared/studioctl/preview-warning.en.md
+++ b/content/altinn-studio/shared/studioctl/preview-warning.en.md
@@ -1,0 +1,6 @@
+---
+headless: true
+hidden: true
+---
+
+`studioctl` is currently released as `v0.1.0-preview`. Breaking changes may still occur, although no breaking changes are planned at the moment.

--- a/content/altinn-studio/shared/studioctl/preview-warning.nb.md
+++ b/content/altinn-studio/shared/studioctl/preview-warning.nb.md
@@ -1,0 +1,6 @@
+---
+headless: true
+hidden: true
+---
+
+`studioctl` er foreløpig utgitt som `v0.1.0-preview`. Det kan fortsatt komme brytende endringer, selv om det ikke er planlagt noen nå.

--- a/content/altinn-studio/shared/studioctl/stop-local-test.en.md
+++ b/content/altinn-studio/shared/studioctl/stop-local-test.en.md
@@ -1,0 +1,9 @@
+---
+headless: true
+hidden: true
+---
+
+### Stop the application and LocalTest
+
+Stop the application by pressing `ctrl+C` in the terminal window where you started it.
+Stop LocalTest with `studioctl env down`.

--- a/content/altinn-studio/shared/studioctl/stop-local-test.nb.md
+++ b/content/altinn-studio/shared/studioctl/stop-local-test.nb.md
@@ -1,0 +1,9 @@
+---
+headless: true
+hidden: true
+---
+
+### Stoppe app og LocalTest
+
+Stopp appen ved å trykke `ctrl+C` i terminalvinduet der du startet den.
+Stopp LocalTest med `studioctl env down`.

--- a/content/altinn-studio/shared/studioctl/useful-commands.en.md
+++ b/content/altinn-studio/shared/studioctl/useful-commands.en.md
@@ -5,13 +5,45 @@ hidden: true
 
 Useful commands:
 
-| Command | Description |
-| ------- | ----------- |
-| `studioctl env up --open` | Starts the local test platform and opens local.altinn.cloud on port `8000`. |
-| `studioctl env status` | Shows local test platform status. |
-| `studioctl env logs` | Shows logs from the LocalTest containers. |
-| `studioctl run --detach` | Runs the app in the background. |
-| `studioctl app logs` | Shows logs from an app running in the background. Use `--follow` for live logs. |
-| `studioctl stop` | Stops apps started with `studioctl run --detach`. |
-| `studioctl env down` | Stops the local test platform. |
-| `studioctl doctor` | Diagnoses missing tools and local environment issues. |
+<table>
+  <thead>
+    <tr>
+      <th>Command</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>studioctl env up --open</code></td>
+      <td>Starts the local test platform and opens local.altinn.cloud on port <code>8000</code>.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl env status</code></td>
+      <td>Shows local test platform status.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl env logs</code></td>
+      <td>Shows logs from the LocalTest containers.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl run --detach</code></td>
+      <td>Runs the app in the background.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl app logs</code></td>
+      <td>Shows logs from an app running in the background. Use <code>--follow</code> for live logs.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl stop</code></td>
+      <td>Stops apps started with <code>studioctl run --detach</code>.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl env down</code></td>
+      <td>Stops the local test platform.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl doctor</code></td>
+      <td>Diagnoses missing tools and local environment issues.</td>
+    </tr>
+  </tbody>
+</table>

--- a/content/altinn-studio/shared/studioctl/useful-commands.en.md
+++ b/content/altinn-studio/shared/studioctl/useful-commands.en.md
@@ -1,0 +1,17 @@
+---
+headless: true
+hidden: true
+---
+
+Useful commands:
+
+| Command | Description |
+| ------- | ----------- |
+| `studioctl env up --open` | Starts the local test platform and opens local.altinn.cloud on port `8000`. |
+| `studioctl env status` | Shows local test platform status. |
+| `studioctl env logs` | Shows logs from the LocalTest containers. |
+| `studioctl run --detach` | Runs the app in the background. |
+| `studioctl app logs` | Shows logs from an app running in the background. Use `--follow` for live logs. |
+| `studioctl stop` | Stops apps started with `studioctl run --detach`. |
+| `studioctl env down` | Stops the local test platform. |
+| `studioctl doctor` | Diagnoses missing tools and local environment issues. |

--- a/content/altinn-studio/shared/studioctl/useful-commands.nb.md
+++ b/content/altinn-studio/shared/studioctl/useful-commands.nb.md
@@ -1,0 +1,17 @@
+---
+headless: true
+hidden: true
+---
+
+Nyttige kommandoer:
+
+| Kommando | Beskrivelse |
+| -------- | ----------- |
+| `studioctl env up --open` | Starter lokal testplattform og åpner local.altinn.cloud på port `8000`. |
+| `studioctl env status` | Viser status for lokal testplattform. |
+| `studioctl env logs` | Viser logger fra LocalTest-containerne. |
+| `studioctl run --detach` | Kjører appen i bakgrunnen. |
+| `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
+| `studioctl stop` | Stopper apper som er startet med `studioctl run --detach`. |
+| `studioctl env down` | Stopper lokal testplattform. |
+| `studioctl doctor` | Diagnostiserer manglende verktøy og lokale miljøproblemer. |

--- a/content/altinn-studio/shared/studioctl/useful-commands.nb.md
+++ b/content/altinn-studio/shared/studioctl/useful-commands.nb.md
@@ -5,13 +5,45 @@ hidden: true
 
 Nyttige kommandoer:
 
-| Kommando | Beskrivelse |
-| -------- | ----------- |
-| `studioctl env up --open` | Starter lokal testplattform og åpner local.altinn.cloud på port `8000`. |
-| `studioctl env status` | Viser status for lokal testplattform. |
-| `studioctl env logs` | Viser logger fra LocalTest-containerne. |
-| `studioctl run --detach` | Kjører appen i bakgrunnen. |
-| `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
-| `studioctl stop` | Stopper apper som er startet med `studioctl run --detach`. |
-| `studioctl env down` | Stopper lokal testplattform. |
-| `studioctl doctor` | Diagnostiserer manglende verktøy og lokale miljøproblemer. |
+<table>
+  <thead>
+    <tr>
+      <th>Kommando</th>
+      <th>Beskrivelse</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>studioctl env up --open</code></td>
+      <td>Starter lokal testplattform og åpner local.altinn.cloud på port <code>8000</code>.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl env status</code></td>
+      <td>Viser status for lokal testplattform.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl env logs</code></td>
+      <td>Viser logger fra LocalTest-containerne.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl run --detach</code></td>
+      <td>Kjører appen i bakgrunnen.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl app logs</code></td>
+      <td>Viser logger fra en app som kjører i bakgrunnen. Bruk <code>--follow</code> for løpende logg.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl stop</code></td>
+      <td>Stopper apper som er startet med <code>studioctl run --detach</code>.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl env down</code></td>
+      <td>Stopper lokal testplattform.</td>
+    </tr>
+    <tr>
+      <td><code>studioctl doctor</code></td>
+      <td>Diagnostiserer manglende verktøy og lokale miljøproblemer.</td>
+    </tr>
+  </tbody>
+</table>

--- a/content/altinn-studio/v10/getting-started/development/custom-development/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/custom-development/_index.en.md
@@ -1,7 +1,7 @@
 ---
-title: Customizations in custom code
+title: Customisations in custom code
 linktitle: Custom code
-description: Customize your app with custom code
+description: Customise your app with custom code
 draft: true
 weight: 40
 ---
@@ -34,7 +34,7 @@ This list is not exhaustive. In practice, you can implement whatever the app nee
 {{% insert "content/altinn-studio/shared/studioctl/install-clone.en.md" %}}
 
 When the app has been cloned, you can open the repository in your preferred development tool and change C# code, configuration, data models, layouts and other files.
-Remember to synchronize changes with Git when you switch between Altinn Studio Designer and your local development environment.
+Remember to synchronise changes with Git when you switch between Altinn Studio Designer and your local development environment.
 
 ## Run and test the app locally
 

--- a/content/altinn-studio/v10/getting-started/development/custom-development/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/custom-development/_index.en.md
@@ -1,0 +1,67 @@
+---
+title: Customizations in custom code
+linktitle: Custom code
+description: Customize your app with custom code
+draft: true
+weight: 40
+---
+
+## About using custom code in an Altinn app
+
+An Altinn app is a complete web application, so you can add custom code when you need to support more than the standard configuration supports.
+
+### Example use cases
+
+This list is not exhaustive. In practice, you can implement whatever the app needs.
+
+- Validate at startup, for example with advanced validation logic, lookups or similar logic.
+- Prefill dynamically from your own systems.
+- Run calculations and other logic while the user fills in the app.
+- Look up data from external sources while the user fills in the app or during submission.
+- Add logic or advanced validation during submission or when the process moves to a new task.
+- Create or fetch dynamic code lists.
+- Configure functionality that is not yet supported through configuration alone, such as payment.
+- Add concepts that are not supported out of the box in an Altinn app today.
+
+## Local development with studioctl
+
+{{% insert "content/altinn-studio/shared/studioctl/local-development-intro.en.md" %}}
+
+{{% notice warning %}}
+{{% insert "content/altinn-studio/shared/studioctl/preview-warning.en.md" %}}
+{{% /notice %}}
+
+{{% insert "content/altinn-studio/shared/studioctl/install-clone.en.md" %}}
+
+When the app has been cloned, you can open the repository in your preferred development tool and change C# code, configuration, data models, layouts and other files.
+Remember to synchronize changes with Git when you switch between Altinn Studio Designer and your local development environment.
+
+## Run and test the app locally
+
+Start the local test platform and run the app:
+
+```bash
+studioctl env up
+studioctl run
+```
+
+When the app is running, you can test it at [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
+
+Run `studioctl doctor` if something does not start as expected.
+The command checks tools such as the .NET SDK, container runtime and local configuration.
+
+Useful commands:
+
+| Command | Description |
+| ------- | ----------- |
+| `studioctl env up --open` | Starts the local test platform and opens local.altinn.cloud on port `8000`. |
+| `studioctl env status` | Shows local test platform status. |
+| `studioctl env logs` | Shows logs from the LocalTest containers. |
+| `studioctl run --detach` | Runs the app in the background. |
+| `studioctl app logs` | Shows logs from an app running in the background. Use `--follow` for live logs. |
+| `studioctl stop` | Stops apps started with `studioctl run --detach`. |
+| `studioctl env down` | Stops the local test platform. |
+| `studioctl doctor` | Diagnoses missing tools and local environment issues. |
+
+If you change JSON files, reloading the page is usually enough.
+If you change C# code, stop the app with `ctrl+C` and start it again with `studioctl run`.

--- a/content/altinn-studio/v10/getting-started/development/custom-development/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/custom-development/_index.en.md
@@ -50,18 +50,7 @@ When the app is running, you can test it at [http://local.altinn.cloud:8000](htt
 Run `studioctl doctor` if something does not start as expected.
 The command checks tools such as the .NET SDK, container runtime and local configuration.
 
-Useful commands:
-
-| Command | Description |
-| ------- | ----------- |
-| `studioctl env up --open` | Starts the local test platform and opens local.altinn.cloud on port `8000`. |
-| `studioctl env status` | Shows local test platform status. |
-| `studioctl env logs` | Shows logs from the LocalTest containers. |
-| `studioctl run --detach` | Runs the app in the background. |
-| `studioctl app logs` | Shows logs from an app running in the background. Use `--follow` for live logs. |
-| `studioctl stop` | Stops apps started with `studioctl run --detach`. |
-| `studioctl env down` | Stops the local test platform. |
-| `studioctl doctor` | Diagnoses missing tools and local environment issues. |
+{{% insert "content/altinn-studio/shared/studioctl/useful-commands.en.md" %}}
 
 If you change JSON files, reloading the page is usually enough.
 If you change C# code, stop the app with `ctrl+C` and start it again with `studioctl run`.

--- a/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
@@ -57,10 +57,10 @@ cd <app-name>
 Når appen er klonet kan du åpne repoet i ønsket utviklingsverktøy og gjøre endringer i C#-kode, konfigurasjon, datamodeller, layouts og andre filer.
 Husk å synkronisere endringer med Git når du bytter mellom Altinn Studio Designer og lokalt utviklingsmiljø.
 
-For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input:
+For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input fra en miljøvariabel:
 
 ```bash
-studioctl auth login --with-token < token.txt
+printf '%s' "$STUDIO_DESIGNER_API_KEY" | studioctl auth login --with-token
 ```
 
 ## Kjøre og teste appen lokalt

--- a/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
@@ -28,6 +28,12 @@ Listen er ikke utfyllende - her kan du i praksis få til hva som helst!
 Du bruker det til å logge inn, klone appen, starte lokal testplattform og kjøre appen fra maskinen din.
 Verktøyet kan også brukes i CI når du vil klone og teste en app uten en interaktiv innlogging.
 
+### Støttede plattformer
+
+`studioctl` kan brukes på Windows, Linux og macOS.
+For å kjøre lokal testplattform trenger du en container runtime.
+Bruk Docker, Podman eller Colima.
+
 Installer `studioctl`:
 
 ```bash

--- a/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
@@ -78,7 +78,7 @@ Nyttige kommandoer:
 | -------- | ----------- |
 | `studioctl env up --open` | Starter lokal testplattform og åpner local.altinn.cloud. |
 | `studioctl env status` | Viser status for lokal testplattform. |
-| `studioctl env logs` | Viser logger fra localtest-containerne. |
+| `studioctl env logs` | Viser logger fra LocalTest-containerne. |
 | `studioctl app run --detach` | Kjører appen i bakgrunnen. |
 | `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
 | `studioctl app stop` | Stopper apper som er startet med `studioctl app run --detach`. |

--- a/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
@@ -32,8 +32,8 @@ Listen er ikke utfyllende - her kan du i praksis få til hva som helst!
 
 {{% insert "content/altinn-studio/shared/studioctl/install-clone.nb.md" %}}
 
-Når appen er klonet kan du åpne repoet i ønsket utviklingsverktøy og gjøre endringer i C#-kode, konfigurasjon, datamodeller, layouts og andre filer.
-Husk å synkronisere endringer med Git når du bytter mellom Altinn Studio Designer og lokalt utviklingsmiljø.
+Når appen er klonet, kan du åpne repoet i ønsket utviklingsverktøy og gjøre endringer i C#-kode, konfigurasjon, datamodeller, layouts og andre filer.
+Husk å synkronisere endringer med Git når du bytter mellom Altinn Studio Designer og ditt lokale utviklingsmiljø.
 
 ## Kjøre og teste appen lokalt
 
@@ -62,7 +62,7 @@ Nyttige kommandoer:
 | `studioctl env down` | Stopper lokal testplattform. |
 | `studioctl doctor` | Diagnostiserer manglende verktøy og lokale miljøproblemer. |
 
-Hvis du endrer JSON-filer er det som regel nok å laste siden på nytt.
+Hvis du endrer JSON-filer, er det som regel nok å laste siden på nytt.
 Hvis du endrer C#-kode, stopp appen med `ctrl+C` og start den på nytt med `studioctl run`.
 
 <!-- ## Konsept: Dependency injection

--- a/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
@@ -22,6 +22,72 @@ Listen er ikke utfyllende - her kan du i praksis få til hva som helst!
 - Oppsett på funksjonalitet som ikke enda er støttet via konfigurasjon alene, f.eks. betaling.
 - Behov for nye konsepter som ikke er støttet ut av boksen i en Altinn-app per i dag
 
+## Lokal utvikling med studioctl
+
+`studioctl` er kommandolinjeverktøyet for lokal utvikling av Altinn Studio-apper.
+Du bruker det til å logge inn, klone appen, starte lokal testplattform og kjøre appen fra maskinen din.
+Verktøyet kan også brukes i CI når du vil klone og teste en app uten en interaktiv innlogging.
+
+Installer `studioctl`:
+
+```bash
+curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
+```
+
+På Windows kan du installere fra PowerShell:
+
+```powershell
+iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
+```
+
+Logg inn og klon appen:
+
+```bash
+studioctl auth login
+studioctl app clone <org>/<app-name>
+cd <app-name>
+```
+
+Når appen er klonet kan du åpne repoet i ønsket utviklingsverktøy og gjøre endringer i C#-kode, konfigurasjon, datamodeller, layouts og andre filer.
+Husk å synkronisere endringer med Git når du bytter mellom Altinn Studio Designer og lokalt utviklingsmiljø.
+
+For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input:
+
+```bash
+studioctl auth login --with-token < token.txt
+```
+
+## Kjøre og teste appen lokalt
+
+Start lokal testplattform og kjør appen:
+
+```bash
+studioctl env up
+studioctl app run
+```
+
+`studioctl app run` finner appmappen automatisk og starter appen med riktige lokale innstillinger.
+Når appen kjører kan du teste den på [http://local.altinn.cloud](http://local.altinn.cloud) med en [testbruker](/nb/altinn-studio/v10/test-a-service/testing/local/testusers/).
+
+Kjør `studioctl doctor` hvis noe ikke starter som forventet.
+Kommandoen sjekker blant annet .NET SDK, container runtime og lokal konfigurasjon.
+
+Nyttige kommandoer:
+
+| Kommando | Beskrivelse |
+| -------- | ----------- |
+| `studioctl env up --open` | Starter lokal testplattform og åpner local.altinn.cloud. |
+| `studioctl env status` | Viser status for lokal testplattform. |
+| `studioctl env logs` | Viser logger fra localtest-containerne. |
+| `studioctl app run --detach` | Kjører appen i bakgrunnen. |
+| `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
+| `studioctl app stop` | Stopper apper som er startet med `studioctl app run --detach`. |
+| `studioctl env down` | Stopper lokal testplattform. |
+| `studioctl doctor` | Diagnostiserer manglende verktøy og lokale miljøproblemer. |
+
+Hvis du endrer JSON-filer er det som regel nok å laste siden på nytt.
+Hvis du endrer C#-kode, stopp appen med `ctrl+C` og start den på nytt med `studioctl app run`.
+
 <!-- ## Konsept: Dependency injection
 En Altinn-app bruker biblioteker som Digdir utvikler og forvalter. Gjennom disse bibliotekene eksponeres det grensesnitt
 for konkret funksjonalitet. Når disse grensesnittene implementeres i din app og registreres der, vil koden som er implementert

--- a/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
@@ -49,18 +49,7 @@ Når appen kjører kan du teste den på [http://local.altinn.cloud:8000](http://
 Kjør `studioctl doctor` hvis noe ikke starter som forventet.
 Kommandoen sjekker blant annet .NET SDK, container runtime og lokal konfigurasjon.
 
-Nyttige kommandoer:
-
-| Kommando | Beskrivelse |
-| -------- | ----------- |
-| `studioctl env up --open` | Starter lokal testplattform og åpner local.altinn.cloud på port `8000`. |
-| `studioctl env status` | Viser status for lokal testplattform. |
-| `studioctl env logs` | Viser logger fra LocalTest-containerne. |
-| `studioctl run --detach` | Kjører appen i bakgrunnen. |
-| `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
-| `studioctl stop` | Stopper apper som er startet med `studioctl run --detach`. |
-| `studioctl env down` | Stopper lokal testplattform. |
-| `studioctl doctor` | Diagnostiserer manglende verktøy og lokale miljøproblemer. |
+{{% insert "content/altinn-studio/shared/studioctl/useful-commands.nb.md" %}}
 
 Hvis du endrer JSON-filer, er det som regel nok å laste siden på nytt.
 Hvis du endrer C#-kode, stopp appen med `ctrl+C` og start den på nytt med `studioctl run`.

--- a/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/custom-development/_index.nb.md
@@ -24,44 +24,16 @@ Listen er ikke utfyllende - her kan du i praksis få til hva som helst!
 
 ## Lokal utvikling med studioctl
 
-`studioctl` er kommandolinjeverktøyet for lokal utvikling av Altinn Studio-apper.
-Du bruker det til å logge inn, klone appen, starte lokal testplattform og kjøre appen fra maskinen din.
-Verktøyet kan også brukes i CI når du vil klone og teste en app uten en interaktiv innlogging.
+{{% insert "content/altinn-studio/shared/studioctl/local-development-intro.nb.md" %}}
 
-### Støttede plattformer
+{{% notice warning %}}
+{{% insert "content/altinn-studio/shared/studioctl/preview-warning.nb.md" %}}
+{{% /notice %}}
 
-`studioctl` kan brukes på Windows, Linux og macOS.
-For å kjøre lokal testplattform trenger du en container runtime.
-Bruk Docker, Podman eller Colima.
-
-Installer `studioctl`:
-
-```bash
-curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
-```
-
-På Windows kan du installere fra PowerShell:
-
-```powershell
-iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
-```
-
-Logg inn og klon appen:
-
-```bash
-studioctl auth login
-studioctl app clone <org>/<app-name>
-cd <app-name>
-```
+{{% insert "content/altinn-studio/shared/studioctl/install-clone.nb.md" %}}
 
 Når appen er klonet kan du åpne repoet i ønsket utviklingsverktøy og gjøre endringer i C#-kode, konfigurasjon, datamodeller, layouts og andre filer.
 Husk å synkronisere endringer med Git når du bytter mellom Altinn Studio Designer og lokalt utviklingsmiljø.
-
-For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input fra en miljøvariabel:
-
-```bash
-printf '%s' "$STUDIO_DESIGNER_API_KEY" | studioctl auth login --with-token
-```
 
 ## Kjøre og teste appen lokalt
 
@@ -69,11 +41,10 @@ Start lokal testplattform og kjør appen:
 
 ```bash
 studioctl env up
-studioctl app run
+studioctl run
 ```
 
-`studioctl app run` finner appmappen automatisk og starter appen med riktige lokale innstillinger.
-Når appen kjører kan du teste den på [http://local.altinn.cloud](http://local.altinn.cloud) med en [testbruker](/nb/altinn-studio/v10/test-a-service/testing/local/testusers/).
+Når appen kjører kan du teste den på [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) med en [testbruker](/nb/altinn-studio/v10/test-a-service/testing/local/testusers/).
 
 Kjør `studioctl doctor` hvis noe ikke starter som forventet.
 Kommandoen sjekker blant annet .NET SDK, container runtime og lokal konfigurasjon.
@@ -82,17 +53,17 @@ Nyttige kommandoer:
 
 | Kommando | Beskrivelse |
 | -------- | ----------- |
-| `studioctl env up --open` | Starter lokal testplattform og åpner local.altinn.cloud. |
+| `studioctl env up --open` | Starter lokal testplattform og åpner local.altinn.cloud på port `8000`. |
 | `studioctl env status` | Viser status for lokal testplattform. |
 | `studioctl env logs` | Viser logger fra LocalTest-containerne. |
-| `studioctl app run --detach` | Kjører appen i bakgrunnen. |
+| `studioctl run --detach` | Kjører appen i bakgrunnen. |
 | `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
-| `studioctl app stop` | Stopper apper som er startet med `studioctl app run --detach`. |
+| `studioctl stop` | Stopper apper som er startet med `studioctl run --detach`. |
 | `studioctl env down` | Stopper lokal testplattform. |
 | `studioctl doctor` | Diagnostiserer manglende verktøy og lokale miljøproblemer. |
 
 Hvis du endrer JSON-filer er det som regel nok å laste siden på nytt.
-Hvis du endrer C#-kode, stopp appen med `ctrl+C` og start den på nytt med `studioctl app run`.
+Hvis du endrer C#-kode, stopp appen med `ctrl+C` og start den på nytt med `studioctl run`.
 
 <!-- ## Konsept: Dependency injection
 En Altinn-app bruker biblioteker som Digdir utvikler og forvalter. Gjennom disse bibliotekene eksponeres det grensesnitt

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
@@ -18,6 +18,12 @@ Here is an overview of how to get started with local development.
 `studioctl` is the recommended command-line tool for local development of Altinn Studio apps.
 It logs in to Altinn Studio, clones the app repository and configures Git authentication for you.
 
+### Supported platforms
+
+`studioctl` can be used on Windows, Linux and macOS.
+To run the local test platform, you need a container runtime.
+Use Docker, Podman or Colima.
+
 Install `studioctl`:
 
 ```bash

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
@@ -58,15 +58,15 @@ Now you can open your preferred development tool and start coding.
 
 {{% /expandlarge %}}
 
-## Synchronize changes in the local development environment
+## Synchronise changes in the local development environment
 
 You must upload (push) changes you make locally to the repository from which the code was cloned.
 If you make changes in Altinn Studio Designer (and upload these to the repository), you must download them (pull) to update the local code.
 
-You can synchronize changes in the local development environment in several ways.
+You can synchronise changes in the local development environment in several ways.
 Many development tools have good integrations for this purpose, so check whether your tool has that type of support.
 
-Below we describe how you can synchronize changes from the command line.
+Below we describe how you can synchronise changes from the command line.
 
 ### Upload changes
 
@@ -81,9 +81,9 @@ Go to your application repository in a terminal and run the command `git pull`.
 
 [Read more about `git pull` here](https://git-scm.com/docs/git-pull)
 
-## Synchronize changes in Altinn Studio
+## Synchronise changes in Altinn Studio
 
-In Altinn Studio, you must synchronize changes in the same way as with local changes.
+In Altinn Studio, you must synchronise changes in the same way as with local changes.
 
 ### Download changes
 1. Click **Hent endringer** (Fetch changes) on the 'Lage' page of the application in Altinn Studio.

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
@@ -44,10 +44,10 @@ studioctl app clone <org>/<app-name>
 cd <app-name>
 ```
 
-For automation and CI, pass an existing Studio/Designer API key through standard input:
+For automation and CI, pass an existing Studio/Designer API key through standard input from an environment variable:
 
 ```bash
-studioctl auth login --with-token < token.txt
+printf '%s' "$STUDIO_DESIGNER_API_KEY" | studioctl auth login --with-token
 ```
 
 {{% expandlarge id="legacy-clone-with-git" header="Old method: Clone manually with Git" %}}

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
@@ -111,27 +111,7 @@ In Altinn Studio, you must synchronise changes in the same way as with local cha
 
 ## Local testing
 
-You can preview the changes you make when working locally.
-`studioctl` starts the local test platform, runs the app and connects the app to local.altinn.cloud on port `8000`.
-You need a container runtime, such as Docker, Podman or Colima, and the .NET SDK to run the app as a local process.
-Run `studioctl doctor` to check that your machine has the required tools.
-
-{{% notice info %}}
-**NOTE**
-To run the app in LocalTest, the application must have an associated [data model](/en/altinn-studio/v10/develop-a-service/reference/data/data-modeling/).
-{{% /notice %}}
-
-1. **Start the local test platform**: Go to the app repository in a terminal and run `studioctl env up`.
-2. **Run your application within LocalTest**: Run `studioctl run` from the app repository. The command detects the app directory and starts the app with the correct local settings.
-3. **Preview and test the application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
-
-You can also open the browser when the test platform starts:
-
-```bash
-studioctl env up --open
-studioctl run
-```
-
+{{% insert "content/altinn-studio/shared/studioctl/local-test-workflow.en.md" "/en/altinn-studio/v10/develop-a-service/reference/data/data-modeling/" "/en/altinn-studio/v10/test-a-service/testing/local/testusers/" %}}
 {{% insert "content/altinn-studio/shared/studioctl/useful-commands.en.md" %}}
 
 ### Preview changes in real-time
@@ -143,21 +123,10 @@ studioctl run
 You can update automatically when changing C# files by starting the application with `dotnet watch`.
 This command will either start the application or reload it ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) when changes are made to the source code.
 
-### Stop the application and LocalTest
-
-Stop the application by pressing `ctrl+C` in the terminal window where you started it.
-Stop LocalTest with `studioctl env down`.
+{{% insert "content/altinn-studio/shared/studioctl/stop-local-test.en.md" %}}
 
 {{% expandlarge id="legacy-app-localtest" header="Old method: Run app-localtest manually" %}}
 
-The old workflow uses the `app-localtest` repository directly.
-This method can still be useful when troubleshooting an old setup, but the recommended local workflow is `studioctl`.
-
-1. **Download and start LocalTest** by following the steps [we describe on GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (includes starting the app, which we also explain below).
-2. **Run your application within LocalTest**: Open a new terminal window and go to the subfolder *App* in your application (`<app-name>/App`). Start the app with the command `dotnet run` and wait for confirmation in the terminal.
-3. **Preview and test the application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
-
-Stop the application by pressing `ctrl+C` in the terminal window where you started it.
-Stop LocalTest by going to the `app-localtest` folder in the terminal and running the command `docker compose down`.
+{{% insert "content/altinn-studio/shared/studioctl/legacy-app-localtest.en.md" "/en/altinn-studio/v10/test-a-service/testing/local/testusers/" %}}
 
 {{% /expandlarge %}}

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
@@ -158,7 +158,7 @@ Useful commands:
 | Command | Description |
 | ------- | ----------- |
 | `studioctl env status` | Shows local test platform status. |
-| `studioctl env logs` | Shows logs from the localtest containers. |
+| `studioctl env logs` | Shows logs from the LocalTest containers. |
 | `studioctl app run --detach` | Runs the app in the background. |
 | `studioctl app logs` | Shows logs from an app running in the background. Use `--follow` for live logs. |
 | `studioctl app stop` | Stops apps started with `studioctl app run --detach`. |
@@ -169,9 +169,9 @@ Useful commands:
 
 - If you change JSON files, simply reload the page.
 - If you change prefilling, you must start a new instance of the application (go to [http://local.altinn.cloud](http://local.altinn.cloud) and log in again).
-- If you change CS files, you must stop the application (`ctrl+C`) and start it again (`studioctl app run`).
+- If you change C# files, you must stop the application (`ctrl+C`) and start it again (`studioctl app run`).
 
-You can update automatically when changing CS files by starting the application with `dotnet watch`.
+You can update automatically when changing C# files by starting the application with `dotnet watch`.
 This command will either start the application or reload it ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) when changes are made to the source code.
 
 ### Stop the application and LocalTest

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
@@ -123,7 +123,7 @@ To run the app in LocalTest, the application must have an associated [data model
 
 1. **Start the local test platform**: Go to the app repository in a terminal and run `studioctl env up`.
 2. **Run your application within LocalTest**: Run `studioctl run` from the app repository. The command detects the app directory and starts the app with the correct local settings.
-3. **Preview and test application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
+3. **Preview and test the application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
 
 You can also open the browser when the test platform starts:
 
@@ -165,7 +165,7 @@ This method can still be useful when troubleshooting an old setup, but the recom
 
 1. **Download and start LocalTest** by following the steps [we describe on GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (includes starting the app, which we also explain below).
 2. **Run your application within LocalTest**: Open a new terminal window and go to the subfolder *App* in your application (`<app-name>/App`). Start the app with the command `dotnet run` and wait for confirmation in the terminal.
-3. **Preview and test application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
+3. **Preview and test the application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
 
 Stop the application by pressing `ctrl+C` in the terminal window where you started it.
 Stop LocalTest by going to the `app-localtest` folder in the terminal and running the command `docker compose down`.

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
@@ -15,6 +15,37 @@ Here is an overview of how to get started with local development.
 
 ## Clone the application to a local development environment
 
+`studioctl` is the recommended command-line tool for local development of Altinn Studio apps.
+It logs in to Altinn Studio, clones the app repository and configures Git authentication for you.
+
+Install `studioctl`:
+
+```bash
+curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
+```
+
+On Windows, install from PowerShell:
+
+```powershell
+iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
+```
+
+Log in and clone the app:
+
+```bash
+studioctl auth login
+studioctl app clone <org>/<app-name>
+cd <app-name>
+```
+
+For automation and CI, pass an existing Studio/Designer API key through standard input:
+
+```bash
+studioctl auth login --with-token < token.txt
+```
+
+{{% expandlarge id="legacy-clone-with-git" header="Old method: Clone manually with Git" %}}
+
 1. Find the application you want to work with locally in the [Dashboard](/en/altinn-studio/v8/getting-started/navigation/dashboard/) in Altinn Studio
 2. Open the repository. Click the **Repository** button
     ![Repository button highlighted in an image](find-app-in-dashboard.png)
@@ -45,6 +76,8 @@ Here is an overview of how to get started with local development.
 
 The system creates a folder with the same name as the application and clones the contents of the application repository into the folder.
 Now you can open your preferred development tool and start coding.
+
+{{% /expandlarge %}}
 
 ## Synchronise changes in the local development environment
 
@@ -100,23 +133,43 @@ In Altinn Studio, you must synchronise changes in the same way as with local cha
 ## Local testing
 
 You can preview the changes you make when working locally.
-*LocalTest* is a programme that spins up a local mock-up of the Altinn Platform.
-It allows you to test and verify local changes without having to synchronise with Altinn Studio.
+`studioctl` starts the local test platform, runs the app and connects the app to local.altinn.cloud.
+You need a container runtime, such as Docker or Podman, and the .NET SDK to run the app as a local process.
+Run `studioctl doctor` to check that your machine has the required tools.
 
 {{% notice info %}}
 **NOTE**
-To run the app in LocalTest, the application must have an associated [data model](/en/altinn-studio/v8/reference/data/data-modeling/).
+To run the app in LocalTest, the application must have an associated [data model](/en/altinn-studio/v10/develop-a-service/reference/data/data-modeling/).
 {{% /notice %}}
 
-1. **Download and start LocalTest** by following the steps [we describe on GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (includes starting the app, which we also explain below).
-2. **Run your application within LocalTest**: Open a new terminal window and go to the subfolder *App* in your application (`<app-name>/App`). Start the app with the command `dotnet run` and wait for confirmation in the terminal.
-3. **Preview and test application**: Go to [http://local.altinn.cloud](http://local.altinn.cloud) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
+1. **Start the local test platform**: Go to the app repository in a terminal and run `studioctl env up`.
+2. **Run your application within LocalTest**: Run `studioctl app run` from the app repository. The command detects the app directory and starts the app with the correct local settings.
+3. **Preview and test application**: Go to [http://local.altinn.cloud](http://local.altinn.cloud) and log in with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
+
+You can also open the browser when the test platform starts:
+
+```bash
+studioctl env up --open
+studioctl app run
+```
+
+Useful commands:
+
+| Command | Description |
+| ------- | ----------- |
+| `studioctl env status` | Shows local test platform status. |
+| `studioctl env logs` | Shows logs from the localtest containers. |
+| `studioctl app run --detach` | Runs the app in the background. |
+| `studioctl app logs` | Shows logs from an app running in the background. Use `--follow` for live logs. |
+| `studioctl app stop` | Stops apps started with `studioctl app run --detach`. |
+| `studioctl env down` | Stops the local test platform. |
+| `studioctl doctor` | Diagnoses missing tools and local environment issues. |
 
 ### Preview changes in real-time
 
 - If you change JSON files, simply reload the page.
 - If you change prefilling, you must start a new instance of the application (go to [http://local.altinn.cloud](http://local.altinn.cloud) and log in again).
-- If you change CS files, you must stop the application (`ctrl+C`) and start it again (`dotnet run`).
+- If you change CS files, you must stop the application (`ctrl+C`) and start it again (`studioctl app run`).
 
 You can update automatically when changing CS files by starting the application with `dotnet watch`.
 This command will either start the application or reload it ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) when changes are made to the source code.
@@ -124,4 +177,18 @@ This command will either start the application or reload it ([hot reload](https:
 ### Stop the application and LocalTest
 
 Stop the application by pressing `ctrl+C` in the terminal window where you started it.
+Stop LocalTest with `studioctl env down`.
+
+{{% expandlarge id="legacy-app-localtest" header="Old method: Run app-localtest manually" %}}
+
+The old workflow uses the `app-localtest` repository directly.
+This method can still be useful when troubleshooting an old setup, but the recommended local workflow is `studioctl`.
+
+1. **Download and start LocalTest** by following the steps [we describe on GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (includes starting the app, which we also explain below).
+2. **Run your application within LocalTest**: Open a new terminal window and go to the subfolder *App* in your application (`<app-name>/App`). Start the app with the command `dotnet run` and wait for confirmation in the terminal.
+3. **Preview and test application**: Go to [http://local.altinn.cloud](http://local.altinn.cloud) and log in with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
+
+Stop the application by pressing `ctrl+C` in the terminal window where you started it.
 Stop LocalTest by going to the `app-localtest` folder in the terminal and running the command `docker compose down`.
+
+{{% /expandlarge %}}

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
@@ -140,7 +140,7 @@ In Altinn Studio, you must synchronise changes in the same way as with local cha
 
 You can preview the changes you make when working locally.
 `studioctl` starts the local test platform, runs the app and connects the app to local.altinn.cloud.
-You need a container runtime, such as Docker or Podman, and the .NET SDK to run the app as a local process.
+You need a container runtime, such as Docker, Podman or Colima, and the .NET SDK to run the app as a local process.
 Run `studioctl doctor` to check that your machine has the required tools.
 
 {{% notice info %}}

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
@@ -15,40 +15,13 @@ Here is an overview of how to get started with local development.
 
 ## Clone the application to a local development environment
 
-`studioctl` is the recommended command-line tool for local development of Altinn Studio apps.
-It logs in to Altinn Studio, clones the app repository and configures Git authentication for you.
+{{% insert "content/altinn-studio/shared/studioctl/local-development-intro.en.md" %}}
 
-### Supported platforms
+{{% notice warning %}}
+{{% insert "content/altinn-studio/shared/studioctl/preview-warning.en.md" %}}
+{{% /notice %}}
 
-`studioctl` can be used on Windows, Linux and macOS.
-To run the local test platform, you need a container runtime.
-Use Docker, Podman or Colima.
-
-Install `studioctl`:
-
-```bash
-curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
-```
-
-On Windows, install from PowerShell:
-
-```powershell
-iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
-```
-
-Log in and clone the app:
-
-```bash
-studioctl auth login
-studioctl app clone <org>/<app-name>
-cd <app-name>
-```
-
-For automation and CI, pass an existing Studio/Designer API key through standard input from an environment variable:
-
-```bash
-printf '%s' "$STUDIO_DESIGNER_API_KEY" | studioctl auth login --with-token
-```
+{{% insert "content/altinn-studio/shared/studioctl/install-clone.en.md" %}}
 
 {{% expandlarge id="legacy-clone-with-git" header="Old method: Clone manually with Git" %}}
 
@@ -85,15 +58,15 @@ Now you can open your preferred development tool and start coding.
 
 {{% /expandlarge %}}
 
-## Synchronise changes in the local development environment
+## Synchronize changes in the local development environment
 
 You must upload (push) changes you make locally to the repository from which the code was cloned.
 If you make changes in Altinn Studio Designer (and upload these to the repository), you must download them (pull) to update the local code.
 
-You can synchronise changes in the local development environment in several ways.
+You can synchronize changes in the local development environment in several ways.
 Many development tools have good integrations for this purpose, so check whether your tool has that type of support.
 
-Below we describe how you can synchronise changes from the command line.
+Below we describe how you can synchronize changes from the command line.
 
 ### Upload changes
 
@@ -108,9 +81,9 @@ Go to your application repository in a terminal and run the command `git pull`.
 
 [Read more about `git pull` here](https://git-scm.com/docs/git-pull)
 
-## Synchronise changes in Altinn Studio
+## Synchronize changes in Altinn Studio
 
-In Altinn Studio, you must synchronise changes in the same way as with local changes.
+In Altinn Studio, you must synchronize changes in the same way as with local changes.
 
 ### Download changes
 1. Click **Hent endringer** (Fetch changes) on the 'Lage' page of the application in Altinn Studio.
@@ -128,7 +101,7 @@ In Altinn Studio, you must synchronise changes in the same way as with local cha
 2. Enter a descriptive message for the change(s) and click **Valider endringer** (Validate changes).
     ![Commit message](commit-message.png)
     *Replace this image.*
-3. Wait a moment whilst the system validates the changes. If a conflict occurs, click **Løs konflikt** (Resolve conflict) and follow the instructions.
+3. Wait a moment while the system validates the changes. If a conflict occurs, click **Løs konflikt** (Resolve conflict) and follow the instructions.
 4. Click **Lagre** (Save) to upload the changes to the repository (master).
     ![Save validated changes](changes-validated.png)
     *Replace this image.*
@@ -139,7 +112,7 @@ In Altinn Studio, you must synchronise changes in the same way as with local cha
 ## Local testing
 
 You can preview the changes you make when working locally.
-`studioctl` starts the local test platform, runs the app and connects the app to local.altinn.cloud.
+`studioctl` starts the local test platform, runs the app and connects the app to local.altinn.cloud on port `8000`.
 You need a container runtime, such as Docker, Podman or Colima, and the .NET SDK to run the app as a local process.
 Run `studioctl doctor` to check that your machine has the required tools.
 
@@ -149,14 +122,14 @@ To run the app in LocalTest, the application must have an associated [data model
 {{% /notice %}}
 
 1. **Start the local test platform**: Go to the app repository in a terminal and run `studioctl env up`.
-2. **Run your application within LocalTest**: Run `studioctl app run` from the app repository. The command detects the app directory and starts the app with the correct local settings.
-3. **Preview and test application**: Go to [http://local.altinn.cloud](http://local.altinn.cloud) and log in with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
+2. **Run your application within LocalTest**: Run `studioctl run` from the app repository. The command detects the app directory and starts the app with the correct local settings.
+3. **Preview and test application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
 
 You can also open the browser when the test platform starts:
 
 ```bash
 studioctl env up --open
-studioctl app run
+studioctl run
 ```
 
 Useful commands:
@@ -165,17 +138,17 @@ Useful commands:
 | ------- | ----------- |
 | `studioctl env status` | Shows local test platform status. |
 | `studioctl env logs` | Shows logs from the LocalTest containers. |
-| `studioctl app run --detach` | Runs the app in the background. |
+| `studioctl run --detach` | Runs the app in the background. |
 | `studioctl app logs` | Shows logs from an app running in the background. Use `--follow` for live logs. |
-| `studioctl app stop` | Stops apps started with `studioctl app run --detach`. |
+| `studioctl stop` | Stops apps started with `studioctl run --detach`. |
 | `studioctl env down` | Stops the local test platform. |
 | `studioctl doctor` | Diagnoses missing tools and local environment issues. |
 
 ### Preview changes in real-time
 
 - If you change JSON files, simply reload the page.
-- If you change prefilling, you must start a new instance of the application (go to [http://local.altinn.cloud](http://local.altinn.cloud) and log in again).
-- If you change C# files, you must stop the application (`ctrl+C`) and start it again (`studioctl app run`).
+- If you change prefilling, you must start a new instance of the application (go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in again).
+- If you change C# files, you must stop the application (`ctrl+C`) and start it again (`studioctl run`).
 
 You can update automatically when changing C# files by starting the application with `dotnet watch`.
 This command will either start the application or reload it ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) when changes are made to the source code.
@@ -192,7 +165,7 @@ This method can still be useful when troubleshooting an old setup, but the recom
 
 1. **Download and start LocalTest** by following the steps [we describe on GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (includes starting the app, which we also explain below).
 2. **Run your application within LocalTest**: Open a new terminal window and go to the subfolder *App* in your application (`<app-name>/App`). Start the app with the command `dotnet run` and wait for confirmation in the terminal.
-3. **Preview and test application**: Go to [http://local.altinn.cloud](http://local.altinn.cloud) and log in with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
+3. **Preview and test application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v10/test-a-service/testing/local/testusers/).
 
 Stop the application by pressing `ctrl+C` in the terminal window where you started it.
 Stop LocalTest by going to the `app-localtest` folder in the terminal and running the command `docker compose down`.

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.en.md
@@ -132,17 +132,7 @@ studioctl env up --open
 studioctl run
 ```
 
-Useful commands:
-
-| Command | Description |
-| ------- | ----------- |
-| `studioctl env status` | Shows local test platform status. |
-| `studioctl env logs` | Shows logs from the LocalTest containers. |
-| `studioctl run --detach` | Runs the app in the background. |
-| `studioctl app logs` | Shows logs from an app running in the background. Use `--follow` for live logs. |
-| `studioctl stop` | Stops apps started with `studioctl run --detach`. |
-| `studioctl env down` | Stops the local test platform. |
-| `studioctl doctor` | Diagnoses missing tools and local environment issues. |
+{{% insert "content/altinn-studio/shared/studioctl/useful-commands.en.md" %}}
 
 ### Preview changes in real-time
 

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
@@ -15,7 +15,7 @@ Her er en oversikt over hvordan du kommer i gang med lokal utvikling.
 
 ## Slik kloner du appen til et lokalt utviklingsmiljø
 
-`studioctl` er anbefalt kommandolinjeverktøy for lokal utvikling av Altinn Studio-apper.
+`studioctl` er et anbefalt kommandolinjeverktøy for lokal utvikling av Altinn Studio-apper.
 Verktøyet logger inn mot Altinn Studio, kloner app-repoet og setter opp Git-autentisering for deg.
 
 Installer `studioctl`:
@@ -158,7 +158,7 @@ Nyttige kommandoer:
 | Kommando | Beskrivelse |
 | -------- | ----------- |
 | `studioctl env status` | Viser status for lokal testplattform. |
-| `studioctl env logs` | Viser logger fra localtest-containerne. |
+| `studioctl env logs` | Viser logger fra LocalTest-containerne. |
 | `studioctl app run --detach` | Kjører appen i bakgrunnen. |
 | `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
 | `studioctl app stop` | Stopper apper som er startet med `studioctl app run --detach`. |
@@ -169,9 +169,9 @@ Nyttige kommandoer:
 
 - Hvis du endrer JSON-filer, holder det å laste inn siden på nytt.
 - Hvis du endrer forhåndsutfylling, må du starte en ny instans av appen (gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn igjen).
-- Hvis du endrer *cs*-filer, må du stoppe appen (`ctrl+C`) og starte den på nytt (`studioctl app run`).
+- Hvis du endrer C#-filer, må du stoppe appen (`ctrl+C`) og starte den på nytt (`studioctl app run`).
 
-Du kan oppdatere automatisk ved endring i *cs*-filer ved å starte appen med `dotnet watch`.
+Du kan oppdatere automatisk ved endring i C#-filer ved å starte appen med `dotnet watch`.
 Denne kommandoen vil enten starte appen eller laste den på nytt ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) ved endringer i kildekoden.
 
 ### Stoppe app og LocalTest

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
@@ -140,7 +140,7 @@ I Altinn Studio må du synkronisere endringer på samme vis som ved lokale endri
 
 Du kan forhåndsvise endringene du gjør når du jobber lokalt.
 `studioctl` starter den lokale testplattformen, kjører appen og kobler appen til local.altinn.cloud.
-Du trenger en container runtime, for eksempel Docker eller Podman, og .NET SDK for å kjøre appen som en lokal prosess.
+Du trenger en container runtime, for eksempel Docker, Podman eller Colima, og .NET SDK for å kjøre appen som en lokal prosess.
 Kjør `studioctl doctor` hvis du vil sjekke at maskinen har det som trengs.
 
 {{% notice info %}}

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
@@ -18,6 +18,12 @@ Her er en oversikt over hvordan du kommer i gang med lokal utvikling.
 `studioctl` er et anbefalt kommandolinjeverktøy for lokal utvikling av Altinn Studio-apper.
 Verktøyet logger inn mot Altinn Studio, kloner app-repoet og setter opp Git-autentisering for deg.
 
+### Støttede plattformer
+
+`studioctl` kan brukes på Windows, Linux og macOS.
+For å kjøre lokal testplattform trenger du en container runtime.
+Bruk Docker, Podman eller Colima.
+
 Installer `studioctl`:
 
 ```bash

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
@@ -15,6 +15,37 @@ Her er en oversikt over hvordan du kommer i gang med lokal utvikling.
 
 ## Slik kloner du appen til et lokalt utviklingsmiljø
 
+`studioctl` er anbefalt kommandolinjeverktøy for lokal utvikling av Altinn Studio-apper.
+Verktøyet logger inn mot Altinn Studio, kloner app-repoet og setter opp Git-autentisering for deg.
+
+Installer `studioctl`:
+
+```bash
+curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
+```
+
+På Windows kan du installere fra PowerShell:
+
+```powershell
+iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
+```
+
+Logg inn og klon appen:
+
+```bash
+studioctl auth login
+studioctl app clone <org>/<app-name>
+cd <app-name>
+```
+
+For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input:
+
+```bash
+studioctl auth login --with-token < token.txt
+```
+
+{{% expandlarge id="legacy-clone-with-git" header="Gammel metode: Klone manuelt med Git" %}}
+
 1. Finn appen du vil jobbe med lokalt i Dashboardet i Altinn Studio
 2. Åpne repositoriet. Klikk på **Repository**-knappen
     ![Repositoryknappen markert i et bilde](find-app-in-dashboard.png)
@@ -38,13 +69,15 @@ Her er en oversikt over hvordan du kommer i gang med lokal utvikling.
     remote: Enumerating objects: 982, done.
     remote: Counting objects: 100% (982/982), done.
     remote: Compressing objects: 100% (950/950), done.
-    remote: Total 982 (delta 600), reused 0 (delta 0), pack-reused 0 
+    remote: Total 982 (delta 600), reused 0 (delta 0), pack-reused 0
     Receiving objects: 100% (982/982), 166.38 KiB | 1.51 MiB/s, done.
     Resolving deltas: 100% (600/600), done.
     ```
 
 Systemet oppretter en mappe med samme navn som appen og kopierer innholdet i app-repoet inn i mappen.
 Nå kan du åpne ditt foretrukne utviklingsverktøy og komme i gang med utviklingen.
+
+{{% /expandlarge %}}
 
 ## Slik synkroniserer du endringer i lokalt utviklingsmiljø
 
@@ -100,23 +133,43 @@ I Altinn Studio må du synkronisere endringer på samme vis som ved lokale endri
 ## Lokal testing
 
 Du kan forhåndsvise endringene du gjør når du jobber lokalt.
-*LocalTest* er et program som starter en lokal kopi av Altinn-plattformen.
-Programmet gir deg mulighet til å teste og bekrefte lokale endringer uten å måtte synkronisere med Altinn Studio.
+`studioctl` starter den lokale testplattformen, kjører appen og kobler appen til local.altinn.cloud.
+Du trenger en container runtime, for eksempel Docker eller Podman, og .NET SDK for å kjøre appen som en lokal prosess.
+Kjør `studioctl doctor` hvis du vil sjekke at maskinen har det som trengs.
 
 {{% notice info %}}
 **MERK**
 For å kunne kjøre appen i LocalTest må appen ha en tilknyttet [datamodell](/nb/altinn-studio/v10/develop-a-service/reference/data/data-modeling/).
 {{% /notice %}}
 
-1. **Last ned og start LocalTest** ved å følge stegene [som vi beskriver på GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (inkluderer start av app som vi også forklarer under).
-2. **Kjør appen i LocalTest**: Åpne et nytt terminalvindu og gå til undermappen *App* i appen din (`<app-name>/App`). Start appen med kommandoen `dotnet run` og vent på bekreftelse i terminalen.
+1. **Start lokal testplattform**: Gå til app-repoet i terminalen og kjør `studioctl env up`.
+2. **Kjør appen i LocalTest**: Kjør `studioctl app run` fra app-repoet. Kommandoen finner appmappen automatisk og starter appen med riktige lokale innstillinger.
 3. **Forhåndsvis og test appen**: Gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn med en [testbruker](/nb/altinn-studio/v10/test-a-service/testing/local/testusers/).
+
+Du kan også åpne nettleseren direkte når testplattformen starter:
+
+```bash
+studioctl env up --open
+studioctl app run
+```
+
+Nyttige kommandoer:
+
+| Kommando | Beskrivelse |
+| -------- | ----------- |
+| `studioctl env status` | Viser status for lokal testplattform. |
+| `studioctl env logs` | Viser logger fra localtest-containerne. |
+| `studioctl app run --detach` | Kjører appen i bakgrunnen. |
+| `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
+| `studioctl app stop` | Stopper apper som er startet med `studioctl app run --detach`. |
+| `studioctl env down` | Stopper lokal testplattform. |
+| `studioctl doctor` | Diagnostiserer manglende verktøy og lokale miljøproblemer. |
 
 ### Se endringer fortløpende
 
 - Hvis du endrer JSON-filer, holder det å laste inn siden på nytt.
 - Hvis du endrer forhåndsutfylling, må du starte en ny instans av appen (gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn igjen).
-- Hvis du endrer *cs*-filer, må du stoppe appen (`ctrl+C`) og starte den på nytt (`dotnet run`).
+- Hvis du endrer *cs*-filer, må du stoppe appen (`ctrl+C`) og starte den på nytt (`studioctl app run`).
 
 Du kan oppdatere automatisk ved endring i *cs*-filer ved å starte appen med `dotnet watch`.
 Denne kommandoen vil enten starte appen eller laste den på nytt ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) ved endringer i kildekoden.
@@ -124,4 +177,18 @@ Denne kommandoen vil enten starte appen eller laste den på nytt ([hot reload](h
 ### Stoppe app og LocalTest
 
 Stopp appen ved å trykke `ctrl+C` i terminalvinduet der du startet den.
+Stopp LocalTest med `studioctl env down`.
+
+{{% expandlarge id="legacy-app-localtest" header="Gammel metode: Kjøre app-localtest manuelt" %}}
+
+Den gamle arbeidsflyten bruker `app-localtest`-repoet direkte.
+Denne metoden er fortsatt nyttig hvis du må feilsøke et gammelt oppsett, men den anbefalte lokale arbeidsflyten er `studioctl`.
+
+1. **Last ned og start LocalTest** ved å følge stegene [som vi beskriver på GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (inkluderer start av app som vi også forklarer under).
+2. **Kjør appen i LocalTest**: Åpne et nytt terminalvindu og gå til undermappen *App* i appen din (`<app-name>/App`). Start appen med kommandoen `dotnet run` og vent på bekreftelse i terminalen.
+3. **Forhåndsvis og test appen**: Gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn med en [testbruker](/nb/altinn-studio/v10/test-a-service/testing/local/testusers/).
+
+Stopp appen ved å trykke `ctrl+C` i terminalvinduet der du startet den.
 Stopp LocalTest ved å gå til mappen `app-localtest` i terminalen og kjøre kommandoen `docker compose down`.
+
+{{% /expandlarge %}}

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
@@ -132,17 +132,7 @@ studioctl env up --open
 studioctl run
 ```
 
-Nyttige kommandoer:
-
-| Kommando | Beskrivelse |
-| -------- | ----------- |
-| `studioctl env status` | Viser status for lokal testplattform. |
-| `studioctl env logs` | Viser logger fra LocalTest-containerne. |
-| `studioctl run --detach` | Kjører appen i bakgrunnen. |
-| `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
-| `studioctl stop` | Stopper apper som er startet med `studioctl run --detach`. |
-| `studioctl env down` | Stopper lokal testplattform. |
-| `studioctl doctor` | Diagnostiserer manglende verktøy og lokale miljøproblemer. |
+{{% insert "content/altinn-studio/shared/studioctl/useful-commands.nb.md" %}}
 
 ### Se endringer fortløpende
 

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
@@ -44,10 +44,10 @@ studioctl app clone <org>/<app-name>
 cd <app-name>
 ```
 
-For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input:
+For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input fra en miljøvariabel:
 
 ```bash
-studioctl auth login --with-token < token.txt
+printf '%s' "$STUDIO_DESIGNER_API_KEY" | studioctl auth login --with-token
 ```
 
 {{% expandlarge id="legacy-clone-with-git" header="Gammel metode: Klone manuelt med Git" %}}

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
@@ -15,40 +15,13 @@ Her er en oversikt over hvordan du kommer i gang med lokal utvikling.
 
 ## Slik kloner du appen til et lokalt utviklingsmiljø
 
-`studioctl` er et anbefalt kommandolinjeverktøy for lokal utvikling av Altinn Studio-apper.
-Verktøyet logger inn mot Altinn Studio, kloner app-repoet og setter opp Git-autentisering for deg.
+{{% insert "content/altinn-studio/shared/studioctl/local-development-intro.nb.md" %}}
 
-### Støttede plattformer
+{{% notice warning %}}
+{{% insert "content/altinn-studio/shared/studioctl/preview-warning.nb.md" %}}
+{{% /notice %}}
 
-`studioctl` kan brukes på Windows, Linux og macOS.
-For å kjøre lokal testplattform trenger du en container runtime.
-Bruk Docker, Podman eller Colima.
-
-Installer `studioctl`:
-
-```bash
-curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
-```
-
-På Windows kan du installere fra PowerShell:
-
-```powershell
-iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
-```
-
-Logg inn og klon appen:
-
-```bash
-studioctl auth login
-studioctl app clone <org>/<app-name>
-cd <app-name>
-```
-
-For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input fra en miljøvariabel:
-
-```bash
-printf '%s' "$STUDIO_DESIGNER_API_KEY" | studioctl auth login --with-token
-```
+{{% insert "content/altinn-studio/shared/studioctl/install-clone.nb.md" %}}
 
 {{% expandlarge id="legacy-clone-with-git" header="Gammel metode: Klone manuelt med Git" %}}
 
@@ -139,7 +112,7 @@ I Altinn Studio må du synkronisere endringer på samme vis som ved lokale endri
 ## Lokal testing
 
 Du kan forhåndsvise endringene du gjør når du jobber lokalt.
-`studioctl` starter den lokale testplattformen, kjører appen og kobler appen til local.altinn.cloud.
+`studioctl` starter den lokale testplattformen, kjører appen og kobler appen til local.altinn.cloud på port `8000`.
 Du trenger en container runtime, for eksempel Docker, Podman eller Colima, og .NET SDK for å kjøre appen som en lokal prosess.
 Kjør `studioctl doctor` hvis du vil sjekke at maskinen har det som trengs.
 
@@ -149,14 +122,14 @@ For å kunne kjøre appen i LocalTest må appen ha en tilknyttet [datamodell](/n
 {{% /notice %}}
 
 1. **Start lokal testplattform**: Gå til app-repoet i terminalen og kjør `studioctl env up`.
-2. **Kjør appen i LocalTest**: Kjør `studioctl app run` fra app-repoet. Kommandoen finner appmappen automatisk og starter appen med riktige lokale innstillinger.
-3. **Forhåndsvis og test appen**: Gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn med en [testbruker](/nb/altinn-studio/v10/test-a-service/testing/local/testusers/).
+2. **Kjør appen i LocalTest**: Kjør `studioctl run` fra app-repoet. Kommandoen finner appmappen automatisk og starter appen med riktige lokale innstillinger.
+3. **Forhåndsvis og test appen**: Gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn med en [testbruker](/nb/altinn-studio/v10/test-a-service/testing/local/testusers/).
 
 Du kan også åpne nettleseren direkte når testplattformen starter:
 
 ```bash
 studioctl env up --open
-studioctl app run
+studioctl run
 ```
 
 Nyttige kommandoer:
@@ -165,17 +138,17 @@ Nyttige kommandoer:
 | -------- | ----------- |
 | `studioctl env status` | Viser status for lokal testplattform. |
 | `studioctl env logs` | Viser logger fra LocalTest-containerne. |
-| `studioctl app run --detach` | Kjører appen i bakgrunnen. |
+| `studioctl run --detach` | Kjører appen i bakgrunnen. |
 | `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
-| `studioctl app stop` | Stopper apper som er startet med `studioctl app run --detach`. |
+| `studioctl stop` | Stopper apper som er startet med `studioctl run --detach`. |
 | `studioctl env down` | Stopper lokal testplattform. |
 | `studioctl doctor` | Diagnostiserer manglende verktøy og lokale miljøproblemer. |
 
 ### Se endringer fortløpende
 
 - Hvis du endrer JSON-filer, holder det å laste inn siden på nytt.
-- Hvis du endrer forhåndsutfylling, må du starte en ny instans av appen (gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn igjen).
-- Hvis du endrer C#-filer, må du stoppe appen (`ctrl+C`) og starte den på nytt (`studioctl app run`).
+- Hvis du endrer forhåndsutfylling, må du starte en ny instans av appen (gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn igjen).
+- Hvis du endrer C#-filer, må du stoppe appen (`ctrl+C`) og starte den på nytt (`studioctl run`).
 
 Du kan oppdatere automatisk ved endring i C#-filer ved å starte appen med `dotnet watch`.
 Denne kommandoen vil enten starte appen eller laste den på nytt ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) ved endringer i kildekoden.
@@ -192,7 +165,7 @@ Denne metoden er fortsatt nyttig hvis du må feilsøke et gammelt oppsett, men d
 
 1. **Last ned og start LocalTest** ved å følge stegene [som vi beskriver på GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (inkluderer start av app som vi også forklarer under).
 2. **Kjør appen i LocalTest**: Åpne et nytt terminalvindu og gå til undermappen *App* i appen din (`<app-name>/App`). Start appen med kommandoen `dotnet run` og vent på bekreftelse i terminalen.
-3. **Forhåndsvis og test appen**: Gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn med en [testbruker](/nb/altinn-studio/v10/test-a-service/testing/local/testusers/).
+3. **Forhåndsvis og test appen**: Gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn med en [testbruker](/nb/altinn-studio/v10/test-a-service/testing/local/testusers/).
 
 Stopp appen ved å trykke `ctrl+C` i terminalvinduet der du startet den.
 Stopp LocalTest ved å gå til mappen `app-localtest` i terminalen og kjøre kommandoen `docker compose down`.

--- a/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
+++ b/content/altinn-studio/v10/getting-started/development/test/local-dev/_index.nb.md
@@ -111,27 +111,7 @@ I Altinn Studio må du synkronisere endringer på samme vis som ved lokale endri
 
 ## Lokal testing
 
-Du kan forhåndsvise endringene du gjør når du jobber lokalt.
-`studioctl` starter den lokale testplattformen, kjører appen og kobler appen til local.altinn.cloud på port `8000`.
-Du trenger en container runtime, for eksempel Docker, Podman eller Colima, og .NET SDK for å kjøre appen som en lokal prosess.
-Kjør `studioctl doctor` hvis du vil sjekke at maskinen har det som trengs.
-
-{{% notice info %}}
-**MERK**
-For å kunne kjøre appen i LocalTest må appen ha en tilknyttet [datamodell](/nb/altinn-studio/v10/develop-a-service/reference/data/data-modeling/).
-{{% /notice %}}
-
-1. **Start lokal testplattform**: Gå til app-repoet i terminalen og kjør `studioctl env up`.
-2. **Kjør appen i LocalTest**: Kjør `studioctl run` fra app-repoet. Kommandoen finner appmappen automatisk og starter appen med riktige lokale innstillinger.
-3. **Forhåndsvis og test appen**: Gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn med en [testbruker](/nb/altinn-studio/v10/test-a-service/testing/local/testusers/).
-
-Du kan også åpne nettleseren direkte når testplattformen starter:
-
-```bash
-studioctl env up --open
-studioctl run
-```
-
+{{% insert "content/altinn-studio/shared/studioctl/local-test-workflow.nb.md" "/nb/altinn-studio/v10/develop-a-service/reference/data/data-modeling/" "/nb/altinn-studio/v10/test-a-service/testing/local/testusers/" %}}
 {{% insert "content/altinn-studio/shared/studioctl/useful-commands.nb.md" %}}
 
 ### Se endringer fortløpende
@@ -143,21 +123,10 @@ studioctl run
 Du kan oppdatere automatisk ved endring i C#-filer ved å starte appen med `dotnet watch`.
 Denne kommandoen vil enten starte appen eller laste den på nytt ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) ved endringer i kildekoden.
 
-### Stoppe app og LocalTest
-
-Stopp appen ved å trykke `ctrl+C` i terminalvinduet der du startet den.
-Stopp LocalTest med `studioctl env down`.
+{{% insert "content/altinn-studio/shared/studioctl/stop-local-test.nb.md" %}}
 
 {{% expandlarge id="legacy-app-localtest" header="Gammel metode: Kjøre app-localtest manuelt" %}}
 
-Den gamle arbeidsflyten bruker `app-localtest`-repoet direkte.
-Denne metoden er fortsatt nyttig hvis du må feilsøke et gammelt oppsett, men den anbefalte lokale arbeidsflyten er `studioctl`.
-
-1. **Last ned og start LocalTest** ved å følge stegene [som vi beskriver på GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (inkluderer start av app som vi også forklarer under).
-2. **Kjør appen i LocalTest**: Åpne et nytt terminalvindu og gå til undermappen *App* i appen din (`<app-name>/App`). Start appen med kommandoen `dotnet run` og vent på bekreftelse i terminalen.
-3. **Forhåndsvis og test appen**: Gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn med en [testbruker](/nb/altinn-studio/v10/test-a-service/testing/local/testusers/).
-
-Stopp appen ved å trykke `ctrl+C` i terminalvinduet der du startet den.
-Stopp LocalTest ved å gå til mappen `app-localtest` i terminalen og kjøre kommandoen `docker compose down`.
+{{% insert "content/altinn-studio/shared/studioctl/legacy-app-localtest.nb.md" "/nb/altinn-studio/v10/test-a-service/testing/local/testusers/" %}}
 
 {{% /expandlarge %}}

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
@@ -16,6 +16,12 @@ During application development, you will need to work both in Altinn Studio and 
 `studioctl` is the recommended command-line tool for local development of Altinn Studio apps.
 It logs in to Altinn Studio, clones the app repository and configures Git authentication for you.
 
+### Supported platforms
+
+`studioctl` can be used on Windows, Linux and macOS.
+To run the local test platform, you need a container runtime.
+Use Docker, Podman or Colima.
+
 Install `studioctl`:
 
 ```bash

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
@@ -151,7 +151,7 @@ Useful commands:
 | Command | Description |
 | ------- | ----------- |
 | `studioctl env status` | Shows local test platform status. |
-| `studioctl env logs` | Shows logs from the localtest containers. |
+| `studioctl env logs` | Shows logs from the LocalTest containers. |
 | `studioctl app run --detach` | Runs the app in the background. |
 | `studioctl app logs` | Shows logs from an app running in the background. Use `--follow` for live logs. |
 | `studioctl app stop` | Stops apps started with `studioctl app run --detach`. |
@@ -162,9 +162,9 @@ Useful commands:
 
 - For changes related to JSON files, simply reload the page.
 - For changes in prefilling, the application must be instantiated again (go to [http://local.altinn.cloud](http://local.altinn.cloud) and log back in).
-- For changes in CS files, the application must be stopped (`ctrl+C`) and restarted (`studioctl app run`).
+- For changes in C# files, the application must be stopped (`ctrl+C`) and restarted (`studioctl app run`).
 
-To automatically update when there are changes in CS files, start the application with `dotnet watch`. This command will either start the application or reload it ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) when changes are made to the source code.
+To automatically update when there are changes in C# files, start the application with `dotnet watch`. This command will either start the application or reload it ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) when changes are made to the source code.
 
 ### Stopping the application and LocalTest
 

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
@@ -13,6 +13,37 @@ During application development, you will need to work both in Altinn Studio and 
 
 ## How to clone the application to a local development environment
 
+`studioctl` is the recommended command-line tool for local development of Altinn Studio apps.
+It logs in to Altinn Studio, clones the app repository and configures Git authentication for you.
+
+Install `studioctl`:
+
+```bash
+curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
+```
+
+On Windows, install from PowerShell:
+
+```powershell
+iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
+```
+
+Log in and clone the app:
+
+```bash
+studioctl auth login
+studioctl app clone <org>/<app-name>
+cd <app-name>
+```
+
+For automation and CI, pass an existing Studio/Designer API key through standard input:
+
+```bash
+studioctl auth login --with-token < token.txt
+```
+
+{{% expandlarge id="legacy-clone-with-git" header="Old method: Clone manually with Git" %}}
+
 1. Find the application you want to work with locally in the [Dashboard](/en/altinn-studio/v8/getting-started/navigation/dashboard/) in Altinn Studio.
 2. Navigate to the repository by clicking the _Repository_ button.
     ![Repository button highlighted in an image](find-app-in-dashboard.png)
@@ -36,13 +67,15 @@ During application development, you will need to work both in Altinn Studio and 
     remote: Enumerating objects: 982, done.
     remote: Counting objects: 100% (982/982), done.
     remote: Compressing objects: 100% (950/950), done.
-    remote: Total 982 (delta 600), reused 0 (delta 0), pack-reused 0 
+    remote: Total 982 (delta 600), reused 0 (delta 0), pack-reused 0
     Receiving objects: 100% (982/982), 166.38 KiB | 1.51 MiB/s, done.
     Resolving deltas: 100% (600/600), done.
     ```
 
 A folder with the same name as the application has been created, and the contents of the application repository have been cloned into the folder.
- Now you can open your preferred development tool and start coding.
+Now you can open your preferred development tool and start coding.
+
+{{% /expandlarge %}}
 
 ## How to synchronize changes in the local development environment
 
@@ -92,25 +125,62 @@ If you're using Altinn Studio for development, changes need to be synchronized w
 
 ## Local testing
 
-When working locally, it can be useful to preview the changes you make. *LocalTest* is a program that spins up a local mock-up of the Altinn Platform. This allows you to test and verify local changes without having to synchronize with Altinn Studio.
+When working locally, it can be useful to preview the changes you make.
+`studioctl` starts the local test platform, runs the app and connects the app to local.altinn.cloud.
+You need a container runtime, such as Docker or Podman, and the .NET SDK to run the app as a local process.
+Run `studioctl doctor` to check that your machine has the required tools.
 
 {{% notice info %}}
 **NOTE**
 To run the app in LocalTest, the application must have an associated [data model](/en/altinn-studio/v8/reference/data/data-modeling/).
 {{% /notice %}}
 
-1. **Download and start LocalTest** by following the steps [described on GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (includes starting the app, which is also explained below).
-2. **Run your application within LocalTest**: Open a new terminal window and navigate to the subfolder *App* in your application (`<app-name>/App`). Start the app with the command `dotnet run` and wait for confirmation in the terminal.
+1. **Start the local test platform**: Go to the app repository in a terminal and run `studioctl env up`.
+2. **Run your application within LocalTest**: Run `studioctl app run` from the app repository. The command detects the app directory and starts the app with the correct local settings.
 3. **Preview and test application**: Go to [http://local.altinn.cloud](http://local.altinn.cloud) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
+
+You can also open the browser when the test platform starts:
+
+```bash
+studioctl env up --open
+studioctl app run
+```
+
+Useful commands:
+
+| Command | Description |
+| ------- | ----------- |
+| `studioctl env status` | Shows local test platform status. |
+| `studioctl env logs` | Shows logs from the localtest containers. |
+| `studioctl app run --detach` | Runs the app in the background. |
+| `studioctl app logs` | Shows logs from an app running in the background. Use `--follow` for live logs. |
+| `studioctl app stop` | Stops apps started with `studioctl app run --detach`. |
+| `studioctl env down` | Stops the local test platform. |
+| `studioctl doctor` | Diagnoses missing tools and local environment issues. |
 
 ### Preview changes in real-time
 
 - For changes related to JSON files, simply reload the page.
 - For changes in prefilling, the application must be instantiated again (go to [http://local.altinn.cloud](http://local.altinn.cloud) and log back in).
-- For changes in CS files, the application must be stopped (`ctrl+C`) and restarted (`dotnet run`).
+- For changes in CS files, the application must be stopped (`ctrl+C`) and restarted (`studioctl app run`).
 
 To automatically update when there are changes in CS files, start the application with `dotnet watch`. This command will either start the application or reload it ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) when changes are made to the source code.
 
 ### Stopping the application and LocalTest
 
-To stop the application, press `ctrl+C` in the terminal window where you started it. To stop LocalTest, navigate to the `app-localtest` folder in the terminal and run the command `docker compose down`.
+To stop the application, press `ctrl+C` in the terminal window where you started it.
+Stop LocalTest with `studioctl env down`.
+
+{{% expandlarge id="legacy-app-localtest" header="Old method: Run app-localtest manually" %}}
+
+The old workflow uses the `app-localtest` repository directly.
+This method can still be useful when troubleshooting an old setup, but the recommended local workflow is `studioctl`.
+
+1. **Download and start LocalTest** by following the steps [described on GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (includes starting the app, which is also explained below).
+2. **Run your application within LocalTest**: Open a new terminal window and navigate to the subfolder *App* in your application (`<app-name>/App`). Start the app with the command `dotnet run` and wait for confirmation in the terminal.
+3. **Preview and test application**: Go to [http://local.altinn.cloud](http://local.altinn.cloud) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
+
+To stop the application, press `ctrl+C` in the terminal window where you started it.
+To stop LocalTest, navigate to the `app-localtest` folder in the terminal and run the command `docker compose down`.
+
+{{% /expandlarge %}}

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
@@ -13,40 +13,13 @@ During application development, you will need to work both in Altinn Studio and 
 
 ## How to clone the application to a local development environment
 
-`studioctl` is the recommended command-line tool for local development of Altinn Studio apps.
-It logs in to Altinn Studio, clones the app repository and configures Git authentication for you.
+{{% insert "content/altinn-studio/shared/studioctl/local-development-intro.en.md" %}}
 
-### Supported platforms
+{{% notice warning %}}
+{{% insert "content/altinn-studio/shared/studioctl/preview-warning.en.md" %}}
+{{% /notice %}}
 
-`studioctl` can be used on Windows, Linux and macOS.
-To run the local test platform, you need a container runtime.
-Use Docker, Podman or Colima.
-
-Install `studioctl`:
-
-```bash
-curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
-```
-
-On Windows, install from PowerShell:
-
-```powershell
-iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
-```
-
-Log in and clone the app:
-
-```bash
-studioctl auth login
-studioctl app clone <org>/<app-name>
-cd <app-name>
-```
-
-For automation and CI, pass an existing Studio/Designer API key through standard input from an environment variable:
-
-```bash
-printf '%s' "$STUDIO_DESIGNER_API_KEY" | studioctl auth login --with-token
-```
+{{% insert "content/altinn-studio/shared/studioctl/install-clone.en.md" %}}
 
 {{% expandlarge id="legacy-clone-with-git" header="Old method: Clone manually with Git" %}}
 
@@ -83,15 +56,15 @@ Now you can open your preferred development tool and start coding.
 
 {{% /expandlarge %}}
 
-## How to synchronise changes in the local development environment
+## How to synchronize changes in the local development environment
 
 Changes made locally need to be uploaded (pushed) to the repository from which the code was cloned.
  If changes are made in Altinn Studio Designer (and uploaded to the repository), these must be downloaded (pulled) to update the local code.
 
-Synchronising changes made in the local development environment can be done in several ways.
+Synchronizing changes made in the local development environment can be done in several ways.
  Many development tools have good integrations for this purpose, so check if your tool has that type of support.
 
-Below is a description of how you can synchronise changes from the command line.
+Below is a description of how you can synchronize changes from the command line.
 
 ### Uploading changes
 
@@ -107,9 +80,9 @@ Navigate to your application repository in a terminal and run the command `git p
 
 [Read more about `git pull` here](https://git-scm.com/docs/git-pull)
 
-## How to synchronise changes in Altinn Studio
+## How to synchronize changes in Altinn Studio
 
-If you're using Altinn Studio for development, changes need to be synchronised with the Altinn Repository.
+If you're using Altinn Studio for development, changes need to be synchronized with the Altinn Repository.
 
 ### Downloading changes
 1. Click on _Hent endringer_ (_Fetch changes_) on the 'Lage' page of the application in Altinn Studio.
@@ -132,7 +105,7 @@ If you're using Altinn Studio for development, changes need to be synchronised w
 ## Local testing
 
 When working locally, it can be useful to preview the changes you make.
-`studioctl` starts the local test platform, runs the app and connects the app to local.altinn.cloud.
+`studioctl` starts the local test platform, runs the app and connects the app to local.altinn.cloud on port `8000`.
 You need a container runtime, such as Docker, Podman or Colima, and the .NET SDK to run the app as a local process.
 Run `studioctl doctor` to check that your machine has the required tools.
 
@@ -142,14 +115,14 @@ To run the app in LocalTest, the application must have an associated [data model
 {{% /notice %}}
 
 1. **Start the local test platform**: Go to the app repository in a terminal and run `studioctl env up`.
-2. **Run your application within LocalTest**: Run `studioctl app run` from the app repository. The command detects the app directory and starts the app with the correct local settings.
-3. **Preview and test application**: Go to [http://local.altinn.cloud](http://local.altinn.cloud) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
+2. **Run your application within LocalTest**: Run `studioctl run` from the app repository. The command detects the app directory and starts the app with the correct local settings.
+3. **Preview and test application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
 
 You can also open the browser when the test platform starts:
 
 ```bash
 studioctl env up --open
-studioctl app run
+studioctl run
 ```
 
 Useful commands:
@@ -158,17 +131,17 @@ Useful commands:
 | ------- | ----------- |
 | `studioctl env status` | Shows local test platform status. |
 | `studioctl env logs` | Shows logs from the LocalTest containers. |
-| `studioctl app run --detach` | Runs the app in the background. |
+| `studioctl run --detach` | Runs the app in the background. |
 | `studioctl app logs` | Shows logs from an app running in the background. Use `--follow` for live logs. |
-| `studioctl app stop` | Stops apps started with `studioctl app run --detach`. |
+| `studioctl stop` | Stops apps started with `studioctl run --detach`. |
 | `studioctl env down` | Stops the local test platform. |
 | `studioctl doctor` | Diagnoses missing tools and local environment issues. |
 
 ### Preview changes in real-time
 
 - For changes related to JSON files, simply reload the page.
-- For changes in prefilling, the application must be instantiated again (go to [http://local.altinn.cloud](http://local.altinn.cloud) and log back in).
-- For changes in C# files, the application must be stopped (`ctrl+C`) and restarted (`studioctl app run`).
+- For changes in prefilling, the application must be instantiated again (go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log back in).
+- For changes in C# files, the application must be stopped (`ctrl+C`) and restarted (`studioctl run`).
 
 To automatically update when there are changes in C# files, start the application with `dotnet watch`. This command will either start the application or reload it ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) when changes are made to the source code.
 
@@ -184,7 +157,7 @@ This method can still be useful when troubleshooting an old setup, but the recom
 
 1. **Download and start LocalTest** by following the steps [described on GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (includes starting the app, which is also explained below).
 2. **Run your application within LocalTest**: Open a new terminal window and navigate to the subfolder *App* in your application (`<app-name>/App`). Start the app with the command `dotnet run` and wait for confirmation in the terminal.
-3. **Preview and test application**: Go to [http://local.altinn.cloud](http://local.altinn.cloud) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
+3. **Preview and test application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
 
 To stop the application, press `ctrl+C` in the terminal window where you started it.
 To stop LocalTest, navigate to the `app-localtest` folder in the terminal and run the command `docker compose down`.

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
@@ -42,10 +42,10 @@ studioctl app clone <org>/<app-name>
 cd <app-name>
 ```
 
-For automation and CI, pass an existing Studio/Designer API key through standard input:
+For automation and CI, pass an existing Studio/Designer API key through standard input from an environment variable:
 
 ```bash
-studioctl auth login --with-token < token.txt
+printf '%s' "$STUDIO_DESIGNER_API_KEY" | studioctl auth login --with-token
 ```
 
 {{% expandlarge id="legacy-clone-with-git" header="Old method: Clone manually with Git" %}}

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
@@ -104,27 +104,7 @@ If you're using Altinn Studio for development, changes need to be synchronized w
 
 ## Local testing
 
-When working locally, it can be useful to preview the changes you make.
-`studioctl` starts the local test platform, runs the app and connects the app to local.altinn.cloud on port `8000`.
-You need a container runtime, such as Docker, Podman or Colima, and the .NET SDK to run the app as a local process.
-Run `studioctl doctor` to check that your machine has the required tools.
-
-{{% notice info %}}
-**NOTE**
-To run the app in LocalTest, the application must have an associated [data model](/en/altinn-studio/v8/reference/data/data-modeling/).
-{{% /notice %}}
-
-1. **Start the local test platform**: Go to the app repository in a terminal and run `studioctl env up`.
-2. **Run your application within LocalTest**: Run `studioctl run` from the app repository. The command detects the app directory and starts the app with the correct local settings.
-3. **Preview and test the application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
-
-You can also open the browser when the test platform starts:
-
-```bash
-studioctl env up --open
-studioctl run
-```
-
+{{% insert "content/altinn-studio/shared/studioctl/local-test-workflow.en.md" "/en/altinn-studio/v8/reference/data/data-modeling/" "/en/altinn-studio/v8/reference/testing/local/testusers/" %}}
 {{% insert "content/altinn-studio/shared/studioctl/useful-commands.en.md" %}}
 
 ### Preview changes in real-time
@@ -135,21 +115,10 @@ studioctl run
 
 To automatically update when there are changes in C# files, start the application with `dotnet watch`. This command will either start the application or reload it ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) when changes are made to the source code.
 
-### Stopping the application and LocalTest
-
-To stop the application, press `ctrl+C` in the terminal window where you started it.
-Stop LocalTest with `studioctl env down`.
+{{% insert "content/altinn-studio/shared/studioctl/stop-local-test.en.md" %}}
 
 {{% expandlarge id="legacy-app-localtest" header="Old method: Run app-localtest manually" %}}
 
-The old workflow uses the `app-localtest` repository directly.
-This method can still be useful when troubleshooting an old setup, but the recommended local workflow is `studioctl`.
-
-1. **Download and start LocalTest** by following the steps [described on GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (includes starting the app, which is also explained below).
-2. **Run your application within LocalTest**: Open a new terminal window and navigate to the subfolder *App* in your application (`<app-name>/App`). Start the app with the command `dotnet run` and wait for confirmation in the terminal.
-3. **Preview and test the application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
-
-To stop the application, press `ctrl+C` in the terminal window where you started it.
-To stop LocalTest, navigate to the `app-localtest` folder in the terminal and run the command `docker compose down`.
+{{% insert "content/altinn-studio/shared/studioctl/legacy-app-localtest.en.md" "/en/altinn-studio/v8/reference/testing/local/testusers/" %}}
 
 {{% /expandlarge %}}

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
@@ -125,17 +125,7 @@ studioctl env up --open
 studioctl run
 ```
 
-Useful commands:
-
-| Command | Description |
-| ------- | ----------- |
-| `studioctl env status` | Shows local test platform status. |
-| `studioctl env logs` | Shows logs from the LocalTest containers. |
-| `studioctl run --detach` | Runs the app in the background. |
-| `studioctl app logs` | Shows logs from an app running in the background. Use `--follow` for live logs. |
-| `studioctl stop` | Stops apps started with `studioctl run --detach`. |
-| `studioctl env down` | Stops the local test platform. |
-| `studioctl doctor` | Diagnoses missing tools and local environment issues. |
+{{% insert "content/altinn-studio/shared/studioctl/useful-commands.en.md" %}}
 
 ### Preview changes in real-time
 

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
@@ -116,7 +116,7 @@ To run the app in LocalTest, the application must have an associated [data model
 
 1. **Start the local test platform**: Go to the app repository in a terminal and run `studioctl env up`.
 2. **Run your application within LocalTest**: Run `studioctl run` from the app repository. The command detects the app directory and starts the app with the correct local settings.
-3. **Preview and test application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
+3. **Preview and test the application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
 
 You can also open the browser when the test platform starts:
 
@@ -157,7 +157,7 @@ This method can still be useful when troubleshooting an old setup, but the recom
 
 1. **Download and start LocalTest** by following the steps [described on GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (includes starting the app, which is also explained below).
 2. **Run your application within LocalTest**: Open a new terminal window and navigate to the subfolder *App* in your application (`<app-name>/App`). Start the app with the command `dotnet run` and wait for confirmation in the terminal.
-3. **Preview and test application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
+3. **Preview and test the application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user](/en/altinn-studio/v8/reference/testing/local/testusers/).
 
 To stop the application, press `ctrl+C` in the terminal window where you started it.
 To stop LocalTest, navigate to the `app-localtest` folder in the terminal and run the command `docker compose down`.

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.en.md
@@ -83,15 +83,15 @@ Now you can open your preferred development tool and start coding.
 
 {{% /expandlarge %}}
 
-## How to synchronize changes in the local development environment
+## How to synchronise changes in the local development environment
 
 Changes made locally need to be uploaded (pushed) to the repository from which the code was cloned.
  If changes are made in Altinn Studio Designer (and uploaded to the repository), these must be downloaded (pulled) to update the local code.
 
-Synchronizing changes made in the local development environment can be done in several ways.
+Synchronising changes made in the local development environment can be done in several ways.
  Many development tools have good integrations for this purpose, so check if your tool has that type of support.
 
-Below is a description of how you can synchronize changes from the command line.
+Below is a description of how you can synchronise changes from the command line.
 
 ### Uploading changes
 
@@ -107,9 +107,9 @@ Navigate to your application repository in a terminal and run the command `git p
 
 [Read more about `git pull` here](https://git-scm.com/docs/git-pull)
 
-## How to synchronize changes in Altinn Studio
+## How to synchronise changes in Altinn Studio
 
-If you're using Altinn Studio for development, changes need to be synchronized with the Altinn Repository.
+If you're using Altinn Studio for development, changes need to be synchronised with the Altinn Repository.
 
 ### Downloading changes
 1. Click on _Hent endringer_ (_Fetch changes_) on the 'Lage' page of the application in Altinn Studio.
@@ -133,7 +133,7 @@ If you're using Altinn Studio for development, changes need to be synchronized w
 
 When working locally, it can be useful to preview the changes you make.
 `studioctl` starts the local test platform, runs the app and connects the app to local.altinn.cloud.
-You need a container runtime, such as Docker or Podman, and the .NET SDK to run the app as a local process.
+You need a container runtime, such as Docker, Podman or Colima, and the .NET SDK to run the app as a local process.
 Run `studioctl doctor` to check that your machine has the required tools.
 
 {{% notice info %}}

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
@@ -17,6 +17,12 @@ Her er en oversikt over hvordan du kommer i gang med lokal utvikling.
 `studioctl` er et anbefalt kommandolinjeverktøy for lokal utvikling av Altinn Studio-apper.
 Verktøyet logger inn mot Altinn Studio, kloner app-repoet og setter opp Git-autentisering for deg.
 
+### Støttede plattformer
+
+`studioctl` kan brukes på Windows, Linux og macOS.
+For å kjøre lokal testplattform trenger du en container runtime.
+Bruk Docker, Podman eller Colima.
+
 Installer `studioctl`:
 
 ```bash

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
@@ -108,27 +108,7 @@ I Altinn Studio må endringer synkroniseres på samme vis som ved lokale endring
 
 ## Lokal testing
 
-Når du jobber lokalt kan det være nyttig med forhåndsvisning av endringene du gjør.
-`studioctl` starter den lokale testplattformen, kjører appen og kobler appen til local.altinn.cloud på port `8000`.
-Du trenger en container runtime, for eksempel Docker, Podman eller Colima, og .NET SDK for å kjøre appen som en lokal prosess.
-Kjør `studioctl doctor` hvis du vil sjekke at maskinen har det som trengs.
-
-{{% notice info %}}
-**MERK**
-For å kunne kjøre appen i LocalTest må applikasjonen ha en tilknyttet [datamodell](/nb/altinn-studio/v8/reference/data/data-modeling/).
-{{% /notice %}}
-
-1. **Start lokal testplattform**: Gå til app-repoet i terminalen og kjør `studioctl env up`.
-2. **Kjør applikasjonen i LocalTest**: Kjør `studioctl run` fra app-repoet. Kommandoen finner appmappen automatisk og starter appen med riktige lokale innstillinger.
-3. **Forhåndsvis og test applikasjonen**: Gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn med en [testbruker](/nb/altinn-studio/v8/reference/testing/local/testusers/).
-
-Du kan også åpne nettleseren direkte når testplattformen starter:
-
-```bash
-studioctl env up --open
-studioctl run
-```
-
+{{% insert "content/altinn-studio/shared/studioctl/local-test-workflow.nb.md" "/nb/altinn-studio/v8/reference/data/data-modeling/" "/nb/altinn-studio/v8/reference/testing/local/testusers/" %}}
 {{% insert "content/altinn-studio/shared/studioctl/useful-commands.nb.md" %}}
 
 ### Se endringer fortløpende
@@ -140,21 +120,10 @@ studioctl run
 For å oppdatere automatisk ved endring i C#-filer, start applikasjonen med `dotnet watch`.
 Denne kommandoen vil enten starte applikasjonen eller laste den inn på nytt ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) ved endringer i kildekoden.
 
-### Stoppe applikasjon og LocalTest
-
-Applikasjonen stoppes ved å trykke `ctrl+C` i terminalvinduet der du startet den.
-LocalTest stoppes med `studioctl env down`.
+{{% insert "content/altinn-studio/shared/studioctl/stop-local-test.nb.md" %}}
 
 {{% expandlarge id="legacy-app-localtest" header="Gammel metode: Kjøre app-localtest manuelt" %}}
 
-Den gamle arbeidsflyten bruker `app-localtest`-repoet direkte.
-Denne metoden er fortsatt nyttig hvis du må feilsøke et gammelt oppsett, men den anbefalte lokale arbeidsflyten er `studioctl`.
-
-1. **Last ned og start LocalTest** ved å følge stegene [beskrevet på GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (inkluderer start av app som også er forklart under).
-2. **Kjør applikasjonen i LocalTest**: Åpne et nytt terminalvindu og naviger til undermappen *App* i din applikasjon (`<app-name>/App`). Start appen med kommandoen `dotnet run` og vent på bekreftelse i terminalen.
-3. **Forhåndsvis og test applikasjonen**: Gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn med en [testbruker](/nb/altinn-studio/v8/reference/testing/local/testusers/).
-
-Applikasjonen stoppes ved å trykke `ctrl+C` i terminalvinduet der du startet den.
-LocalTest stoppes ved å navigere til mappen `app-localtest` i terminalen og kjøre kommandoen `docker compose down`.
+{{% insert "content/altinn-studio/shared/studioctl/legacy-app-localtest.nb.md" "/nb/altinn-studio/v8/reference/testing/local/testusers/" %}}
 
 {{% /expandlarge %}}

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
@@ -129,17 +129,7 @@ studioctl env up --open
 studioctl run
 ```
 
-Nyttige kommandoer:
-
-| Kommando | Beskrivelse |
-| -------- | ----------- |
-| `studioctl env status` | Viser status for lokal testplattform. |
-| `studioctl env logs` | Viser logger fra LocalTest-containerne. |
-| `studioctl run --detach` | Kjører appen i bakgrunnen. |
-| `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
-| `studioctl stop` | Stopper apper som er startet med `studioctl run --detach`. |
-| `studioctl env down` | Stopper lokal testplattform. |
-| `studioctl doctor` | Diagnostiserer manglende verktøy og lokale miljøproblemer. |
+{{% insert "content/altinn-studio/shared/studioctl/useful-commands.nb.md" %}}
 
 ### Se endringer fortløpende
 

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
@@ -43,10 +43,10 @@ studioctl app clone <org>/<app-name>
 cd <app-name>
 ```
 
-For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input:
+For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input fra en miljøvariabel:
 
 ```bash
-studioctl auth login --with-token < token.txt
+printf '%s' "$STUDIO_DESIGNER_API_KEY" | studioctl auth login --with-token
 ```
 
 {{% expandlarge id="legacy-clone-with-git" header="Gammel metode: Klone manuelt med Git" %}}

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
@@ -14,40 +14,13 @@ Her er en oversikt over hvordan du kommer i gang med lokal utvikling.
 
 ## Hvordan klone applikasjonen til et lokalt utviklingsmiljø
 
-`studioctl` er et anbefalt kommandolinjeverktøy for lokal utvikling av Altinn Studio-apper.
-Verktøyet logger inn mot Altinn Studio, kloner app-repoet og setter opp Git-autentisering for deg.
+{{% insert "content/altinn-studio/shared/studioctl/local-development-intro.nb.md" %}}
 
-### Støttede plattformer
+{{% notice warning %}}
+{{% insert "content/altinn-studio/shared/studioctl/preview-warning.nb.md" %}}
+{{% /notice %}}
 
-`studioctl` kan brukes på Windows, Linux og macOS.
-For å kjøre lokal testplattform trenger du en container runtime.
-Bruk Docker, Podman eller Colima.
-
-Installer `studioctl`:
-
-```bash
-curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
-```
-
-På Windows kan du installere fra PowerShell:
-
-```powershell
-iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
-```
-
-Logg inn og klon appen:
-
-```bash
-studioctl auth login
-studioctl app clone <org>/<app-name>
-cd <app-name>
-```
-
-For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input fra en miljøvariabel:
-
-```bash
-printf '%s' "$STUDIO_DESIGNER_API_KEY" | studioctl auth login --with-token
-```
+{{% insert "content/altinn-studio/shared/studioctl/install-clone.nb.md" %}}
 
 {{% expandlarge id="legacy-clone-with-git" header="Gammel metode: Klone manuelt med Git" %}}
 
@@ -136,7 +109,7 @@ I Altinn Studio må endringer synkroniseres på samme vis som ved lokale endring
 ## Lokal testing
 
 Når du jobber lokalt kan det være nyttig med forhåndsvisning av endringene du gjør.
-`studioctl` starter den lokale testplattformen, kjører appen og kobler appen til local.altinn.cloud.
+`studioctl` starter den lokale testplattformen, kjører appen og kobler appen til local.altinn.cloud på port `8000`.
 Du trenger en container runtime, for eksempel Docker, Podman eller Colima, og .NET SDK for å kjøre appen som en lokal prosess.
 Kjør `studioctl doctor` hvis du vil sjekke at maskinen har det som trengs.
 
@@ -146,14 +119,14 @@ For å kunne kjøre appen i LocalTest må applikasjonen ha en tilknyttet [datamo
 {{% /notice %}}
 
 1. **Start lokal testplattform**: Gå til app-repoet i terminalen og kjør `studioctl env up`.
-2. **Kjør applikasjonen i LocalTest**: Kjør `studioctl app run` fra app-repoet. Kommandoen finner appmappen automatisk og starter appen med riktige lokale innstillinger.
-3. **Forhåndsvis og test applikasjonen**: Gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn med en [testbruker](/nb/altinn-studio/v8/reference/testing/local/testusers/).
+2. **Kjør applikasjonen i LocalTest**: Kjør `studioctl run` fra app-repoet. Kommandoen finner appmappen automatisk og starter appen med riktige lokale innstillinger.
+3. **Forhåndsvis og test applikasjonen**: Gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn med en [testbruker](/nb/altinn-studio/v8/reference/testing/local/testusers/).
 
 Du kan også åpne nettleseren direkte når testplattformen starter:
 
 ```bash
 studioctl env up --open
-studioctl app run
+studioctl run
 ```
 
 Nyttige kommandoer:
@@ -162,17 +135,17 @@ Nyttige kommandoer:
 | -------- | ----------- |
 | `studioctl env status` | Viser status for lokal testplattform. |
 | `studioctl env logs` | Viser logger fra LocalTest-containerne. |
-| `studioctl app run --detach` | Kjører appen i bakgrunnen. |
+| `studioctl run --detach` | Kjører appen i bakgrunnen. |
 | `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
-| `studioctl app stop` | Stopper apper som er startet med `studioctl app run --detach`. |
+| `studioctl stop` | Stopper apper som er startet med `studioctl run --detach`. |
 | `studioctl env down` | Stopper lokal testplattform. |
 | `studioctl doctor` | Diagnostiserer manglende verktøy og lokale miljøproblemer. |
 
 ### Se endringer fortløpende
 
 - Ved endringer knyttet til JSON-filer holder det å laste inn siden på nytt.
-- Ved endringer i forhåndsutfylling må applikasjonen instansieres på nytt (gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn igjen).
-- Ved endringer i C#-filer må applikasjonen stoppes (`ctrl+C`) og startes på nytt (`studioctl app run`).
+- Ved endringer i forhåndsutfylling må applikasjonen instansieres på nytt (gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn igjen).
+- Ved endringer i C#-filer må applikasjonen stoppes (`ctrl+C`) og startes på nytt (`studioctl run`).
 
 For å oppdatere automatisk ved endring i C#-filer, start applikasjonen med `dotnet watch`.
 Denne kommandoen vil enten starte applikasjonen eller laste den inn på nytt ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) ved endringer i kildekoden.
@@ -189,7 +162,7 @@ Denne metoden er fortsatt nyttig hvis du må feilsøke et gammelt oppsett, men d
 
 1. **Last ned og start LocalTest** ved å følge stegene [beskrevet på GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (inkluderer start av app som også er forklart under).
 2. **Kjør applikasjonen i LocalTest**: Åpne et nytt terminalvindu og naviger til undermappen *App* i din applikasjon (`<app-name>/App`). Start appen med kommandoen `dotnet run` og vent på bekreftelse i terminalen.
-3. **Forhåndsvis og test applikasjonen**: Gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn med en [testbruker](/nb/altinn-studio/v8/reference/testing/local/testusers/).
+3. **Forhåndsvis og test applikasjonen**: Gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn med en [testbruker](/nb/altinn-studio/v8/reference/testing/local/testusers/).
 
 Applikasjonen stoppes ved å trykke `ctrl+C` i terminalvinduet der du startet den.
 LocalTest stoppes ved å navigere til mappen `app-localtest` i terminalen og kjøre kommandoen `docker compose down`.

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
@@ -14,6 +14,37 @@ Her er en oversikt over hvordan du kommer i gang med lokal utvikling.
 
 ## Hvordan klone applikasjonen til et lokalt utviklingsmiljø
 
+`studioctl` er anbefalt kommandolinjeverktøy for lokal utvikling av Altinn Studio-apper.
+Verktøyet logger inn mot Altinn Studio, kloner app-repoet og setter opp Git-autentisering for deg.
+
+Installer `studioctl`:
+
+```bash
+curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
+```
+
+På Windows kan du installere fra PowerShell:
+
+```powershell
+iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
+```
+
+Logg inn og klon appen:
+
+```bash
+studioctl auth login
+studioctl app clone <org>/<app-name>
+cd <app-name>
+```
+
+For automatisering og CI kan du sende inn en eksisterende Studio/Designer API-nøkkel via standard input:
+
+```bash
+studioctl auth login --with-token < token.txt
+```
+
+{{% expandlarge id="legacy-clone-with-git" header="Gammel metode: Klone manuelt med Git" %}}
+
 1. Finn applikasjonen du vil jobbe med lokalt i Dashboardet i Altinn Studio
 2. Navigér til repositoriet ved å trykke på _Repository_-knappen
     ![Repositoryknappen markert i et bilde](find-app-in-dashboard.png)
@@ -38,13 +69,15 @@ Her er en oversikt over hvordan du kommer i gang med lokal utvikling.
     remote: Enumerating objects: 982, done.
     remote: Counting objects: 100% (982/982), done.
     remote: Compressing objects: 100% (950/950), done.
-    remote: Total 982 (delta 600), reused 0 (delta 0), pack-reused 0 
+    remote: Total 982 (delta 600), reused 0 (delta 0), pack-reused 0
     Receiving objects: 100% (982/982), 166.38 KiB | 1.51 MiB/s, done.
     Resolving deltas: 100% (600/600), done.
     ```
 
 En mappe med samme navn som applikasjonen er opprettet og innholdet i applikasjonsrepoet er klonet inn i mappen.
- Nå er det bare å åpne ditt foretrukne utviklingsverktøy og komme i gang med utviklingen.
+Nå er det bare å åpne ditt foretrukne utviklingsverktøy og komme i gang med utviklingen.
+
+{{% /expandlarge %}}
 
 ## Hvordan synkronisere endringer i lokalt utviklingsmiljø
 
@@ -97,23 +130,43 @@ I Altinn Studio må endringer synkroniseres på samme vis som ved lokale endring
 ## Lokal testing
 
 Når du jobber lokalt kan det være nyttig med forhåndsvisning av endringene du gjør.
-*LocalTest* er et program som spinner opp en lokal mockup av Altinn Plattform.
- Denne gir deg mulighet til å teste og verifisere lokale endringer uten å måtte synkronisere med Altinn Studio.
+`studioctl` starter den lokale testplattformen, kjører appen og kobler appen til local.altinn.cloud.
+Du trenger en container runtime, for eksempel Docker eller Podman, og .NET SDK for å kjøre appen som en lokal prosess.
+Kjør `studioctl doctor` hvis du vil sjekke at maskinen har det som trengs.
 
 {{% notice info %}}
 **MERK**
 For å kunne kjøre appen i LocalTest må applikasjonen ha en tilknyttet [datamodell](/nb/altinn-studio/v8/reference/data/data-modeling/).
 {{% /notice %}}
 
-1. **Last ned og start LocalTest** ved å følg stegene [beskrevet på GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (inkluderer start av app som også er forklart under).
-2. **Kjør applikasjonen i LocalTest**: Åpne et nytt terminalvindu og naviger til undermappen *App* i din applikasjon (`<app-name>/App`). Start appen med kommandoen `dotnet run` og vent på bekreftelse i terminalen.
+1. **Start lokal testplattform**: Gå til app-repoet i terminalen og kjør `studioctl env up`.
+2. **Kjør applikasjonen i LocalTest**: Kjør `studioctl app run` fra app-repoet. Kommandoen finner appmappen automatisk og starter appen med riktige lokale innstillinger.
 3. **Forhåndsvis og test applikasjonen**: Gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn med en [testbruker](/nb/altinn-studio/v8/reference/testing/local/testusers/).
+
+Du kan også åpne nettleseren direkte når testplattformen starter:
+
+```bash
+studioctl env up --open
+studioctl app run
+```
+
+Nyttige kommandoer:
+
+| Kommando | Beskrivelse |
+| -------- | ----------- |
+| `studioctl env status` | Viser status for lokal testplattform. |
+| `studioctl env logs` | Viser logger fra localtest-containerne. |
+| `studioctl app run --detach` | Kjører appen i bakgrunnen. |
+| `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
+| `studioctl app stop` | Stopper apper som er startet med `studioctl app run --detach`. |
+| `studioctl env down` | Stopper lokal testplattform. |
+| `studioctl doctor` | Diagnostiserer manglende verktøy og lokale miljøproblemer. |
 
 ### Se endringer fortløpende
 
 - Ved endringer knyttet til JSON-filer holder det å laste inn siden på nytt.
 - Ved endringer i forhåndsutfylling må applikasjonen instansieres på nytt (gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn igjen).
-- Ved endringer i *cs*-filer må applikasjonen stoppes (`ctrl+C`) og startes på nytt (`dotnet run`).
+- Ved endringer i *cs*-filer må applikasjonen stoppes (`ctrl+C`) og startes på nytt (`studioctl app run`).
 
 For å oppdatere automatisk ved endring i *cs*-filer, start applikasjonen med `dotnet watch`.
 Denne kommandoen vil enten starte applikasjonen eller laste den inn på nytt ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) ved endringer i kildekoden.
@@ -121,4 +174,18 @@ Denne kommandoen vil enten starte applikasjonen eller laste den inn på nytt ([h
 ### Stoppe applikasjon og LocalTest
 
 Applikasjonen stoppes ved å trykke `ctrl+C` i terminalvinduet der du startet den.
+LocalTest stoppes med `studioctl env down`.
+
+{{% expandlarge id="legacy-app-localtest" header="Gammel metode: Kjøre app-localtest manuelt" %}}
+
+Den gamle arbeidsflyten bruker `app-localtest`-repoet direkte.
+Denne metoden er fortsatt nyttig hvis du må feilsøke et gammelt oppsett, men den anbefalte lokale arbeidsflyten er `studioctl`.
+
+1. **Last ned og start LocalTest** ved å følg stegene [beskrevet på GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (inkluderer start av app som også er forklart under).
+2. **Kjør applikasjonen i LocalTest**: Åpne et nytt terminalvindu og naviger til undermappen *App* i din applikasjon (`<app-name>/App`). Start appen med kommandoen `dotnet run` og vent på bekreftelse i terminalen.
+3. **Forhåndsvis og test applikasjonen**: Gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn med en [testbruker](/nb/altinn-studio/v8/reference/testing/local/testusers/).
+
+Applikasjonen stoppes ved å trykke `ctrl+C` i terminalvinduet der du startet den.
 LocalTest stoppes ved å navigere til mappen `app-localtest` i terminalen og kjøre kommandoen `docker compose down`.
+
+{{% /expandlarge %}}

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
@@ -14,7 +14,7 @@ Her er en oversikt over hvordan du kommer i gang med lokal utvikling.
 
 ## Hvordan klone applikasjonen til et lokalt utviklingsmiljø
 
-`studioctl` er anbefalt kommandolinjeverktøy for lokal utvikling av Altinn Studio-apper.
+`studioctl` er et anbefalt kommandolinjeverktøy for lokal utvikling av Altinn Studio-apper.
 Verktøyet logger inn mot Altinn Studio, kloner app-repoet og setter opp Git-autentisering for deg.
 
 Installer `studioctl`:
@@ -155,7 +155,7 @@ Nyttige kommandoer:
 | Kommando | Beskrivelse |
 | -------- | ----------- |
 | `studioctl env status` | Viser status for lokal testplattform. |
-| `studioctl env logs` | Viser logger fra localtest-containerne. |
+| `studioctl env logs` | Viser logger fra LocalTest-containerne. |
 | `studioctl app run --detach` | Kjører appen i bakgrunnen. |
 | `studioctl app logs` | Viser logger fra en app som kjører i bakgrunnen. Bruk `--follow` for løpende logg. |
 | `studioctl app stop` | Stopper apper som er startet med `studioctl app run --detach`. |
@@ -166,9 +166,9 @@ Nyttige kommandoer:
 
 - Ved endringer knyttet til JSON-filer holder det å laste inn siden på nytt.
 - Ved endringer i forhåndsutfylling må applikasjonen instansieres på nytt (gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn igjen).
-- Ved endringer i *cs*-filer må applikasjonen stoppes (`ctrl+C`) og startes på nytt (`studioctl app run`).
+- Ved endringer i C#-filer må applikasjonen stoppes (`ctrl+C`) og startes på nytt (`studioctl app run`).
 
-For å oppdatere automatisk ved endring i *cs*-filer, start applikasjonen med `dotnet watch`.
+For å oppdatere automatisk ved endring i C#-filer, start applikasjonen med `dotnet watch`.
 Denne kommandoen vil enten starte applikasjonen eller laste den inn på nytt ([hot reload](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-watch#hot-reload)) ved endringer i kildekoden.
 
 ### Stoppe applikasjon og LocalTest
@@ -181,7 +181,7 @@ LocalTest stoppes med `studioctl env down`.
 Den gamle arbeidsflyten bruker `app-localtest`-repoet direkte.
 Denne metoden er fortsatt nyttig hvis du må feilsøke et gammelt oppsett, men den anbefalte lokale arbeidsflyten er `studioctl`.
 
-1. **Last ned og start LocalTest** ved å følg stegene [beskrevet på GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (inkluderer start av app som også er forklart under).
+1. **Last ned og start LocalTest** ved å følge stegene [beskrevet på GitHub](https://github.com/Altinn/app-localtest/blob/master/README.md) (inkluderer start av app som også er forklart under).
 2. **Kjør applikasjonen i LocalTest**: Åpne et nytt terminalvindu og naviger til undermappen *App* i din applikasjon (`<app-name>/App`). Start appen med kommandoen `dotnet run` og vent på bekreftelse i terminalen.
 3. **Forhåndsvis og test applikasjonen**: Gå til [http://local.altinn.cloud](http://local.altinn.cloud) og logg inn med en [testbruker](/nb/altinn-studio/v8/reference/testing/local/testusers/).
 

--- a/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/local-dev/_index.nb.md
@@ -137,7 +137,7 @@ I Altinn Studio må endringer synkroniseres på samme vis som ved lokale endring
 
 Når du jobber lokalt kan det være nyttig med forhåndsvisning av endringene du gjør.
 `studioctl` starter den lokale testplattformen, kjører appen og kobler appen til local.altinn.cloud.
-Du trenger en container runtime, for eksempel Docker eller Podman, og .NET SDK for å kjøre appen som en lokal prosess.
+Du trenger en container runtime, for eksempel Docker, Podman eller Colima, og .NET SDK for å kjøre appen som en lokal prosess.
 Kjør `studioctl doctor` hvis du vil sjekke at maskinen har det som trengs.
 
 {{% notice info %}}


### PR DESCRIPTION
## What
- Document `studioctl` as the recommended local development workflow for v8 and v10 local development docs.
- Add `studioctl` install, login, clone, localtest, app run, diagnostics, logs, and stop commands.
- Keep the legacy manual Git clone and `app-localtest` workflow in collapsible sections.
- Add a v10 custom-code section for local development and testing with `studioctl`.
- Share repeated `studioctl` install, local test workflow, stop, legacy LocalTest, and command-reference content through hidden shared docs partials.

## Why
`studioctl` is replacing the old `app-localtest` based harness and should be the default documented path for cloning, developing, and testing apps locally and in CI.

## Testing
- `git diff --check`
- `hugo`
- Rendered screenshots posted in PR comment

cc @martinothamar
