### PR TITLE
docs(notifications): rewrite SMS segmentation around actual GSM segmentation

### DIFF
--- a/content/notifications/explanation/sms-segmentation/_index.en.md
+++ b/content/notifications/explanation/sms-segmentation/_index.en.md
@@ -1,122 +1,70 @@
 ---
-title: SMS Segmentation
-description: "Altinn Notifications automatically splits long SMS messages into multiple segments to ensure delivery. This article explains how SMS segmentation works, which character limits apply, and what will and will not work when using the API."
-linktitle: SMS Segmentation
+title: SMS segmentation
+description: "Long SMS messages are automatically split into several segments so they can be delivered. This article explains how SMS segmentation works, how the characters in a message determine the number of segments, and what this means for the cost."
+linktitle: SMS segmentation
 tags: [sms, segmentation, character limit]
 weight: 40
 ---
 
 ## Introduction
 
-SMS messages have technical limitations on how many characters can be sent in a single message. When you send SMS via Altinn Notifications, the system automatically handles the splitting of long messages into multiple segments. This allows you to send longer texts without having to split them manually.
+An SMS can only hold a limited number of characters. When you send a longer message through Altinn Notifications, it is automatically split into several parts, called segments. The recipient still sees a single, continuous message, because the phone reassembles the segments.
 
-Understanding how segmentation works is important to ensure that your messages are delivered as expected and to avoid messages being rejected due to length limitations.
+It is useful to understand how this splitting works, because each segment is counted and charged as a separate SMS. A message that looks short can still become several segments if it contains certain characters. The characters you use therefore affect both the cost and how much text there is room for.
 
-## How SMS segmentation works
+## The character encoding determines the segment length
 
-SMS technology has two different modes for message length:
+How many characters fit in each segment depends on how the text is encoded. An SMS is sent in one of two ways, and the receiving phone chooses automatically based on which characters the message contains:
 
-### Single message (up to 160 characters)
+- **GSM-7** is the standard alphabet for SMS. It covers ordinary letters, numbers and punctuation, and **the Norwegian letters æ, ø and å** (including capitals). As long as the message only uses characters from this alphabet, there is plenty of room in each segment.
+- **UCS-2** is used when the message contains at least one character that is not in the GSM-7 alphabet, for example an emoji or a non-Latin character. The whole message is then encoded in a way that takes more space, leaving room for far fewer characters per segment.
 
-If your message is **160 characters or shorter**, it is sent as a single SMS. This is the most efficient way to send short messages.
+A single character outside the GSM-7 alphabet is enough to switch the whole message to UCS-2. This more than halves the available space, as the table below shows.
 
-### Concatenated messages (over 160 characters)
+## How many characters fit
 
-When the message is **longer than 160 characters**, it is automatically split into multiple segments that are sent separately and reassembled on the recipient's phone. Each segment in a concatenated message can contain **up to 134 characters**.
+| Character encoding | Single message | Per segment in a split message |
+|--------------------|----------------|--------------------------------|
+| GSM-7 (ordinary text, including æ, ø, å) | 160 characters | 153 characters |
+| UCS-2 (emoji, typographic characters, non-Latin characters) | 70 characters | 67 characters |
 
-{{% notice info %}}
-The reason segments are 134 characters instead of 160 characters is that some space is used for metadata that tells the recipient's phone how to reassemble the segments.
-{{% /notice %}}
+When a message has to be split, part of the space in each segment is used for joining information, that is, the data the phone needs to put the segments back together in the right order. Each segment therefore holds slightly less than a single message: 153 characters with GSM-7 and 67 characters with UCS-2.
 
-## Character limitations
+### Characters that count double in GSM-7
 
-Altinn Notifications has the following limitations for SMS messages:
+Some characters are part of GSM-7, but live in a separate extension table, and each of them counts as **two** characters:
 
-- **Single message**: up to **160 characters**
-- **Concatenated message**: up to **134 characters per segment**
-- **Maximum number of segments**: **16 segments**
-- **Maximum total length**: **2144 characters** (16 × 134 characters)
+- `^ { } \ [ ] ~ |`
+- `€` (the euro sign)
 
