### PR TITLE
fix: main navigation link to "create apps"

### DIFF
--- a/layouts/partials/blocks/apps.html
+++ b/layouts/partials/blocks/apps.html
@@ -1,5 +1,5 @@
 <div class="col-12 col-lg-4 mb-5">
-    <a href="{{ with .Site.GetPage `/altinn-studio`}}{{.RelPermalink}}{{end}}" class="a-illustrationLink">
+    <a href="{{ with .Site.GetPage `/altinn-studio/v8`}}{{.RelPermalink}}{{end}}" class="a-illustrationLink">
         <h2 class="a-h3">{{T "create-your-first-app"}}</h2>
         <p class="a-js-truncate-2">{{T "create-your-first-app-description"}}</p>
         <div class="a-illustration-icon">


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/ef902518-7ccb-41d5-863d-2b918086ee72



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The "create your first app" link now directs to Altinn Studio v8.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio-docs/pull/2919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->