### PR TITLE
docs: improve Maskinporten guide readability

### DIFF
--- a/content/altinn-studio/v10/develop-a-service/integration/maskinporten/_index.en.md
+++ b/content/altinn-studio/v10/develop-a-service/integration/maskinporten/_index.en.md
@@ -7,7 +7,7 @@ tags: [needsReview]
 toc: true
 ---
 
-This guide shows how to set up an Altinn app to use the built-in Maskinporten client (`IMaskinportenClient`) for authorised requests on behalf of the app owner, as opposed to the active user.
+This guide shows how to set up an Altinn app to make authorised requests with Maskinporten on behalf of the app owner, as opposed to the active user.
 
 {{% insert "content/shared/maskinporten/altinn-studio-scope-setup.en.md" %}}
 

--- a/content/altinn-studio/v10/develop-a-service/integration/maskinporten/_index.en.md
+++ b/content/altinn-studio/v10/develop-a-service/integration/maskinporten/_index.en.md
@@ -15,6 +15,8 @@ This guide shows how to set up an Altinn app to use the built-in Maskinporten cl
 
 The following manual setup is only needed for legacy apps or special cases where Altinn Studio should not provision the Maskinporten client.
 
+{{% insert "content/shared/maskinporten/altinn-studio-scope-migration.en.md" %}}
+
 {{% expandlarge id="legacy-manual-maskinporten-setup" header="Show manual setup with Samarbeidsportalen and Azure Key Vault" %}}
 
 ### Azure Key Vault access

--- a/content/altinn-studio/v10/develop-a-service/integration/maskinporten/_index.nb.md
+++ b/content/altinn-studio/v10/develop-a-service/integration/maskinporten/_index.nb.md
@@ -7,7 +7,7 @@ tags: [needsReview]
 toc: true
 ---
 
-Denne veiledningen viser hvordan du setter opp en Altinn-app til å bruke den innebygde Maskinporten-klienten (`IMaskinportenClient`) for å utføre autoriserte forespørsler på vegne av eieren av appen, i stedet for den aktive brukeren.
+Denne veiledningen viser hvordan du setter opp en Altinn-app til å utføre autoriserte forespørsler med Maskinporten på vegne av eieren av appen, i stedet for den aktive brukeren.
 
 {{% insert "content/shared/maskinporten/altinn-studio-scope-setup.nb.md" %}}
 

--- a/content/altinn-studio/v10/develop-a-service/integration/maskinporten/_index.nb.md
+++ b/content/altinn-studio/v10/develop-a-service/integration/maskinporten/_index.nb.md
@@ -15,6 +15,8 @@ Denne veiledningen viser hvordan du setter opp en Altinn-app til å bruke den in
 
 Det følgende manuelle oppsettet er bare nødvendig for eldre apper eller spesialtilfeller der Altinn Studio ikke skal opprette Maskinporten-klienten.
 
+{{% insert "content/shared/maskinporten/altinn-studio-scope-migration.nb.md" %}}
+
 {{% expandlarge id="legacy-manual-maskinporten-setup" header="Vis manuelt oppsett med Samarbeidsportalen og Azure Key Vault" %}}
 
 ### Tilgang til Azure Key Vault

--- a/content/altinn-studio/v10/develop-a-service/reference/integration/maskinporten/_index.nb.md
+++ b/content/altinn-studio/v10/develop-a-service/reference/integration/maskinporten/_index.nb.md
@@ -16,6 +16,8 @@ Slik setter du opp en Altinn-app til å bruke den innebygde Maskinporten-kliente
 
 Det følgende manuelle oppsettet er bare nødvendig for eldre apper eller spesialtilfeller der Altinn Studio ikke skal opprette Maskinporten-klienten.
 
+{{% insert "content/shared/maskinporten/altinn-studio-scope-migration.nb.md" %}}
+
 {{% expandlarge id="legacy-manual-maskinporten-setup" header="Vis manuelt oppsett med Samarbeidsportalen og Azure Key Vault" %}}
 
 ### Tilgang til Azure Key Vault

--- a/content/altinn-studio/v10/develop-a-service/reference/integration/maskinporten/_index.nb.md
+++ b/content/altinn-studio/v10/develop-a-service/reference/integration/maskinporten/_index.nb.md
@@ -8,7 +8,7 @@ tags: [needsReview]
 toc: true
 ---
 
-Slik setter du opp en Altinn-app til å bruke den innebygde Maskinporten-klienten (`IMaskinportenClient`) for å utføre autoriserte forespørsler på vegne av eieren av appen, i stedet for den aktive brukeren.
+Slik setter du opp en Altinn-app til å utføre autoriserte forespørsler med Maskinporten på vegne av eieren av appen, i stedet for den aktive brukeren.
 
 {{% insert "content/shared/maskinporten/altinn-studio-scope-setup.nb.md" %}}
 

--- a/content/altinn-studio/v8/guides/integration/maskinporten/_index.en.md
+++ b/content/altinn-studio/v8/guides/integration/maskinporten/_index.en.md
@@ -9,7 +9,7 @@ aliases:
 - /altinn-studio/guides/integration/maskinporten-app-integration
 ---
 
-This guide details how to set up an Altinn application to use the built-in Maskinporten authentication client (`IMaskinportenClient`) for making authorized requests on behalf of the app owner, as opposed to the active user.
+This guide shows how to set up an Altinn app to make authorised requests with Maskinporten on behalf of the app owner, as opposed to the active user.
 
 {{% insert "content/shared/maskinporten/altinn-studio-scope-setup.en.md" %}}
 

--- a/content/altinn-studio/v8/guides/integration/maskinporten/_index.en.md
+++ b/content/altinn-studio/v8/guides/integration/maskinporten/_index.en.md
@@ -17,6 +17,8 @@ This guide details how to set up an Altinn application to use the built-in Maski
 
 The following manual setup is only needed for legacy apps or special cases where Altinn Studio should not provision the Maskinporten client.
 
+{{% insert "content/shared/maskinporten/altinn-studio-scope-migration.en.md" %}}
+
 {{% expandlarge id="legacy-manual-maskinporten-setup" header="Show manual setup with Samarbeidsportalen and Azure Key Vault" %}}
 
 ### Azure Key Vault Access