-{{% notice warning %}}
-The maximum limit of 16 segments is a limitation in the SMS gateway that Altinn Notifications uses. Messages that exceed this limit are truncated to the first 16 segments.
-{{% /notice %}}
+If you use several curly brackets or euro signs, for example, the message fills up faster than the number of visible characters suggests.
 
-### Segmentation examples
+## Number of segments and upper limit
 
-| Message length | Number of segments | Description |
-|----------------|-------------------|-------------|
-| 50 characters | 1 | Sent as a single SMS |
-| 160 characters | 1 | Sent as a single SMS (maximum length) |
-| 161 characters | 2 | Split into 2 segments (134 + 27 characters) |
-| 268 characters | 2 | Split into 2 segments (134 + 134 characters) |
-| 269 characters | 3 | Split into 3 segments (134 + 134 + 1 character) |
-| 2144 characters | 16 | Split into 16 segments (maximum length) |
-| 2145 characters | 16 | Truncated to 16 segments (content shortened) |
+A message can become up to **16 segments** in Altinn Notifications. How much text this allows in total depends on the character encoding:
 
-## Special characters and URL encoding
+- With **GSM-7**, the upper limit is 16 × 153 characters.
+- With **UCS-2**, the upper limit is 16 × 67 characters.
 
-When the system calculates message length, **URL-encoded length** is used. This means that certain special characters count as more than one character.
+There is therefore no single fixed cap on the number of characters. The cap depends on which characters the message contains. A message with only ordinary text fits far more than a message with an emoji or other special characters.
 
-### Characters that affect length
+Messages longer than 16 segments are truncated. The full text then does not reach the recipient, so it is important to keep long messages within the limit.
 
-The following types of characters can affect the actual length of the message:
+## Example: one character can double the cost
 
-- **Æ, Ø, Å** and other national special characters
-- **Emojis** and other special symbols
-- **Line breaks** and other control characters
+Imagine a 70-character message that uses only ordinary letters:
 
-### Practical example
+- Written as ordinary text (GSM-7), it fits in **one** SMS, since the limit is 160 characters. You pay for one segment.
+- Replace the straight quotation mark `"` with a typographic one (`"` or `"`), or add a single emoji, and the whole message switches to UCS-2. The limit for a single message is then 70 characters, and a 70-character message fills it exactly. Add a little more text and it splits into **two** segments of 67 characters each, and you pay for two.
 
-```text
-Original message: "Meeting at 14:00"
-Character length: 16 characters
-URL-encoded length: 22 characters (38% longer)
-```
+A single "smart" quotation mark, a dash (– or —) or an emoji can therefore move the message from GSM-7 to UCS-2 and more than double the number of segments, and with it the cost.
 
-The example shows how spaces become "%20" (3 characters) and colons become "%3A" (3 characters) in URL encoding.
+## Advice for keeping costs down
 
-{{% notice info %}}
-To be sure that your message does not exceed the limits, you should test with representative examples that contain the same types of special characters you plan to use.
-{{% /notice %}}
+To avoid messages becoming more expensive or longer than necessary:
 
