### PR TITLE
docs/update dialogporten migration status june 02

### DIFF
--- a/content/dialogporten/status-migration/_index.en.md
+++ b/content/dialogporten/status-migration/_index.en.md
@@ -17,8 +17,8 @@ Live sync: All changes[^1] (forms, messages) show up in Dialogporten.
 
 | Source | Migrated back to |
 |----------|----------|
-| A2-Correspondence | 06.12.2016 |
-| A2 archived forms / A3-app instances | 01.01.2017 |
+| A2-Correspondence | 13.04.2014 |
+| A2 archived forms / A3-app instances | 01.07.2015 |
 
 ## Goals and plans
 
@@ -68,6 +68,8 @@ Newly archived app instances created in Altinn 2 are migrated in batches every 5
 Forms that are still being filled out are not migrated until they are archived.
 
 ## Changelog
+02.06.2026: Correspondence migrated back to 13.04.2014. Archived forms back to 01.07.2015.
+
 28.05.2026: Correspondence migrated back to 06.12.2016. Archived forms back to 01.01.2017.
 
 26.05.2026: Correspondence migrated back to 22.06.2017. Archived forms back to 01.01.2018 with the exception of a few 2018-forms that are missing. We are working to migrate these as well.

--- a/content/dialogporten/status-migration/_index.nb.md
+++ b/content/dialogporten/status-migration/_index.nb.md
@@ -17,8 +17,8 @@ Livesynkronisering: Alle endringer[^1] (skjema, meldinger) vises i Dialogporten.
 
 | Kilde | Migrert tilbake til |
 |----------|----------|
-| A2-Melding | 06.12.2016 |
-| A2 arkiverte skjema / A3-app-instanser | 01.01.2017 |
+| A2-Melding | 13.04.2014 |
+| A2 arkiverte skjema / A3-app-instanser | 01.07.2015 |
 
 ## Mål og planer
 
@@ -69,6 +69,8 @@ Nylig arkiverte app-instanser opprettet i Altinn 2 migreres i puljer hvert 5. mi
 Skjema som er under utfylling blir ikke migrert før de er arkivert.
 
 ## Endringslogg
+02.06.2026: Meldinger migrert tilbake til 13.04.2014. Arkiverte skjema tilbake til 01.07.2015.
+
 28.05.2026: Meldinger migrert tilbake til 06.12.2016. Arkiverte skjema tilbake til 01.01.2017.
 
 26.05.2026: Meldinger migrert tilbake til 22.06.2017. Arkiverte skjema tilbake til 01.01.2018 med unntak av noen få 2018-skjema som mangler. Vi jobber med å migrere disse også.


### PR DESCRIPTION
- **Start oppdatering migreringsstatus**
- **Added english version**




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated status migration documentation with revised historical data migration dates: correspondence records now show migration back to 13.04.2014 (previously 06.12.2016) and archived forms/application instances to 01.07.2015 (previously 01.01.2017).
  * Added changelog entry documenting the updated migration dates effective from 02.06.2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->