### PR TITLE
fix: align Maskinporten code example indentation

### DIFF
--- a/content/altinn-studio/v8/guides/integration/maskinporten/_index.en.md
+++ b/content/altinn-studio/v8/guides/integration/maskinporten/_index.en.md
@@ -44,30 +44,30 @@ When preparing the application to use secrets from Azure Key Vault, there are so
    - The base64 encoded JWT public and private key pair
    - The client ID for the integration
 
-   It is important that the name of these secrets in Azure Key Vault corresponds with the name of the section in the
-   appsettings file in the application repository. E.g. if your appsettings section for the Maskinporten integration section looks like this:
+It is important that the name of these secrets in Azure Key Vault corresponds with the name of the section in the
+appsettings file in the application repository. E.g. if your appsettings section for the Maskinporten integration section looks like this:
 
-   {{< code-title >}}
-   App/appsettings.json
-   {{< /code-title >}}
+{{< code-title >}}
+App/appsettings.json
+{{< /code-title >}}
 
-   ```json
-   {
-     "MaskinportenSettings": {
-       "Authority": "https://test.maskinporten.no/",
-       "ClientId": "",
-       "JwkBase64": ""
-     }
-   }
-   ```
+```json
+{
+  "MaskinportenSettings": {
+    "Authority": "https://test.maskinporten.no/",
+    "ClientId": "",
+    "JwkBase64": ""
+  }
+}
+```
 
-   The secrets in Azure Key Vault should have names like this:
+The secrets in Azure Key Vault should have names like this:
 
-   ```
-   MaskinportenSettings--Authority
-   MaskinportenSettings--ClientId
-   MaskinportenSettings--JwkBase64
-   ```
+```
+MaskinportenSettings--Authority
+MaskinportenSettings--ClientId
+MaskinportenSettings--JwkBase64
+```
 2. For the application to be able to read the secrets from Azure Key Vault, it needs to be configured to do so.
    See the [secrets section](/en/altinn-studio/v8/reference/configuration/secrets/) to achieve this.
 3. Add the appsettings section example from above into the `appsettings.{env}.json` file.

--- a/content/altinn-studio/v8/guides/integration/maskinporten/_index.en.md
+++ b/content/altinn-studio/v8/guides/integration/maskinporten/_index.en.md
@@ -63,7 +63,7 @@ App/appsettings.json
 
 The secrets in Azure Key Vault should have names like this:
 
-```
+```text
 MaskinportenSettings--Authority
 MaskinportenSettings--ClientId
 MaskinportenSettings--JwkBase64

--- a/content/altinn-studio/v8/guides/integration/maskinporten/_index.nb.md
+++ b/content/altinn-studio/v8/guides/integration/maskinporten/_index.nb.md
@@ -40,29 +40,29 @@ Når applikasjonen forberedes til å bruke hemmeligheter fra Azure Key Vault, m�
     - Base64-kodet JWT offentlig og privat nøkkelpar
     - Klient-ID for integrasjonen
 
-   Det er viktig at navnet på disse hemmelighetene i Azure Key Vault tilsvarer navnet på seksjonen i appsettings-filen i kodebasen til applikasjonen. F.eks. hvis din appsettings-seksjon for Maskinporten-integrasjonen ser slik ut:
+Det er viktig at navnet på disse hemmelighetene i Azure Key Vault tilsvarer navnet på seksjonen i appsettings-filen i kodebasen til applikasjonen. F.eks. hvis din appsettings-seksjon for Maskinporten-integrasjonen ser slik ut:
 
-   {{< code-title >}}
-   App/appsettings.json
-   {{< /code-title >}}
+{{< code-title >}}
+App/appsettings.json
+{{< /code-title >}}
 
-   ```json
-   {
-     "MaskinportenSettings": {
-       "Authority": "https://test.maskinporten.no/",
-       "ClientId": "",
-       "JwkBase64": ""
-     }
-   }
-   ```
+```json
+{
+  "MaskinportenSettings": {
+    "Authority": "https://test.maskinporten.no/",
+    "ClientId": "",
+    "JwkBase64": ""
+  }
+}
+```
 
-   Skal hemmelighetene i Azure Key Vault ha navn som dette:
+Skal hemmelighetene i Azure Key Vault ha navn som dette:
 
-   ```
-   MaskinportenSettings--Authority
-   MaskinportenSettings--ClientId
-   MaskinportenSettings--JwkBase64
-   ```
+```
+MaskinportenSettings--Authority
+MaskinportenSettings--ClientId
+MaskinportenSettings--JwkBase64
+```
 2. For at applikasjonen skal kunne lese hemmelighetene fra Azure Key Vault, må den konfigureres til å gjøre det. Se [secrets-seksjonen](/nb/altinn-studio/v8/reference/configuration/secrets/) for å oppnå dette.
 3. Legg til appsettings-eksempelet ovenfor i `appsettings.{env}.json`-filen.
 {.floating-bullet-numbers}

--- a/content/altinn-studio/v8/guides/integration/maskinporten/_index.nb.md
+++ b/content/altinn-studio/v8/guides/integration/maskinporten/_index.nb.md
@@ -58,7 +58,7 @@ App/appsettings.json
 
 Skal hemmelighetene i Azure Key Vault ha navn som dette:
 
-```
+```text
 MaskinportenSettings--Authority
 MaskinportenSettings--ClientId
 MaskinportenSettings--JwkBase64


### PR DESCRIPTION
## Summary
- Align the `App/appsettings.json` code title with the following code block in the Maskinporten Azure Key Vault guide.
- Apply the same Markdown structure to both Norwegian and English v8 Maskinporten docs.
- Mark the Key Vault secret-name examples as `text` code blocks.

## Testing
- `hugo --minify`
- Browser verification against local Hugo server at `1680px` width with the manual setup expander open.
- Alignment measured in browser: `code-title` left `434px`, code block left `434px`.

## Screenshot
Full-page screenshot with the manual setup expander open:

![Full-page screenshot showing aligned Maskinporten code example](https://tmpfiles.org/dl/wqwCK2ncEpcf/maskinporten-indent-fix-fullpage.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined Azure Key Vault configuration documentation for Maskinporten integration to provide clearer instructions with improved code example formatting and explicit secret naming conventions. Available in English and Norwegian Bokmål.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