-## Limitations and what does not work
-
-### What happens to messages over 2144 characters?
-
-When a message (measured in URL-encoded length) exceeds 2144 characters:
-
-- The message is **automatically truncated** to the first 16 segments (2144 characters)
-- Content beyond this limit **is not sent**
-- You receive **no error message** from the API indicating that the content has been truncated
-
-{{% notice warning %}}
-The API will not notify you that the message has been truncated. It is therefore essential to test message length in advance, especially if you are using many special characters.
-{{% /notice %}}
-
-### Recommendations
-
-To ensure that your messages are delivered as expected:
-
-1. **Keep messages short and concise** - under 160 characters if possible
-2. **Avoid unnecessary emojis** - these can significantly increase the length
-3. **Test with representative data** - use special characters similar to what you will use in production
-4. **Plan for segmentation** - if you know the message will be long, ensure it still makes sense even when split up
-5. **Consider alternative channels** - for longer messages, email may be a better choice
-
-## How the API handles segmentation
-
-When you send an SMS via the Altinn Notifications API:
-
-1. **You send the entire message** - you do not need to split it yourself
-2. **The system calculates the length** - based on URL-encoded length
-3. **The system calculates the number of segments** - and limits to a maximum of 16 segments
-4. **The system splits the message** - automatically into segments if necessary
-5. **The message is sent** - segments are delivered to the SMS gateway
-
-{{% notice warning %}}
-If the URL-encoded length of the message requires more than 16 segments, only the first 16 segments (2144 characters) are sent. You receive no error message about this, so it is important to validate message length in advance.
-{{% /notice %}}
-
-{{% notice info %}}
-You cannot control how the message is split into segments. The splitting happens automatically based on the character limits described in this article.
-{{% /notice %}}
+- keep messages short. The shorter the text, the greater the chance it fits in a single segment
+- be careful with emoji and typographic characters. A single such character can halve the available space and double the cost
+- watch which quotation marks and dashes you paste in. Characters from word processors are often typographic variants that trigger UCS-2. Use the straight `"` and the hyphen `-` instead
+- keep long messages within 16 segments. Text beyond the limit is truncated and does not arrive
+- consider email for longer content. SMS is best suited to short messages

--- a/content/notifications/explanation/sms-segmentation/_index.nb.md
+++ b/content/notifications/explanation/sms-segmentation/_index.nb.md
@@ -1,122 +1,70 @@
 ---
 title: SMS-segmentering
-description: "Altinn Varslinger deler automatisk opp lange SMS-meldinger i flere segmenter for å sikre levering. Denne artikkelen forklarer hvordan SMS-segmentering fungerer, hvilke tegnbegrensninger som gjelder, og hva som fungerer og ikke fungerer når du bruker API-et."
+description: "Lange SMS-meldinger deles automatisk opp i flere segmenter for å kunne leveres. Denne artikkelen forklarer hvordan SMS-segmentering fungerer, hvordan tegnene i meldingen avgjør hvor mange segmenter den blir, og hva det betyr for kostnaden."
 linktitle: SMS-segmentering
 tags: [sms, segmentering, tegnbegrensning]
 weight: 40
 ---
 
-## Introduksjon
+## Innledning
 
-SMS-meldinger har tekniske begrensninger på hvor mange tegn som kan sendes i én enkelt melding. Når du sender SMS via Altinn Varslinger, håndterer systemet automatisk oppdeling av lange meldinger i flere segmenter. Dette gjør at du kan sende lengre tekster uten å måtte dele dem opp manuelt.
+En SMS kan bare inneholde et begrenset antall tegn. Når du sender en lengre melding gjennom Altinn Varslinger, deles den automatisk opp i flere deler, kalt segmenter. Mottakeren ser fortsatt én sammenhengende melding, fordi telefonen setter segmentene sammen igjen.
 
-Å forstå hvordan segmentering fungerer er viktig for å sikre at meldingene dine leveres som forventet, og for å unngå at meldinger blir avvist på grunn av lengdebegrensninger.
+Det er nyttig å forstå hvordan denne oppdelingen fungerer, for hvert segment teller og faktureres som en egen SMS. En melding som ser kort ut, kan likevel bli til flere segmenter dersom den inneholder visse tegn. Tegnene du bruker, påvirker altså både kostnaden og hvor mye tekst det er plass til.
 
-## Hvordan SMS-segmentering fungerer
+## Tegnkodingen bestemmer segmentlengden
 
-SMS-teknologien har to forskjellige måter å håndtere meldingslengde på:
+Hvor mange tegn det er plass til i hvert segment, avhenger av hvordan teksten kodes. En SMS sendes på én av to måter, og mottelefonen velger automatisk ut fra hvilke tegn meldingen inneholder:
 