--- a/content/altinn-studio/v8/guides/integration/maskinporten/_index.nb.md
+++ b/content/altinn-studio/v8/guides/integration/maskinporten/_index.nb.md
@@ -17,6 +17,8 @@ Denne veiledningen viser hvordan du setter opp en Altinn-applikasjon til å bruk
 
 Det følgende manuelle oppsettet er bare nødvendig for eldre applikasjoner eller spesialtilfeller der Altinn Studio ikke skal opprette Maskinporten-klienten.
 
+{{% insert "content/shared/maskinporten/altinn-studio-scope-migration.nb.md" %}}
+
 {{% expandlarge id="legacy-manual-maskinporten-setup" header="Vis manuelt oppsett med Samarbeidsportalen og Azure Key Vault" %}}
 
 ### Tilgang til Azure Key Vault

--- a/content/altinn-studio/v8/guides/integration/maskinporten/_index.nb.md
+++ b/content/altinn-studio/v8/guides/integration/maskinporten/_index.nb.md
@@ -9,7 +9,7 @@ aliases:
 - /altinn-studio/guides/integration/maskinporten-app-integration
 ---
 
-Denne veiledningen viser hvordan du setter opp en Altinn-applikasjon til å bruke den innebygde Maskinporten-klienten (`IMaskinportenClient`) for å utføre autoriserte forespørsler på vegne av eieren av applikasjonen, i stedet for den aktive brukeren.
+Denne veiledningen viser hvordan du setter opp en Altinn-app til å utføre autoriserte forespørsler med Maskinporten på vegne av eieren av appen, i stedet for den aktive brukeren.
 
 {{% insert "content/shared/maskinporten/altinn-studio-scope-setup.nb.md" %}}
 

