### PR TITLE
feat: Skill: tekstforfatter-altinn-docs — norsk tekstredaktør for Claude Code

### DIFF
--- a/.claude/skills/tekstforfatter-altinn-docs/SKILL.md
+++ b/.claude/skills/tekstforfatter-altinn-docs/SKILL.md
@@ -1,6 +1,5 @@
 ---
-name: forfatter-uten
-description: "Norsk tekstforfatter og redaktør: klarspråk, AI-markører, anglisismer, fagtermer, mikrotekst. Fungerer uten CLAUDE.md."
+description: "Norsk tekstforfatter og redaktør: klarspråk, AI-markører, anglisismer, fagtermer, mikrotekst."
 ---
 
 # Tekstredaktør

--- a/.claude/skills/tekstforfatter-altinn-docs/SKILL.md
+++ b/.claude/skills/tekstforfatter-altinn-docs/SKILL.md
@@ -57,7 +57,7 @@ Bruk verb, ikke substantiv laget av verb. De gjør teksten tung. Eksempel: ing +
 
 - Korte setninger i stedet for lange
 - Vanlige ord i stedet for moteord
-- Aktiv form i stedet for passiv ("vi bruker" ikke "det benyttes"). Når systemet handler, bruk "appen", "tjenesten", "plattformen" eller "Studio" som subjekt: "Studio fjerner ukjente verdier" ikke "Ukjente verdier fjernes"
+- Aktiv form i stedet for passiv ("vi bruker" ikke "det benyttes"). Når systemet handler, bruk "tjenesten" eller det aktuelle produktnavnet som subjekt: "Tjenesten fjerner ukjente verdier" ikke "Ukjente verdier fjernes"
 - Konkret i stedet for abstrakt ("vi bygger nytt image" ikke "det kreves en tilpasning av image-artefaktet")
 - Kutt fyllord: "i bunn og grunn", "i stor grad", "på mange måter"
 - Skriv direkte: "CNPG fikser dette" ikke "CNPG har adressert denne problemstillingen"
@@ -217,7 +217,7 @@ Noen engelske termer har blitt muntlig fagspråk og brukes også skriftlig i fag
 Bruk bindestrek mellom et engelsk og et norsk ord, og mellom akronymer og norsk ord:
 
 ```text
-✅ image-bygg, backlog-oversikt, Gitea-området
+✅ image-bygg, backlog-oversikt, API-endepunktet
 ✅ GitHub-repoet, Microsoft-programmer
 ❌ GitHub repoet, Microsoft programmer
 ```


### PR DESCRIPTION
@ErlingHauan og @Ildest har, med utgangspunkt i Nav sin tekstforfatter-skill, laget en Claude Code-skill for norsk klarspråk og tekstredigering. Skillen er testet på dokumentasjon i Altinn Studio og i KI-assistenten og ser ut til å fungere godt.

### Hva gjør skillen?
Den sjekker og forbedrer norsk tekst etter klarspråkprinsippene til Språkrådet og ISO 24495-1. Den fanger blant annet opp:

- AI-markører og klisjeer
- Substantivsyke (substantiverte verb)
- Anglisismer og feiloversatte fagtermer
- Passivt språk der aktiv form passer bedre
- Inkonsekvent bruk av lister og overskrifter (Diátaxis-rammeverket)
- Feil bruk av parenteser, skråstrek og anførselstegn

### Slik installerer du den
Kopier mappen tekstforfatter-altinn-docs til .claude/skills/ i prosjektet ditt (eller til ~/.claude/skills/ for global tilgang). Deretter kaller du den med /tekstforfatter-altinn-docs i Claude Code.

PR: [skill-tekstforfatter-altinn-docs](https://github.com/Altinn/altinn-studio-docs/compare/skill-rename-tekstforfatter?expand=1#:~:text=feat%3A%20Skill%3A%20tekstforfatter%2Daltinn%2Ddocs%20%E2%80%94%20norsk%20tekstredakt%C3%B8r%20for%20Claude%20Code)

Tilbakemeldinger mottas med takk når dere har prøvd den ut.