-### Enkeltmelding (opp til 160 tegn)
+- **GSM-7** er standardalfabetet for SMS. Det dekker vanlige bokstaver, tall og tegnsetting, og **de norske bokstavene æ, ø og å** (også store). Så lenge meldingen bare bruker tegn fra dette alfabetet, er det god plass i hvert segment.
+- **UCS-2** brukes når meldingen inneholder minst ett tegn som ikke finnes i GSM-7-alfabetet, for eksempel en emoji eller et ikke-latinsk tegn. Da kodes hele meldingen på en måte som tar mer plass, og det blir plass til langt færre tegn per segment.
 
-Hvis meldingen din inneholder **160 tegn eller mindre**, sendes den som én enkelt SMS. Dette er den mest effektive måten å sende korte meldinger på.
+Det holder med ett eneste tegn utenfor GSM-7-alfabetet for at hele meldingen går over til UCS-2. Da blir plassen mer enn halvert, slik tabellen under viser.
 
-### Konkatenerte meldinger (over 160 tegn)
+## Hvor mange tegn det er plass til
 
-Når meldingen er **lengre enn 160 tegn**, deles den automatisk opp i flere segmenter som sendes separat og settes sammen igjen på mottakerens telefon. Hvert segment i en konkatenert melding kan inneholde **opp til 134 tegn**.
+| Tegnkoding | Enkeltmelding | Per segment i en oppdelt melding |
+|------------|---------------|----------------------------------|
+| GSM-7 (vanlig tekst, inkludert æ, ø, å) | 160 tegn | 153 tegn |
+| UCS-2 (emoji, typografiske tegn, ikke-latinske tegn) | 70 tegn | 67 tegn |
 
-{{% notice info %}}
-Grunnen til at segmentene er på 134 tegn i stedet for 160 tegn, er at noe plass brukes til metadata som forteller mottakerens telefon hvordan segmentene skal settes sammen igjen.
-{{% /notice %}}
+Når en melding må deles opp, går noe av plassen i hvert segment med til skjøteinformasjon, altså opplysninger telefonen trenger for å sette segmentene sammen i riktig rekkefølge. Derfor rommer hvert segment litt mindre enn en enkeltmelding: 153 tegn med GSM-7 og 67 tegn med UCS-2.
 
-## Tegnbegrensninger
+### Tegn som teller dobbelt i GSM-7
 
-Altinn Varslinger har følgende begrensninger for SMS-meldinger:
+Noen tegn finnes i GSM-7, men i en egen utvidelsestabell, og hvert av dem teller som **to** tegn:
 
-- **Enkeltmelding**: opp til **160 tegn**
-- **Konkatenert melding**: opp til **134 tegn per segment**
-- **Maksimalt antall segmenter**: **16 segmenter**
-- **Maksimal totallengde**: **2144 tegn** (16 × 134 tegn)
+- `^ { } \ [ ] ~ |`
+- `€` (eurotegnet)
 
-{{% notice warning %}}
-Den maksimale grensen på 16 segmenter er en begrensning i SMS-gatewayen som Altinn Varslinger bruker. Meldinger som overskrider denne grensen avkortes til de første 16 segmentene.
-{{% /notice %}}
+Bruker du for eksempel flere krøllparenteser eller eurotegn, fylles meldingen raskere enn antall synlige tegn skulle tilsi.
 
-### Eksempel på segmentering
+## Antall segmenter og øvre grense
 
-| Meldingslengde | Antall segmenter | Beskrivelse |
-|----------------|------------------|-------------|
-| 50 tegn | 1 | Sendes som én enkelt SMS |
-| 160 tegn | 1 | Sendes som én enkelt SMS (maksimal lengde) |
-| 161 tegn | 2 | Deles i 2 segmenter (134 + 27 tegn) |
-| 268 tegn | 2 | Deles i 2 segmenter (134 + 134 tegn) |
-| 269 tegn | 3 | Deles i 3 segmenter (134 + 134 + 1 tegn) |
-| 2144 tegn | 16 | Deles i 16 segmenter (maksimal lengde) |
-| 2145 tegn | 16 | Avkortes til 16 segmenter (innhold forkortes) |
+En melding kan bli inntil **16 segmenter** i Altinn Varslinger. Hvor mye tekst det gir plass til totalt, avhenger av tegnkodingen:
 
