### PR TITLE
docs: warn about old app-localtest stack

### DIFF
--- a/content/altinn-studio/shared/studioctl/local-test-workflow.en.md
+++ b/content/altinn-studio/shared/studioctl/local-test-workflow.en.md
@@ -11,6 +11,9 @@ Run `studioctl doctor` to check that your machine has the required tools.
 <div class="notices info"><strong>NOTE</strong>
 To run the app in LocalTest, the application must have an associated <a href="{0}">data model</a>.</div>
 
+<div class="notices warning"><strong>WARNING</strong>
+If you have an existing <code>app-localtest</code> Docker Compose stack, stop and remove it completely before running <code>studioctl env up</code>. Go to the <code>app-localtest</code> folder and run <code>docker compose down</code>, or use the equivalent command for your container runtime.</div>
+
 1. **Start the local test platform**: Go to the app repository in a terminal and run `studioctl env up`.
 2. **Run your application within LocalTest**: Run `studioctl run` from the app repository. The command detects the app directory and starts the app with the correct local settings.
 3. **Preview and test the application**: Go to [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) and log in with a [test user]({1}).

--- a/content/altinn-studio/shared/studioctl/local-test-workflow.en.md
+++ b/content/altinn-studio/shared/studioctl/local-test-workflow.en.md
@@ -12,7 +12,7 @@ Run `studioctl doctor` to check that your machine has the required tools.
 To run the app in LocalTest, the application must have an associated <a href="{0}">data model</a>.</div>
 
 <div class="notices warning"><strong>WARNING</strong>
-If you have an existing <code>app-localtest</code> Docker Compose stack, stop and remove it completely before running <code>studioctl env up</code>. Go to the <code>app-localtest</code> folder and run <code>docker compose down</code>, or use the equivalent command for your container runtime.</div>
+If you have an existing <code>app-localtest</code> stack, stop and remove it completely before running <code>studioctl env up</code>. Use the command that matches your container runtime, such as <code>docker compose down -v</code> or the Podman equivalent.</div>
 
 1. **Start the local test platform**: Go to the app repository in a terminal and run `studioctl env up`.
 2. **Run your application within LocalTest**: Run `studioctl run` from the app repository. The command detects the app directory and starts the app with the correct local settings.

--- a/content/altinn-studio/shared/studioctl/local-test-workflow.nb.md
+++ b/content/altinn-studio/shared/studioctl/local-test-workflow.nb.md
@@ -11,6 +11,9 @@ Kjør `studioctl doctor` for å sjekke at maskinen din har verktøyene som treng
 <div class="notices info"><strong>MERK</strong>
 For å kunne kjøre appen i LocalTest må applikasjonen ha en tilknyttet <a href="{0}">datamodell</a>.</div>
 
+<div class="notices warning"><strong>ADVARSEL</strong>
+Hvis du har en eksisterende Docker Compose-stack fra <code>app-localtest</code>, må den stoppes og fjernes helt før du kjører <code>studioctl env up</code>. Gå til <code>app-localtest</code>-mappen og kjør <code>docker compose down</code>, eller bruk tilsvarende kommando for din container runtime.</div>
+
 1. **Start lokal testplattform**: Gå til app-repoet i terminalen og kjør `studioctl env up`.
 2. **Kjør applikasjonen i LocalTest**: Kjør `studioctl run` fra app-repoet. Kommandoen finner appmappen automatisk og starter appen med riktige lokale innstillinger.
 3. **Forhåndsvis og test applikasjonen**: Gå til [http://local.altinn.cloud:8000](http://local.altinn.cloud:8000) og logg inn med en [testbruker]({1}).

--- a/content/altinn-studio/shared/studioctl/local-test-workflow.nb.md
+++ b/content/altinn-studio/shared/studioctl/local-test-workflow.nb.md
@@ -12,7 +12,7 @@ Kjør `studioctl doctor` for å sjekke at maskinen din har verktøyene som treng
 For å kunne kjøre appen i LocalTest må applikasjonen ha en tilknyttet <a href="{0}">datamodell</a>.</div>
 
 <div class="notices warning"><strong>ADVARSEL</strong>
-Hvis du har en eksisterende Docker Compose-stack fra <code>app-localtest</code>, må den stoppes og fjernes helt før du kjører <code>studioctl env up</code>. Gå til <code>app-localtest</code>-mappen og kjør <code>docker compose down</code>, eller bruk tilsvarende kommando for din container runtime.</div>
+Hvis du har en eksisterende <code>app-localtest</code>-stack, må den stoppes og fjernes helt før du kjører <code>studioctl env up</code>. Bruk kommandoen som passer til din container runtime, for eksempel <code>docker compose down -v</code> eller tilsvarende for Podman.</div>
 
 1. **Start lokal testplattform**: Gå til app-repoet i terminalen og kjør `studioctl env up`.
 2. **Kjør applikasjonen i LocalTest**: Kjør `studioctl run` fra app-repoet. Kommandoen finner appmappen automatisk og starter appen med riktige lokale innstillinger.


### PR DESCRIPTION
## Summary
- Adds a warning to the shared studioctl LocalTest workflow about stopping and removing existing app-localtest Docker Compose stacks before running `studioctl env up`.
- Updates both English and Norwegian shared snippets, covering the v8 and v10 local development pages.

## Testing
- `hugo --minify`
- `hugo --minify --buildDrafts`

cc @martinothamar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added warning notices to LocalTest workflow documentation in both English and Norwegian versions, reminding users to stop and remove any existing Docker Compose stacks before running `studioctl env up`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio-docs/pull/2901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->