### PR TITLE
Change runner from ubuntu-latest to self-hosted

### DIFF
--- a/.github/workflows/hugo-verifications.yml
+++ b/.github/workflows/hugo-verifications.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   build:
     runs-on: self-hosted
-    env:
-      HUGO_VERSION: 0.153.2
     name: Build and Check links
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -18,10 +16,11 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Install Hugo
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
+        with:
+          hugo-version: '0.153.2'
+          extended: true 
 
       - name: Build
         run: hugo

--- a/.github/workflows/hugo-verifications.yml
+++ b/.github/workflows/hugo-verifications.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       HUGO_VERSION: 0.153.2
     name: Build and Check links

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -29,8 +29,6 @@ jobs:
   # Build job
   build:
     runs-on: self-hosted
-    env:
-      HUGO_VERSION: 0.153.2
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -38,10 +36,11 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Install Hugo
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
+        with:
+          hugo-version: '0.153.2'
+          extended: true
 
       - name: Install Dart Sass Embedded
         run: sudo snap install dart-sass-embedded

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -28,7 +28,7 @@ defaults:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       HUGO_VERSION: 0.153.2
     steps:
@@ -76,7 +76,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: build
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Hugo verification workflow to use a self-hosted runner for the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio-docs/pull/2907?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->