-## Spesialtegn og URL-koding
+- Med **GSM-7** er den øvre grensen 16 × 153 tegn.
+- Med **UCS-2** er den øvre grensen 16 × 67 tegn.
 
-Når systemet beregner meldingslengden, måles lengden basert på **URL-kodet format**. Dette betyr at visse spesialtegn teller som mer enn ett tegn.
+Det finnes altså ikke ett fast tak på antall tegn. Taket avhenger av hvilke tegn meldingen inneholder. En melding med bare vanlig tekst får plass til mye mer enn en melding med emoji eller andre spesialtegn.
 
-### Tegn som påvirker lengden
+Meldinger som er lengre enn 16 segmenter, blir avkortet. Da kommer ikke hele teksten fram til mottakeren, og derfor er det viktig å holde lange meldinger innenfor grensen.
 
-Følgende typer tegn kan påvirke den faktiske lengden av meldingen:
+## Eksempel: ett tegn kan doble kostnaden
 
-- **Æ, Ø, Å** og andre nasjonale spesialtegn
-- **Emojier** og andre spesialsymboler
-- **Linjeskift** og andre kontrolltegn
+Tenk deg en melding på 70 tegn som bare bruker vanlige bokstaver:
 
-### Praktisk eksempel
+- Skrevet med vanlig tekst (GSM-7) får den plass i **én** SMS, siden grensen er 160 tegn. Du betaler for ett segment.
+- Bytter du ut det vanlige sitattegnet `"` med et typografisk anførselstegn (`"` eller `"`), eller legger til én emoji, går hele meldingen over til UCS-2. Da er grensen 70 tegn for en enkeltmelding, og en melding på 70 tegn fyller akkurat opp. Legger du til litt mer tekst, deles den i **to** segmenter à 67 tegn, og du betaler for to.
 
-```text
-Original melding: "Møte kl. 14:00"
-Lengde i tegn: 14 tegn
-URL-kodet lengde: 25 tegn (nesten dobbelt så lang)
-```
+Ett enkelt «smart» anførselstegn, en tankestrek (– eller —) eller en emoji kan altså flytte meldingen fra GSM-7 til UCS-2 og mer enn doble antall segmenter, og dermed kostnaden.
 
-Eksempelet viser hvordan norske tegn som "ø" blir til "%C3%B8" (6 tegn) og mellomrom blir til "%20" (3 tegn) i URL-koding.
+## Råd for å holde kostnaden nede
 
-{{% notice info %}}
-For å være sikker på at meldingen din ikke overstiger grensene, bør du teste med representative eksempler som inneholder de samme typene spesialtegn du planlegger å bruke.
-{{% /notice %}}
+For å unngå at meldingene blir dyrere eller lengre enn nødvendig:
 
