### PR TITLE
Fixed version reference to app-lib in validation section in "Lag ny kopi"

### DIFF
--- a/content/altinn-studio/v8/reference/configuration/messagebox/create_copy/_index.en.md
+++ b/content/altinn-studio/v8/reference/configuration/messagebox/create_copy/_index.en.md
@@ -70,7 +70,7 @@ During the copying of an instance the logic will perform a method call to **IIns
 
 ## Validation
 
-{{%notice warning%}}Validation requires version 8.13 or newer of app-lib{{% /notice%}}
+{{%notice warning%}}Validation requires version 8.12.2 or newer of app-lib{{% /notice%}}
 
 Validation is useful if the service owner wishes to restrict when end users can copy instances, for example based on deadlines or changes to the application.
 

--- a/content/altinn-studio/v8/reference/configuration/messagebox/create_copy/_index.nb.md
+++ b/content/altinn-studio/v8/reference/configuration/messagebox/create_copy/_index.nb.md
@@ -72,7 +72,7 @@ Under kopiering av skjema vil logikken utføre metode kall mot **IInstantiationP
 
 ## Validering
 
-{{%notice warning%}}Validering krever versjon 8.13 eller nyere av app-lib{{% /notice%}}
+{{%notice warning%}}Validering krever versjon 8.12.2 eller nyere av app-lib{{% /notice%}}
 
 Validering er nyttig hvis tjenesteeier ønsker å begrense når brukere kan kopiere instanser, for eksempel basert på tidsfrister eller endringer i applikasjonen.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated messagebox "Create new copy" configuration documentation to reflect the correct validation requirement: app-lib version 8.12.2 or newer, corrected from version 8.13 or newer. Changes applied to both English and Norwegian language versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Altinn/altinn-studio-docs/pull/2922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->