--- a/content/altinn-studio/v8/guides/integration/maskinporten/add-scopes/_index.en.md
+++ b/content/altinn-studio/v8/guides/integration/maskinporten/add-scopes/_index.en.md
@@ -16,21 +16,6 @@ If the app only needs the default service owner scopes, `altinn:serviceowner`, `
 
 The screenshots show the Norwegian Altinn Studio UI. The flow and placement are the same in English.
 
-## If You Do Not Have Access
-
-If Studio shows **You do not have access on behalf of the organisation**, Studio cannot fetch available Maskinporten scopes for the app owner organisation with the Ansattporten access you are already signed in with. Scopes already added to the app are still shown, but you cannot add or remove scopes until the access is in place.
-
-![The Maskinporten tab shows a message about missing access on behalf of the organisation](maskinporten-scopes-no-access.nb.png "Message about missing access on behalf of the organisation.")
-
-To resolve it:
-
-1. Check that the app is owned by the correct organisation in Altinn Studio.
-2. Ask a director/manager in the organisation, or someone with the Altinn **Hovedadministrator** role, to give your user access to self-service for clients in ID-porten/Maskinporten in Altinn. If the organisation also administers API scopes itself, the user also needs access to self-service for APIs. See [Digdir's guide for access in test and production environments](https://docs.digdir.no/docs/Maskinporten/maskinporten_sjolvbetjening_web.html#tilgang-i-test-og-produksjonsmilj%C3%B8).
-3. Alternatively, ask a user who already has this access to add the scopes to the app.
-4. Try again in Altinn Studio after the access has been granted.
-5. Contact Altinn servicedesk if the access should be correct but the message is still shown.
-{.floating-bullet-numbers}
-
 ## Steps
 
 1. Open the app in Altinn Studio. Go to **Settings**, open the **Maskinporten** tab, and select **Add**.
@@ -50,4 +35,19 @@ To resolve it:
    ![Selected Maskinporten scopes shown in app settings](maskinporten-scopes-selected.nb.png "Selected scopes shown in app settings.")
 
 5. Build and deploy the app again. Scope changes take effect the next time the app is built and deployed.
+{.floating-bullet-numbers}
+
+## If you do not have access
+
+If Studio shows **You do not have access on behalf of the organisation**, Studio cannot fetch available Maskinporten scopes for the app owner organisation with the Ansattporten access you are already signed in with. Scopes already added to the app are still shown, but you cannot add or remove scopes until the access is in place.
+
+![The Maskinporten tab shows a message about missing access on behalf of the organisation](maskinporten-scopes-no-access.nb.png "Message about missing access on behalf of the organisation.")
+
+To resolve it:
+
+1. Check that the app is owned by the correct organisation in Altinn Studio.
+2. Ask a director/manager in the organisation, or someone with the Altinn **Hovedadministrator** role, to give your user access to self-service for clients in ID-porten/Maskinporten in Altinn. If the organisation also administers API scopes itself, the user also needs access to self-service for APIs. See [Digdir's guide for access in test and production environments](https://docs.digdir.no/docs/Maskinporten/maskinporten_sjolvbetjening_web.html#tilgang-i-test-og-produksjonsmilj%C3%B8).
+3. Alternatively, ask a user who already has this access to add the scopes to the app.
+4. Try again in Altinn Studio after the access has been granted.
+5. Contact Altinn servicedesk if the access should be correct but the message is still shown.
 {.floating-bullet-numbers}

--- a/content/altinn-studio/v8/guides/integration/maskinporten/add-scopes/_index.nb.md
+++ b/content/altinn-studio/v8/guides/integration/maskinporten/add-scopes/_index.nb.md
@@ -14,21 +14,6 @@ Før du starter må du være logget inn med Ansattporten på vegne av virksomhet
 Hvis appen bare trenger standardscopene for tjenesteeier, `altinn:serviceowner`, `altinn:serviceowner/instances.read` og `altinn:serviceowner/instances.write`, kan apper som bruker Altinn App v8.3 eller nyere bruke knappen **Legg til standard-scopes** når den vises. Apper som bruker Altinn App v9 får disse scopene automatisk hvis de mangler.
 {{% /notice %}}
 
-## Hvis du ikke har tilgang
-
-Hvis Studio viser meldingen **Du har ikke tilgang på vegne av virksomheten**, kan ikke Studio hente tilgjengelige Maskinporten-scopes for virksomheten som eier appen med Ansattporten-tilgangen du allerede er logget inn med. Scopes som allerede er lagt til i appen vises fortsatt, men du kan ikke legge til eller fjerne scopes før tilgangen er på plass.
-
-![Maskinporten-fanen viser melding om manglende tilgang på vegne av virksomheten](maskinporten-scopes-no-access.nb.png "Melding om manglende tilgang på vegne av virksomheten.")
-
-For å løse dette:
-
-1. Kontroller at appen eies av riktig virksomhet i Altinn Studio.
-2. Be en direktør/leder i virksomheten, eller noen med Altinn-rollen **Hovedadministrator**, gi brukeren din tilgang til selvbetjening av klienter i ID-porten/Maskinporten i Altinn. Hvis virksomheten også administrerer API-scopes selv, må brukeren også ha tilgang til selvbetjening av API-er. Se [Digdirs veiledning for tilgang i test- og produksjonsmiljø](https://docs.digdir.no/docs/Maskinporten/maskinporten_sjolvbetjening_web.html#tilgang-i-test-og-produksjonsmilj%C3%B8).
-3. Alternativt kan en bruker som allerede har denne tilgangen legge til scopene i appen.
-4. Prøv igjen i Altinn Studio når tilgangen er på plass.
-5. Kontakt Altinn servicedesk hvis tilgangen skal være riktig, men meldingen fortsatt vises.
-{.floating-bullet-numbers}
-
 ## Steg
 
 1. Åpne appen i Altinn Studio. Gå til **Innstillinger**, åpne fanen **Maskinporten**, og velg **Legg til**.
@@ -48,4 +33,19 @@ For å løse dette:
    ![Valgte Maskinporten-scopes vises i appinnstillingene](maskinporten-scopes-selected.nb.png "Valgte scopes vises i appinnstillingene.")
 
 5. Bygg og publiser appen på nytt. Scope-endringer trer i kraft neste gang appen bygges og publiseres.
+{.floating-bullet-numbers}
+
+## Hvis du ikke har tilgang
+
+Hvis Studio viser meldingen **Du har ikke tilgang på vegne av virksomheten**, kan ikke Studio hente tilgjengelige Maskinporten-scopes for virksomheten som eier appen med Ansattporten-tilgangen du allerede er logget inn med. Scopes som allerede er lagt til i appen vises fortsatt, men du kan ikke legge til eller fjerne scopes før tilgangen er på plass.
+
+![Maskinporten-fanen viser melding om manglende tilgang på vegne av virksomheten](maskinporten-scopes-no-access.nb.png "Melding om manglende tilgang på vegne av virksomheten.")
+
+For å løse dette:
+
+1. Kontroller at appen eies av riktig virksomhet i Altinn Studio.
+2. Be en direktør/leder i virksomheten, eller noen med Altinn-rollen **Hovedadministrator**, gi brukeren din tilgang til selvbetjening av klienter i ID-porten/Maskinporten i Altinn. Hvis virksomheten også administrerer API-scopes selv, må brukeren også ha tilgang til selvbetjening av API-er. Se [Digdirs veiledning for tilgang i test- og produksjonsmiljø](https://docs.digdir.no/docs/Maskinporten/maskinporten_sjolvbetjening_web.html#tilgang-i-test-og-produksjonsmilj%C3%B8).
+3. Alternativt kan en bruker som allerede har denne tilgangen legge til scopene i appen.
+4. Prøv igjen i Altinn Studio når tilgangen er på plass.
+5. Kontakt Altinn servicedesk hvis tilgangen skal være riktig, men meldingen fortsatt vises.
 {.floating-bullet-numbers}

--- a/content/shared/maskinporten/altinn-studio-scope-migration.en.md
+++ b/content/shared/maskinporten/altinn-studio-scope-migration.en.md
@@ -10,9 +10,9 @@ To move such an app to Altinn Studio-managed credentials:
 
 1. Check which scopes the existing Maskinporten client is configured with in Samarbeidsportalen, and which scopes the app requests in code.
 2. Add the same scopes to the app in Altinn Studio. If the app only needs service owner access to Altinn instances, use the default service owner scopes.
-3. Build and deploy the app to TT02. The deployed app will receive credentials for the selected scopes at the default `MaskinportenSettings` configuration path.
-4. Update app code that explicitly binds Maskinporten configuration to a custom path. Remove the custom `ConfigureMaskinportenClient("...")` call, or change it to use `MaskinportenSettings`, so the app uses the configuration supplied by Altinn Studio.
-5. Verify the app in TT02. Test that it can retrieve a Maskinporten token, and that calls requiring exchanged Altinn tokens still work if the app uses `UseMaskinportenAltinnAuthorization` or `GetAltinnExchangedToken`.
+3. Update app code that explicitly binds Maskinporten configuration to a custom path. Remove the custom `ConfigureMaskinportenClient("...")` call, or change it to use `MaskinportenSettings`, so the app uses the configuration supplied by Altinn Studio.
+4. Build and deploy the app to TT02. The deployed app will receive credentials for the selected scopes at the default `MaskinportenSettings` configuration path.
+5. Verify the app in TT02. Test that it can retrieve a Maskinporten token, and that calls requiring exchanged Altinn tokens still work.
 6. Repeat the deployment and verification in production.
 7. After production is verified, remove the old app-specific Key Vault secrets and the custom Key Vault configuration if they are no longer used. Do not delete the old Maskinporten client before you have verified that no other app or integration uses it.
 {.floating-bullet-numbers}
@@ -27,7 +27,7 @@ After deployment, the app can temporarily have two configuration sources for the
 - the configuration Altinn Studio adds to the app during deployment
 - Azure Key Vault
 
-Configuration providers added later override earlier providers. Ensure that the Azure Key Vault provider is registered after the call to `ConfigureAppWebHost` while the app should still use the old Key Vault values.
+While the app should still use the old Key Vault values, Azure Key Vault must override the configuration from Altinn Studio. Ensure that the Azure Key Vault provider is registered after the call to `ConfigureAppWebHost`.
 
 When the app should use the Altinn Studio-managed credentials:
 

--- a/content/shared/maskinporten/altinn-studio-scope-migration.en.md
+++ b/content/shared/maskinporten/altinn-studio-scope-migration.en.md
@@ -1,0 +1,39 @@
+---
+headless: true
+---
+
+{{% expandlarge id="migrate-from-manual-maskinporten-setup" header="Migrate from manually managed credentials" %}}
+
+Some existing apps use a manually created Maskinporten client from Samarbeidsportalen and read the client credentials from the service owner Azure Key Vault. This setup often uses app-specific secret prefixes because the Key Vault is shared by several apps, for example `myapp--MaskinportenSettings--ClientId`, and app code may bind the built-in client to a custom configuration path such as `myapp:MaskinportenSettings`.
+
+To move such an app to Altinn Studio-managed credentials:
+
+1. Check which scopes the existing Maskinporten client is configured with in Samarbeidsportalen, and which scopes the app requests in code.
+2. Add the same scopes to the app in Altinn Studio. If the app only needs service owner access to Altinn instances, use the default service owner scopes.
+3. Build and deploy the app to TT02. The deployed app will receive credentials for the selected scopes at the default `MaskinportenSettings` configuration path.
+4. Update app code that explicitly binds Maskinporten configuration to a custom path. Remove the custom `ConfigureMaskinportenClient("...")` call, or change it to use `MaskinportenSettings`, so the app uses the configuration supplied by Altinn Studio.
+5. Verify the app in TT02. Test that it can retrieve a Maskinporten token, and that calls requiring exchanged Altinn tokens still work if the app uses `UseMaskinportenAltinnAuthorization` or `GetAltinnExchangedToken`.
+6. Repeat the deployment and verification in production.
+7. After production is verified, remove the old app-specific Key Vault secrets and the custom Key Vault configuration if they are no longer used. Do not delete the old Maskinporten client before you have verified that no other app or integration uses it.
+{.floating-bullet-numbers}
+
+Keep any Azure Key Vault setup that the app uses for other secrets. If Maskinporten credentials were the only values the app read from Azure Key Vault, the Azure Key Vault configuration provider and related app settings can be removed after the migration is verified.
+
+{{% notice warning %}}
+**If the app already uses `MaskinportenSettings` from Azure Key Vault**
+
+After deployment, the app can temporarily have two configuration sources for the same keys:
+
+- the configuration Altinn Studio adds to the app during deployment
+- Azure Key Vault
+
+Configuration providers added later override earlier providers. Ensure that the Azure Key Vault provider is registered after the call to `ConfigureAppWebHost` while the app should still use the old Key Vault values.
+
+When the app should use the Altinn Studio-managed credentials:
+
+- remove or rename the old `MaskinportenSettings--...` Key Vault secrets
+- remove the Azure Key Vault setup entirely if the app does not use Azure Key Vault for anything else
+- redeploy the app
+{{% /notice %}}
+
+{{% /expandlarge %}}

--- a/content/shared/maskinporten/altinn-studio-scope-migration.nb.md
+++ b/content/shared/maskinporten/altinn-studio-scope-migration.nb.md
@@ -1,0 +1,39 @@
+---
+headless: true
+---
+
+{{% expandlarge id="migrate-from-manual-maskinporten-setup" header="Migrer fra manuelt håndterte klientdetaljer" %}}
+
+Noen eksisterende apper bruker en Maskinporten-klient som er opprettet manuelt i Samarbeidsportalen, og leser klientdetaljene fra tjenesteeierens Azure Key Vault. Dette oppsettet bruker ofte appspesifikke prefikser på hemmeligheter fordi Key Vault er delt mellom flere apper, for eksempel `myapp--MaskinportenSettings--ClientId`, og appkoden kan binde den innebygde klienten til en egendefinert konfigurasjonssti som `myapp:MaskinportenSettings`.
+
+For å flytte en slik app til klientdetaljer håndtert av Altinn Studio:
+
+1. Kontroller hvilke scopes den eksisterende Maskinporten-klienten er konfigurert med i Samarbeidsportalen, og hvilke scopes appen ber om i kode.
+2. Legg de samme scopene til appen i Altinn Studio. Hvis appen bare trenger tjenesteeiertilgang til Altinn-instanser, bruker du standardscopene for tjenesteeier.
+3. Bygg og publiser appen til TT02. Den publiserte appen får klientdetaljer for valgte scopes på standardstien `MaskinportenSettings`.
+4. Oppdater appkode som eksplisitt binder Maskinporten-konfigurasjon til en egendefinert sti. Fjern det egendefinerte `ConfigureMaskinportenClient("...")`-kallet, eller endre det til å bruke `MaskinportenSettings`, slik at appen bruker konfigurasjonen fra Altinn Studio.
+5. Verifiser appen i TT02. Test at den kan hente Maskinporten-token, og at kall som krever innvekslede Altinn-token fortsatt fungerer hvis appen bruker `UseMaskinportenAltinnAuthorization` eller `GetAltinnExchangedToken`.
+6. Gjenta publisering og verifisering i produksjon.
+7. Når produksjon er verifisert, kan gamle appspesifikke Key Vault-hemmeligheter og egendefinert Key Vault-konfigurasjon fjernes hvis de ikke brukes lenger. Ikke slett den gamle Maskinporten-klienten før du har verifisert at ingen andre apper eller integrasjoner bruker den.
+{.floating-bullet-numbers}
+
+Behold Azure Key Vault-oppsett som appen bruker for andre hemmeligheter. Hvis Maskinporten-klientdetaljer var de eneste verdiene appen leste fra Azure Key Vault, kan Azure Key Vault-konfigurasjonsprovideren og tilhørende appinnstillinger fjernes etter at migreringen er verifisert.
+
+{{% notice warning %}}
+**Hvis appen allerede bruker `MaskinportenSettings` fra Azure Key Vault**
+
+Etter publisering kan appen midlertidig ha to konfigurasjonskilder for de samme nøklene:
+
+- konfigurasjonen Altinn Studio legger inn i appen ved publisering
+- Azure Key Vault
+
+Konfigurasjonsprovidere som legges til senere, overstyrer tidligere providere. Sørg for at Azure Key Vault-provideren registreres etter kallet til `ConfigureAppWebHost` mens appen fortsatt skal bruke de gamle Key Vault-verdiene.
+
+Når appen skal bruke klientdetaljene håndtert av Altinn Studio:
+
+- fjern eller gi nytt navn til de gamle `MaskinportenSettings--...`-hemmelighetene i Key Vault
+- fjern Azure Key Vault-oppsettet helt hvis appen ikke bruker Azure Key Vault til noe annet
+- publiser appen på nytt
+{{% /notice %}}
+
+{{% /expandlarge %}}

--- a/content/shared/maskinporten/altinn-studio-scope-migration.nb.md
+++ b/content/shared/maskinporten/altinn-studio-scope-migration.nb.md
@@ -10,9 +10,9 @@ For å flytte en slik app til klientdetaljer håndtert av Altinn Studio:
 
 1. Kontroller hvilke scopes den eksisterende Maskinporten-klienten er konfigurert med i Samarbeidsportalen, og hvilke scopes appen ber om i kode.
 2. Legg de samme scopene til appen i Altinn Studio. Hvis appen bare trenger tjenesteeiertilgang til Altinn-instanser, bruker du standardscopene for tjenesteeier.
-3. Bygg og publiser appen til TT02. Den publiserte appen får klientdetaljer for valgte scopes på standardstien `MaskinportenSettings`.
-4. Oppdater appkode som eksplisitt binder Maskinporten-konfigurasjon til en egendefinert sti. Fjern det egendefinerte `ConfigureMaskinportenClient("...")`-kallet, eller endre det til å bruke `MaskinportenSettings`, slik at appen bruker konfigurasjonen fra Altinn Studio.
-5. Verifiser appen i TT02. Test at den kan hente Maskinporten-token, og at kall som krever innvekslede Altinn-token fortsatt fungerer hvis appen bruker `UseMaskinportenAltinnAuthorization` eller `GetAltinnExchangedToken`.
+3. Oppdater appkode som eksplisitt binder Maskinporten-konfigurasjon til en egendefinert sti. Fjern det egendefinerte `ConfigureMaskinportenClient("...")`-kallet, eller endre det til å bruke `MaskinportenSettings`, slik at appen bruker konfigurasjonen fra Altinn Studio.
+4. Bygg og publiser appen til TT02. Den publiserte appen får klientdetaljer for valgte scopes på standardstien `MaskinportenSettings`.
+5. Verifiser appen i TT02. Test at den kan hente Maskinporten-token, og at kall som krever innvekslede Altinn-token fortsatt fungerer.
 6. Gjenta publisering og verifisering i produksjon.
 7. Når produksjon er verifisert, kan gamle appspesifikke Key Vault-hemmeligheter og egendefinert Key Vault-konfigurasjon fjernes hvis de ikke brukes lenger. Ikke slett den gamle Maskinporten-klienten før du har verifisert at ingen andre apper eller integrasjoner bruker den.
 {.floating-bullet-numbers}
@@ -27,7 +27,7 @@ Etter publisering kan appen midlertidig ha to konfigurasjonskilder for de samme 
 - konfigurasjonen Altinn Studio legger inn i appen ved publisering
 - Azure Key Vault
 
-Konfigurasjonsprovidere som legges til senere, overstyrer tidligere providere. Sørg for at Azure Key Vault-provideren registreres etter kallet til `ConfigureAppWebHost` mens appen fortsatt skal bruke de gamle Key Vault-verdiene.
+Mens appen fortsatt skal bruke de gamle Key Vault-verdiene, må Azure Key Vault overstyre konfigurasjonen fra Altinn Studio. Sørg for at Azure Key Vault-provideren registreres etter kallet til `ConfigureAppWebHost`.
 
 Når appen skal bruke klientdetaljene håndtert av Altinn Studio:
 

--- a/content/shared/maskinporten/altinn-studio-scope-setup.en.md
+++ b/content/shared/maskinporten/altinn-studio-scope-setup.en.md
@@ -9,11 +9,11 @@
 - The app must also authorise the service owner in [`App/config/authorization/policy.xml`](/en/altinn-studio/v8/reference/configuration/authorization/). New apps include this rule in the app template. For existing apps, add or update the `[org]` rule so it grants `read` and `write`.
 {{</notice>}}
 
-The recommended setup is to add the scopes the app needs in Altinn Studio. When the app is built and deployed, the built-in Maskinporten client in the app can use the selected scopes.
+The recommended setup is to select the scopes the app needs in Altinn Studio and use the built-in Maskinporten client in application code. When the app is built and deployed, Altinn Studio adds the credentials to the app at the default `MaskinportenSettings` configuration path.
 
 To set this up:
 
-1. [Ensure that your user can add Maskinporten scopes for the organisation](#access-to-maskinporten-scopes).
+1. [Check that your user has access to Maskinporten scopes](#access-to-maskinporten-scopes).
 2. [Add the required scopes in Altinn Studio](/en/altinn-studio/v8/guides/integration/maskinporten/add-scopes/).
 3. [Deploy the app so the selected scopes become available to the app](#deployment-and-credentials).
 4. [Use the built-in Maskinporten client in application code](#application-setup).
@@ -22,7 +22,7 @@ To set this up:
 
 Altinn Studio uses your signed-in Ansattporten access to find the Maskinporten scopes you can add for the service owner organisation.
 
-If you cannot see any scopes in Altinn Studio, your user may not have access to administer clients for the organisation. Contact the person who administers Maskinporten access for your organisation or Altinn servicedesk.
+If you cannot see any scopes in Altinn Studio, your user may not have access to administer clients for the organisation. See [what to do if you do not have access](/en/altinn-studio/v8/guides/integration/maskinporten/add-scopes/#if-you-do-not-have-access), contact the person who administers Maskinporten access for your organisation, or contact Altinn servicedesk.
 
 ## Add scopes in Altinn Studio
 
@@ -54,12 +54,23 @@ To move such an app to Altinn Studio-managed credentials:
 Keep any Azure Key Vault setup that the app uses for other secrets. If Maskinporten credentials were the only values the app read from Azure Key Vault, the Azure Key Vault configuration provider and related app settings can be removed after the migration is verified.
 
 {{% notice warning %}}
-If the app already uses the default `MaskinportenSettings` configuration path and reads those values from Azure Key Vault, the app will temporarily have two configuration sources for the same keys after Studio-managed credentials are deployed: the runtime secrets file added by `ConfigureAppWebHost`, and Azure Key Vault.
+**If the app already uses `MaskinportenSettings` from Azure Key Vault**
 
-Configuration providers added later override earlier providers. Ensure that the Azure Key Vault provider is registered after the call to `ConfigureAppWebHost`, so the existing Key Vault values keep taking precedence until you intentionally remove them. When you want the app to use the Studio-managed credentials, remove or rename the old `MaskinportenSettings--...` Key Vault secrets, or remove the Azure Key Vault setup entirely if the app does not use it for anything else, and redeploy the app.
+After deployment, the app can temporarily have two configuration sources for the same keys:
+
+- the runtime secrets file registered by `ConfigureAppWebHost`
+- Azure Key Vault
+
+Configuration providers added later override earlier providers. Ensure that the Azure Key Vault provider is registered after the call to `ConfigureAppWebHost` while the app should still use the old Key Vault values.
+
+When the app should use the Altinn Studio-managed credentials:
+
+- remove or rename the old `MaskinportenSettings--...` Key Vault secrets
+- remove the Azure Key Vault setup entirely if the app does not use Azure Key Vault for anything else
+- redeploy the app
 {{% /notice %}}
 
-## Application Setup
+## Usage {#application-setup}
 
 The app automatically includes the built-in `IMaskinportenClient` which can be injected into your services.
 

--- a/content/shared/maskinporten/altinn-studio-scope-setup.en.md
+++ b/content/shared/maskinporten/altinn-studio-scope-setup.en.md
@@ -36,40 +36,6 @@ When an app with Maskinporten scopes is deployed, Altinn Studio includes the sel
 
 You do not need to handle client credentials, JWKS generation, rotation, or app configuration yourself for the standard app setup.
 
-## Migrate from manually managed credentials
-
-Some existing apps use a manually created Maskinporten client from Samarbeidsportalen and read the client credentials from the service owner Azure Key Vault. This setup often uses app-specific secret prefixes because the Key Vault is shared by several apps, for example `myapp--MaskinportenSettings--ClientId`, and app code may bind the built-in client to a custom configuration path such as `myapp:MaskinportenSettings`.
-
-To move such an app to Altinn Studio-managed credentials:
-
-1. Check which scopes the existing Maskinporten client is configured with in Samarbeidsportalen, and which scopes the app requests in code.
-2. Add the same scopes to the app in Altinn Studio. If the app only needs service owner access to Altinn instances, use the default service owner scopes.
-3. Build and deploy the app to TT02. The deployed app will receive credentials for the selected scopes at the default `MaskinportenSettings` configuration path.
-4. Update app code that explicitly binds Maskinporten configuration to a custom path. Remove the custom `ConfigureMaskinportenClient("...")` call, or change it to use `MaskinportenSettings`, so the app uses the configuration supplied by Altinn Studio.
-5. Verify the app in TT02. Test that it can retrieve a Maskinporten token, and that calls requiring exchanged Altinn tokens still work if the app uses `UseMaskinportenAltinnAuthorization` or `GetAltinnExchangedToken`.
-6. Repeat the deployment and verification in production.
-7. After production is verified, remove the old app-specific Key Vault secrets and the custom Key Vault configuration if they are no longer used. Do not delete the old Maskinporten client before you have verified that no other app or integration uses it.
-{.floating-bullet-numbers}
-
-Keep any Azure Key Vault setup that the app uses for other secrets. If Maskinporten credentials were the only values the app read from Azure Key Vault, the Azure Key Vault configuration provider and related app settings can be removed after the migration is verified.
-
-{{% notice warning %}}
-**If the app already uses `MaskinportenSettings` from Azure Key Vault**
-
-After deployment, the app can temporarily have two configuration sources for the same keys:
-
-- the runtime secrets file registered by `ConfigureAppWebHost`
-- Azure Key Vault
-
-Configuration providers added later override earlier providers. Ensure that the Azure Key Vault provider is registered after the call to `ConfigureAppWebHost` while the app should still use the old Key Vault values.
-
-When the app should use the Altinn Studio-managed credentials:
-
-- remove or rename the old `MaskinportenSettings--...` Key Vault secrets
-- remove the Azure Key Vault setup entirely if the app does not use Azure Key Vault for anything else
-- redeploy the app
-{{% /notice %}}
-
 ## Usage {#application-setup}
 
 The app automatically includes the built-in `IMaskinportenClient` which can be injected into your services.

--- a/content/shared/maskinporten/altinn-studio-scope-setup.en.md
+++ b/content/shared/maskinporten/altinn-studio-scope-setup.en.md
@@ -9,8 +9,6 @@
 - The app must also authorise the service owner in [`App/config/authorization/policy.xml`](/en/altinn-studio/v8/reference/configuration/authorization/). New apps include this rule in the app template. For existing apps, add or update the `[org]` rule so it grants `read` and `write`.
 {{</notice>}}
 
-The recommended setup is to select the scopes the app needs in Altinn Studio and use the built-in Maskinporten client in application code. When the app is built and deployed, Altinn Studio adds the credentials to the app at the default `MaskinportenSettings` configuration path.
-
 To set this up:
 
 1. [Check that your user has access to Maskinporten scopes](#access-to-maskinporten-scopes).

--- a/content/shared/maskinporten/altinn-studio-scope-setup.nb.md
+++ b/content/shared/maskinporten/altinn-studio-scope-setup.nb.md
@@ -9,8 +9,6 @@
 - Appen må også autorisere tjenesteeier i [`App/config/authorization/policy.xml`](/nb/altinn-studio/v8/reference/configuration/authorization/). Nye apper har denne regelen i appmalen. For eksisterende apper må du legge til eller oppdatere `[org]`-regelen slik at den gir `read` og `write`.
 {{</notice>}}
 
-Anbefalt oppsett er å velge scopene appen trenger i Altinn Studio og bruke den innebygde Maskinporten-klienten i appkoden. Når appen bygges og publiseres, legger Altinn Studio klientdetaljene inn i appen på standardstien `MaskinportenSettings`.
-
 For å sette dette opp må du:
 
 1. [Kontrollere at brukeren din har tilgang til Maskinporten-scopes](#tilgang-til-maskinporten-scopes).

--- a/content/shared/maskinporten/altinn-studio-scope-setup.nb.md
+++ b/content/shared/maskinporten/altinn-studio-scope-setup.nb.md
@@ -9,11 +9,11 @@
 - Appen må også autorisere tjenesteeier i [`App/config/authorization/policy.xml`](/nb/altinn-studio/v8/reference/configuration/authorization/). Nye apper har denne regelen i appmalen. For eksisterende apper må du legge til eller oppdatere `[org]`-regelen slik at den gir `read` og `write`.
 {{</notice>}}
 
-Anbefalt oppsett er å legge til scopene appen trenger i Altinn Studio. Når appen bygges og publiseres, kan den innebygde Maskinporten-klienten i appen bruke de valgte scopene.
+Anbefalt oppsett er å velge scopene appen trenger i Altinn Studio og bruke den innebygde Maskinporten-klienten i appkoden. Når appen bygges og publiseres, legger Altinn Studio klientdetaljene inn i appen på standardstien `MaskinportenSettings`.
 
 For å sette dette opp må du:
 
-1. [Sørge for at brukeren din kan legge til Maskinporten-scopes for organisasjonen](#tilgang-til-maskinporten-scopes).
+1. [Kontrollere at brukeren din har tilgang til Maskinporten-scopes](#tilgang-til-maskinporten-scopes).
 2. [Legge til nødvendige scopes i Altinn Studio](/nb/altinn-studio/v8/guides/integration/maskinporten/add-scopes/).
 3. [Publisere appen slik at valgte scopes blir tilgjengelige for appen](#publisering-og-klientdetaljer).
 4. [Bruke den innebygde Maskinporten-klienten i appkoden](#maskinporten-application-setup).
@@ -22,7 +22,7 @@ For å sette dette opp må du:
 
 Altinn Studio bruker den innloggede Ansattporten-tilgangen din til å finne Maskinporten-scopene du kan legge til for tjenesteeierorganisasjonen.
 
-Hvis du ikke ser noen scopes i Altinn Studio, kan brukeren din mangle tilgang til å administrere klienter for organisasjonen. Kontakt den som administrerer Maskinporten-tilganger for organisasjonen din, eller Altinn servicedesk.
+Hvis du ikke ser noen scopes i Altinn Studio, kan brukeren din mangle tilgang til å administrere klienter for organisasjonen. Se [hva du gjør hvis du ikke har tilgang](/nb/altinn-studio/v8/guides/integration/maskinporten/add-scopes/#hvis-du-ikke-har-tilgang), kontakt den som administrerer Maskinporten-tilganger for organisasjonen din, eller kontakt Altinn servicedesk.
 
 ## Legg til scopes i Altinn Studio
 
@@ -54,12 +54,23 @@ For å flytte en slik app til klientdetaljer håndtert av Altinn Studio:
 Behold Azure Key Vault-oppsett som appen bruker for andre hemmeligheter. Hvis Maskinporten-klientdetaljer var de eneste verdiene appen leste fra Azure Key Vault, kan Azure Key Vault-konfigurasjonsprovideren og tilhørende appinnstillinger fjernes etter at migreringen er verifisert.
 
 {{% notice warning %}}
-Hvis appen allerede bruker standardstien `MaskinportenSettings` og leser disse verdiene fra Azure Key Vault, vil appen midlertidig ha to konfigurasjonskilder for de samme nøklene etter at klientdetaljer håndtert av Studio er publisert: runtime secrets-filen som legges til av `ConfigureAppWebHost`, og Azure Key Vault.
+**Hvis appen allerede bruker `MaskinportenSettings` fra Azure Key Vault**
 
-Konfigurasjonsprovidere som legges til senere overstyrer tidligere providere. Sørg for at Azure Key Vault-provideren registreres etter kallet til `ConfigureAppWebHost`, slik at de eksisterende Key Vault-verdiene har forrang frem til du bevisst fjerner dem. Når appen skal bruke klientdetaljene håndtert av Studio, fjerner eller gir du nytt navn til de gamle `MaskinportenSettings--...`-hemmelighetene i Key Vault, eller fjerner Azure Key Vault-oppsettet helt hvis appen ikke bruker det til noe annet, og publiserer appen på nytt.
+Etter publisering kan appen midlertidig ha to konfigurasjonskilder for de samme nøklene:
+
+- runtime secrets-filen som registreres av `ConfigureAppWebHost`
+- Azure Key Vault
+
+Konfigurasjonsprovidere som legges til senere, overstyrer tidligere providere. Sørg for at Azure Key Vault-provideren registreres etter kallet til `ConfigureAppWebHost` mens appen fortsatt skal bruke de gamle Key Vault-verdiene.
+
+Når appen skal bruke klientdetaljene håndtert av Altinn Studio:
+
+- fjern eller gi nytt navn til de gamle `MaskinportenSettings--...`-hemmelighetene i Key Vault
+- fjern Azure Key Vault-oppsettet helt hvis appen ikke bruker Azure Key Vault til noe annet
+- publiser appen på nytt
 {{% /notice %}}
 
-## Appoppsett {#maskinporten-application-setup}
+## Bruk {#maskinporten-application-setup}
 Appen inkluderer automatisk den innebygde `IMaskinportenClient` som kan brukes i tjenestene dine.
 
 ### Konfigurasjonsstier
@@ -67,9 +78,9 @@ Klienten leter automatisk etter Maskinporten-konfigurasjon på standardstien _"M
 
 Bruk standardstien når scopes er valgt i Altinn Studio. Egendefinerte konfigurasjonsseksjoner fylles ikke ut av scope-oppsettet i Altinn Studio, og bør bare brukes med manuelt eller eldre oppsett.
 
-### Autorisere Http-klienter
+### Autoriser HTTP-klienter
 
-Typede og navngitte Http-klienter kan autoriseres med de tilgjengelige utvidelsesmetodene, som illustrert nedenfor.
+Typede og navngitte HTTP-klienter kan autoriseres med de tilgjengelige utvidelsesmetodene, som illustrert nedenfor.
 
 {{< code-title >}}
 App/Program.cs

--- a/content/shared/maskinporten/altinn-studio-scope-setup.nb.md
+++ b/content/shared/maskinporten/altinn-studio-scope-setup.nb.md
@@ -36,40 +36,6 @@ Når en app med Maskinporten-scopes publiseres, legger Altinn Studio valgte scop
 
 Du trenger ikke å håndtere klientdetaljer, JWKS-generering, rotasjon eller appkonfigurasjon selv for standard oppsett av apper.
 
-## Migrer fra manuelt håndterte klientdetaljer
-
-Noen eksisterende apper bruker en Maskinporten-klient som er opprettet manuelt i Samarbeidsportalen, og leser klientdetaljene fra tjenesteeierens Azure Key Vault. Dette oppsettet bruker ofte appspesifikke prefikser på hemmeligheter fordi Key Vault er delt mellom flere apper, for eksempel `myapp--MaskinportenSettings--ClientId`, og appkoden kan binde den innebygde klienten til en egendefinert konfigurasjonssti som `myapp:MaskinportenSettings`.
-
-For å flytte en slik app til klientdetaljer håndtert av Altinn Studio:
-
-1. Kontroller hvilke scopes den eksisterende Maskinporten-klienten er konfigurert med i Samarbeidsportalen, og hvilke scopes appen ber om i kode.
-2. Legg de samme scopene til appen i Altinn Studio. Hvis appen bare trenger tjenesteeiertilgang til Altinn-instanser, bruker du standardscopene for tjenesteeier.
-3. Bygg og publiser appen til TT02. Den publiserte appen får klientdetaljer for valgte scopes på standardstien `MaskinportenSettings`.
-4. Oppdater appkode som eksplisitt binder Maskinporten-konfigurasjon til en egendefinert sti. Fjern det egendefinerte `ConfigureMaskinportenClient("...")`-kallet, eller endre det til å bruke `MaskinportenSettings`, slik at appen bruker konfigurasjonen fra Altinn Studio.
-5. Verifiser appen i TT02. Test at den kan hente Maskinporten-token, og at kall som krever innvekslede Altinn-token fortsatt fungerer hvis appen bruker `UseMaskinportenAltinnAuthorization` eller `GetAltinnExchangedToken`.
-6. Gjenta publisering og verifisering i produksjon.
-7. Når produksjon er verifisert, kan gamle appspesifikke Key Vault-hemmeligheter og egendefinert Key Vault-konfigurasjon fjernes hvis de ikke brukes lenger. Ikke slett den gamle Maskinporten-klienten før du har verifisert at ingen andre apper eller integrasjoner bruker den.
-{.floating-bullet-numbers}
-
-Behold Azure Key Vault-oppsett som appen bruker for andre hemmeligheter. Hvis Maskinporten-klientdetaljer var de eneste verdiene appen leste fra Azure Key Vault, kan Azure Key Vault-konfigurasjonsprovideren og tilhørende appinnstillinger fjernes etter at migreringen er verifisert.
-
-{{% notice warning %}}
-**Hvis appen allerede bruker `MaskinportenSettings` fra Azure Key Vault**
-
-Etter publisering kan appen midlertidig ha to konfigurasjonskilder for de samme nøklene:
-
-- runtime secrets-filen som registreres av `ConfigureAppWebHost`
-- Azure Key Vault
-
-Konfigurasjonsprovidere som legges til senere, overstyrer tidligere providere. Sørg for at Azure Key Vault-provideren registreres etter kallet til `ConfigureAppWebHost` mens appen fortsatt skal bruke de gamle Key Vault-verdiene.
-
-Når appen skal bruke klientdetaljene håndtert av Altinn Studio:
-
-- fjern eller gi nytt navn til de gamle `MaskinportenSettings--...`-hemmelighetene i Key Vault
-- fjern Azure Key Vault-oppsettet helt hvis appen ikke bruker Azure Key Vault til noe annet
-- publiser appen på nytt
-{{% /notice %}}
-
 ## Bruk {#maskinporten-application-setup}
 Appen inkluderer automatisk den innebygde `IMaskinportenClient` som kan brukes i tjenestene dine.
 


### PR DESCRIPTION
## What

- Tightened the Maskinporten automation guide narrative so the recommended flow is clearer: access, scopes, deployment, then use in code.
- Reworked the Azure Key Vault warning into shorter paragraphs and bullet lists.
- Moved migration from manually managed Maskinporten credentials into a collapsed item under legacy/manual setup.
- Renamed the Norwegian `Appoppsett` section to `Bruk`, and adjusted the HTTP client heading/casing.
- Linked the access note to the detailed troubleshooting section.
- Moved `Hvis du ikke har tilgang` / `If you do not have access` to the bottom of the add-scopes guide so it does not interrupt the main setup flow.

## Screenshots

Full integration guide with the migration path collapsed under legacy/manual setup:

![Maskinporten guide full page](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio-docs/pr-screenshots-maskinporten-guide-readability/screenshots/maskinporten-guide-full-nb-feedback.png)

Full integration guide with migration details expanded:

![Maskinporten migration expanded full page](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio-docs/pr-screenshots-maskinporten-guide-readability/screenshots/maskinporten-guide-migration-expanded-full-nb-feedback.png)

Full add-scopes guide with the access fallback at the bottom:

![Maskinporten add scopes full page](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio-docs/pr-screenshots-maskinporten-guide-readability/screenshots/maskinporten-add-scopes-full-nb-feedback.png)

## Testing

- `hugo --minify`
- `git diff --check`
- Ran `hugo server --bind 127.0.0.1 --port 1313 --disableFastRender` and inspected the rendered Norwegian guide with Chromium/Playwright.
- Checked computed heading styles for the affected headings; rendered headings use `text-transform: none`, so the visible casing issue was handled by making the heading text/casing less ambiguous rather than changing global CSS.

cc @martinothamar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new migration guidance for existing Maskinporten credential setups, explaining how to transition from manually managed credentials to Altinn Studio-managed credentials with step-by-step instructions.
  * Updated Maskinporten integration guides with clearer scope selection recommendations and enhanced troubleshooting information.
  * Reorganised setup documentation for improved readability and user workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio-docs/pull/2902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
