### PR TITLE
chore: remove deprecated CodeRabbit setting

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,7 +5,6 @@ language: en-GB
 tone_instructions: "Please check documentation in British English (en-GB) and Norwegian Bokmål (nb-NO)."
 early_access: false
 enable_free_tier: true
-auto_resolve_threads: true
 reviews:
   profile: "chill"
   high_level_summary: true


### PR DESCRIPTION
## What
- Remove `auto_resolve_threads` from `.coderabbit.yaml`.

## Why
CodeRabbit reported this key as unrecognised in PR review output, and the current CodeRabbit configuration schema does not include `auto_resolve_threads`. Removing it avoids the configuration warning without changing any supported CodeRabbit settings.

Reference: https://coderabbit.ai/integrations/schema.v2.json

Reported by @altinnadmin.

## Testing
- `yq . .coderabbit.yaml`
- `git diff --check`
- `curl -fsSL https://coderabbit.ai/integrations/schema.v2.json | rg -n 'auto_resolve_threads' || true`

cc @martinothamar