### PR TITLE
fix: Fix dead maskinporten link

### DIFF
--- a/content/api/scenarios/authentication/_index.en.md
+++ b/content/api/scenarios/authentication/_index.en.md
@@ -10,7 +10,7 @@ aliases:
 
 ## Authentication for application owners
 
-Application owners should be authenticated with [Maskinporten](https://www.digdir.no/felleslosninger/maskinporten/869).
+Application owners should be authenticated with [Maskinporten](https://samarbeid.digdir.no/maskinporten/maskinporten/25).
 
 ### API provisioning in Maskinporten
 

--- a/content/api/scenarios/authentication/_index.nb.md
+++ b/content/api/scenarios/authentication/_index.nb.md
@@ -8,7 +8,7 @@ weight: 100
 
 ## Authentication for application owners
 
-Application owners should be authenticated with [Maskinporten](https://www.digdir.no/felleslosninger/maskinporten/869).
+Application owners should be authenticated with [Maskinporten](https://samarbeid.digdir.no/maskinporten/maskinporten/25).
 
 ### API provisioning in Maskinporten
 


### PR DESCRIPTION
Replaced https://www.digdir.no/felleslosninger/maskinporten/869 with https://samarbeid.digdir.no/maskinporten/maskinporten/25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated authentication guidance documentation with current Maskinporten reference information for application owners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->