-## Begrensninger og hva som ikke fungerer
-
-### Hva skjer med meldinger over 2144 tegn?
-
-Når en melding (målt i URL-kodet lengde) overskrider 2144 tegn:
-
-- Meldingen **avkortes automatisk** til de første 16 segmentene (2144 tegn)
-- Innhold utover denne grensen **sendes ikke**
-- Du får **ingen feilmelding** fra API-et om at innholdet er avkortet
-
-{{% notice warning %}}
-API-et vil ikke varsle deg om at meldingen er avkortet. Det er derfor svært viktig å teste meldingslengden på forhånd, spesielt hvis du bruker mange spesialtegn.
-{{% /notice %}}
-
-### Anbefalinger
-
-For å sikre at meldingene dine leveres som forventet:
-
-1. **Hold meldinger korte og konsise** - under 160 tegn om mulig
-2. **Unngå unødvendige emojier** - disse kan øke lengden betydelig
-3. **Test med representative data** - bruk spesialtegn som ligner på det du vil bruke i produksjon
-4. **Planlegg for segmentering** - dersom du vet at meldingen blir lang, sørg for at den fortsatt gir mening selv om den deles opp
-5. **Vurder alternative kanaler** - for lengre meldinger kan e-post være et bedre valg
-
-## Hvordan API-et håndterer segmentering
-
-Når du sender en SMS via Altinn Varslinger API-et:
-
-1. **Du sender hele meldingen** - du trenger ikke dele den opp selv
-2. **Systemet beregner lengden** - basert på URL-kodet lengde
-3. **Systemet beregner antall segmenter** - og begrenser til maksimalt 16 segmenter
-4. **Systemet deler opp meldingen** - automatisk i segmenter dersom nødvendig
-5. **Meldingen sendes** - segmentene leveres til SMS-gatewayen
-
-{{% notice warning %}}
-Hvis den URL-kodede lengden av meldingen krever mer enn 16 segmenter, sendes kun de første 16 segmentene (2144 tegn). Du får ingen feilmelding om dette, så det er viktig å validere meldingslengden på forhånd.
-{{% /notice %}}
-
-{{% notice info %}}
-Du kan ikke kontrollere hvordan meldingen deles opp i segmenter. Oppdelingen skjer automatisk basert på tegngrensene beskrevet i denne artikkelen.
-{{% /notice %}}
+- Hold meldingene korte. Jo kortere teksten er, desto større er sjansen for at den får plass i ett segment.
+- Vær forsiktig med emoji og typografiske tegn. Ett enkelt slikt tegn kan halvere plassen og doble kostnaden.
+- Pass på hvilke anførselstegn og tankestreker du kopierer inn. Tegn fra tekstbehandlere er ofte typografiske varianter som utløser UCS-2. Bruk heller vanlig `"` og bindestrek `-`.
+- Hold lange meldinger innenfor 16 segmenter. Tekst utover grensen blir avkortet og kommer ikke fram.
+- Vurder e-post for lengre innhold. SMS egner seg best til korte beskjeder.


### PR DESCRIPTION
Addresses **Altinn/team-core-private#493**.

Rewrites the SMS segmentation explanation page so it describes the **actual** SMS segmentation that the operator performs and that the service owner is billed for, instead of Altinn's current internal (and incorrect) estimate.

## Changes
- **GSM-7** (ordinary text, including Norwegian æ ø å): **160** chars single / **153** per concatenated segment.
- **UCS-2** (triggered by any character outside GSM-7, e.g. emoji, typographic quotes/dashes, non-Latin): **70** / **67**.
- GSM-7 extension characters (`^ { } \ [ ] ~ |` and `€`) count as **two**.
- Up to **16 segments**; total length depends on encoding (16×153 or 16×67), not a single fixed number.
- Worked example showing how a single special character switches the whole message to UCS-2 and can double the cost.
- Advice section aimed at (non-technical) service owners focused on cost.

Removes the previous tables and numbers (134 chars/segment, 2144 max) that were derived from a **URL-encoded length** calculation. Both Norwegian (source) and English versions updated and language-reviewed.

## ⚠️ Depends on a code fix — likely bug in altinn-notifications
This rewrite assumes the segment count will be fixed in code. Today the code counts segments from the **URL-encoded** length of the message, while the **raw** message is what is actually sent to Link Mobility. This over-counts segments for any message with characters that expand under URL-encoding (e.g. `ø` → `%c3%b8`).

- Count uses URL-encoded length: `SmsOrderProcessingService.cs:138-162` (`CalculateSegmentCount`), duplicated in `InstantOrderRequestService.cs:154-178`. The constant `134` matches neither GSM-7 (153) nor UCS-2 (67).
- Raw message sent to gateway: `SmsClient.cs:54`.
- Count persisted as `smsMessageCount`: `OrderRepository.cs:714,725`.

A separate code issue should be filed in `altinn-notifications` for this. **Until the code is fixed, the segment count shown in Altinn may differ from what this page describes.**

## Open questions for reviewers
- The 153/67 figures and double-counting characters are the GSM standard; they have **not** been verified against Link Mobility's exact configuration.
- Once the code is fixed, decide whether the page should also state which segment count the service owner sees in Altinn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)