### PR TITLE
Added documentation for hideAppNameInPdf

### DIFF
--- a/content/altinn-studio/v8/reference/ux/pdf/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/pdf/_index.en.md
@@ -375,7 +375,7 @@ The footer will contain the following information:
 
   ![PDF footer example](pdf-footer-example.png)
 
-## Hide app name in PDF
+## Hide the app name in PDF
 
 You can hide the app name in the header and footer of the generated PDF by setting `hideAppNameInPdf` in `uiSettings` in `layout-sets.json`.
 

--- a/content/altinn-studio/v8/reference/ux/pdf/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/pdf/_index.en.md
@@ -67,9 +67,9 @@ Depending on the version you are using, the programmatic method is set up differ
 1. Create a class that implements the `IPdfFormatter` interface found in the `Altinn.App.Core.Features.Pdf` namespace.  
    You can name and place the file in any folder you like within your project, but we suggest you use meaningful namespaces like in any other .Net project.
 2. Register you custom implementation in the _Program.cs_ class.
-   `C#
- services.AddTransient<IPdfFormatter, PdfFormatter>();
- `
+   ```C#
+    services.AddTransient<IPdfFormatter, PdfFormatter>();
+   ```
    This ensures your custom code is known to the application and that it will be executed.
    {{</content-version-container>}}
 
@@ -379,7 +379,7 @@ The footer will contain the following information:
 
 You can hide the app name in the header and footer of the generated PDF by setting `hideAppNameInPdf` in `uiSettings` in `layout-sets.json`.
 
-The property accepts `true`, `false`, or a boolean [dynamic expression](/altinn-studio/v8/reference/logic/expressions/). The expression must evaluate to `true` or `false` — string expressions are not supported.
+The property accepts `true`, `false`, or a boolean [dynamic expression](/en/altinn-studio/v8/reference/logic/expressions/). The expression must evaluate to `true` or `false` — string expressions are not supported.
 
 ```json {linenos=false,hl_lines=["3"]}
 {
@@ -389,7 +389,7 @@ The property accepts `true`, `false`, or a boolean [dynamic expression](/altinn-
 }
 ```
 
-See [dynamic expressions](/altinn-studio/v8/reference/logic/expressions/) for more information.
+See [dynamic expressions](/en/altinn-studio/v8/reference/logic/expressions/) for more information.
 
 ## Prototype PDF in Figma
 

--- a/content/altinn-studio/v8/reference/ux/pdf/_index.en.md
+++ b/content/altinn-studio/v8/reference/ux/pdf/_index.en.md
@@ -5,8 +5,11 @@ weight: 50
 ---
 
 {{%notice warning%}}
+
 ## New PDF generation
+
 ### Enable feature
+
 As of version 7.5 of the nuget packages (Altinn.App.Api and Altinn.App.Core) a new way of generating PDFs launched as a preview. This feature can be toggled on/off by adding the following section and feature toggle in _appsettings.json_.
 
 ```json
@@ -18,6 +21,7 @@ As of version 7.5 of the nuget packages (Altinn.App.Api and Altinn.App.Core) a n
 This will call the new PDF service which accepts a URL pointing back to an automatic generated page in the app. The rendered page is then used as the foundation for the PDF. The `IPdfFormatter` as documented below is still relevant if you need custom logic for excluding components/pages from PDF.
 
 ### Settings
+
 While the default settings for the new service should be enough for most applications they can be overridden by adding a PdfGeneratorSettings section in _appsettings.json_ (default settings shown below).
 
 ```json
@@ -61,13 +65,13 @@ Depending on the version you are using, the programmatic method is set up differ
 {{<content-version-container version-label="v7">}}
 
 1. Create a class that implements the `IPdfFormatter` interface found in the `Altinn.App.Core.Features.Pdf` namespace.  
-    You can name and place the file in any folder you like within your project, but we suggest you use meaningful namespaces like in any other .Net project.
+   You can name and place the file in any folder you like within your project, but we suggest you use meaningful namespaces like in any other .Net project.
 2. Register you custom implementation in the _Program.cs_ class.
-    ```C#
-    services.AddTransient<IPdfFormatter, PdfFormatter>();
-    ```
-    This ensures your custom code is known to the application and that it will be executed.
-{{</content-version-container>}}
+   `C#
+ services.AddTransient<IPdfFormatter, PdfFormatter>();
+ `
+   This ensures your custom code is known to the application and that it will be executed.
+   {{</content-version-container>}}
 
 {{<content-version-container version-label="v4, v5, v6">}}
 Modify the `PdfHandler.cs` file under `App/logic/Print`.
@@ -83,11 +87,11 @@ Add a list of page names to exclude called `excludeFromPdf` under `pages`:
 
 ```json {linenos=false,hl_lines=["5"]}
 {
-   "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
-   "pages": {
-      "order": ["page1", "page2"],
-      "excludeFromPdf": ["page2"]
-   }
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": ["page1", "page2"],
+    "excludeFromPdf": ["page2"]
+  }
 }
 ```
 
@@ -103,6 +107,7 @@ public async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, objec
   return await Task.FromResult(layoutSettings);
 }
 ```
+
 <br>
 
 **Note**: You only need to choose one of the above methods.
@@ -116,13 +121,13 @@ Add a list of component IDs to exclude called `excludeFromPdf` under `components
 
 ```json {linenos=false,hl_lines=["7"]}
 {
-   "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
-   "pages": {
-      "order": ["page1"]
-   },
-   "components": {
-      "excludeFromPdf": ["image-component-id"]
-   }
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": ["page1"]
+  },
+  "components": {
+    "excludeFromPdf": ["image-component-id"]
+  }
 }
 ```
 
@@ -138,6 +143,7 @@ public async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, objec
   return await Task.FromResult(layoutSettings);
 }
 ```
+
 <br>
 
 **Note**: You only need to choose one of the above methods.
@@ -152,13 +158,13 @@ The required format is: `componentId-<groupIndex>`.
 
 ```json {linenos=false,hl_lines=["7"]}
 {
-   "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
-   "pages": {
-      "order": ["page1"]
-   },
-   "components": {
-      "excludeFromPdf": ["ownerId-1"]
-   }
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": ["page1"]
+  },
+  "components": {
+    "excludeFromPdf": ["ownerId-1"]
+  }
 }
 ```
 
@@ -174,6 +180,7 @@ public async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, objec
   return await Task.FromResult(layoutSettings);
 }
 ```
+
 <br>
 
 **Note**: You only need to choose one of the above methods.
@@ -198,16 +205,18 @@ If you add a [Summary]({{< ref "altinn-studio/v8/reference/ux/components/summary
 ![Screenshot of a summary2 component in a PDF layout page](pdf-summary-component.png)
 
 ### Manual configuration
+
 This method lets you fully customize the generated PDF by using a layout file to specify what it should contain.
 
 To use this method you need to create a new layout file for the PDF and set `pdfLayoutName` in `Settings.json` to point to that file:
+
 ```json {linenos=false,hl_lines=["5"]}
 {
-   "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
-   "pages": {
-      "order": ["page1"],
-      "pdfLayoutName": "myPdfLayout"
-   }
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": ["page1"],
+    "pdfLayoutName": "myPdfLayout"
+  }
 }
 ```
 
@@ -257,23 +266,23 @@ You can specify that a component should start on a new page or that a page break
 
 ```json {linenos=false,hl_lines=["12-15"]}
 {
-   "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layout.schema.v1.json",
-   "data": {
-      "layout": [
-         {
-            "id": "pdf-header",
-            "type": "Header",
-            "textResourceBindings": {
-               "title": "This is a new section"
-            },
-            "size": "L",
-            "pageBreak": {
-               "breakBefore": "always",
-               "breakAfter": "avoid"
-            }
-         }
-      ]
-   }
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layout.schema.v1.json",
+  "data": {
+    "layout": [
+      {
+        "id": "pdf-header",
+        "type": "Header",
+        "textResourceBindings": {
+          "title": "This is a new section"
+        },
+        "size": "L",
+        "pageBreak": {
+          "breakBefore": "always",
+          "breakAfter": "avoid"
+        }
+      }
+    ]
+  }
 }
 ```
 
@@ -286,19 +295,17 @@ It is possible to exclude child components from a group by using the `excludedCh
 
 ```json {linenos=false,hl_lines=["10"]}
 {
-   "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layout.schema.v1.json",
-   "data": {
-      "layout": [
-         {
-            "id": "pdf-group-summary",
-            "type": "Summary",
-            "componentRef": "some-group-component",
-            "excludedChildren": [
-               "some-child-component"
-            ]
-         }
-      ]
-   }
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layout.schema.v1.json",
+  "data": {
+    "layout": [
+      {
+        "id": "pdf-group-summary",
+        "type": "Summary",
+        "componentRef": "some-group-component",
+        "excludedChildren": ["some-child-component"]
+      }
+    ]
+  }
 }
 ```
 
@@ -366,11 +373,27 @@ The footer will contain the following information:
 - The Altinn reference ID
 - The page number
 
-   ![PDF footer example](pdf-footer-example.png)
+  ![PDF footer example](pdf-footer-example.png)
 
-## Prototype PDF in Figma 
+## Hide app name in PDF
+
+You can hide the app name in the header and footer of the generated PDF by setting `hideAppNameInPdf` in `uiSettings` in `layout-sets.json`.
+
+The property accepts `true`, `false`, or a boolean [dynamic expression](/altinn-studio/v8/reference/logic/expressions/). The expression must evaluate to `true` or `false` — string expressions are not supported.
+
+```json {linenos=false,hl_lines=["3"]}
+{
+  "uiSettings": {
+    "hideAppNameInPdf": true
+  }
+}
+```
+
+See [dynamic expressions](/altinn-studio/v8/reference/logic/expressions/) for more information.
+
+## Prototype PDF in Figma
 
 If you want to test and set up your PDF, you can do it here:  
 [Altinn Studio Komponenter](https://www.figma.com/community/file/1344307804742953785/altinn-studio-komponenter).
- 
+
 Note that the example is not identical to the actual code but has been adapted to create prototypes in Figma.

--- a/content/altinn-studio/v8/reference/ux/pdf/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/pdf/_index.nb.md
@@ -67,9 +67,9 @@ Den programmatiske metoden du velger å sette opp er avhengig av hvilken versjon
 1. Opprett en klasse som implementerer `IPdfFormatter`-grensesnittet som ligger i `Altinn.App.Core.Features`-navnerommet.  
    Du kan navngi og plassere filene i den mappestrukturen du selv ønsker i prosjektet ditt. Men vi anbefaler at du benytter meningsfulle navnerom som i et hvilket som helst annet .Net-prosjekt.
 2. Registrer din implementering i _Program.cs_-klassen.
-   `C#
- services.AddTransient<IPdfFormatter, PdfFormatter>();
- `
+   ```C#
+    services.AddTransient<IPdfFormatter, PdfFormatter>();
+   ```
    Dette sørger for at din kode er kjent for applikasjonen og at koden blir kjørt når den skal.
    {{</content-version-container>}}
 

--- a/content/altinn-studio/v8/reference/ux/pdf/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/pdf/_index.nb.md
@@ -198,7 +198,7 @@ Du kan bruke komponenten [Oppsummering]({{< ref "altinn-studio/v8/reference/ux/c
 
 ![Skjermbilde av en oppsummeringskomponent i en PDF-oppsett-side](pdf-summary-component.png)
 
-### Manual configuration
+### Manuell konfigurasjon
 
 {{%notice warning%}}
 

--- a/content/altinn-studio/v8/reference/ux/pdf/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/pdf/_index.nb.md
@@ -18,11 +18,11 @@ Fra og med versjon 7.5 av nuget-pakkene (Altinn.App.Api og Altinn.App.Core) er d
   }
 ```
 
-Dette vil sørge for at den nye PDF-tjenesten kalles. Denne aksepterer en URL som peker tilbake til en automatisk generert side i appen. Siden bygges opp og danner grunnlaget for PDF-en. Grensesnittet `IPdfFormatter` som dokumentert nedenfor er fortsatt relevant hvis du trenger spesiallogikk for å skjule komponenter/sider fra PDF-en.
+Dette kaller den nye PDF-tjenesten. Den aksepterer en URL, som peker tilbake til en automatisk generert side i appen. Siden bygges opp og danner grunnlaget for PDF-en. Grensesnittet `IPdfFormatter`, som dokumentert under er fortsatt relevant hvis du trenger spesiallogikk for å skjule komponenter/sider fra PDF-en.
 
 ### Innstillinger
 
-Selv om standardinnstillingene for den nye tjenesten skal være nok for de fleste applikasjoner, kan de overstyres ved å legge til en PdfGeneratorSettings-seksjon i _appsettings.json_ (standardinnstillinger vises under).
+Selv om standardinnstillingene for den nye tjenesten skal være nok for de fleste apper, kan du overstyre dem ved å legge til en PdfGeneratorSettings-seksjon i _appsettings.json_ (se standardinnstillingene under).
 
 ```json
   "PdfGeneratorSettings": {
@@ -59,14 +59,14 @@ Dette kan konfigureres på to ulike måter:
 1. Ved å modifisere `Settings.json`-filen for layout-settet.
 2. Programmatisk ved å implementere det i kode. Dette åpner for dynamisk ekskludering basert på skjemadataen.
 
-Avhengig av hvilken versjon du kjører setter man opp den programmatiske metoden litt forskjellig, men logikken er helt lik. Oversikten under viser hvordan det settes opp for versjonen du kjører:
+Den programmatiske metoden du velger å sette opp er avhengig av hvilken versjon du kjører, men logikken er helt lik. Oversikten under viser hvordan du setter det opp for den versjonen du kjører:
 {{<content-version-selector classes="border-box">}}
 
 {{<content-version-container version-label="v7">}}
 
 1. Opprett en klasse som implementerer `IPdfFormatter`-grensesnittet som ligger i `Altinn.App.Core.Features`-navnerommet.  
    Du kan navngi og plassere filene i den mappestrukturen du selv ønsker i prosjektet ditt. Men vi anbefaler at du benytter meningsfulle navnerom som i et hvilket som helst annet .Net-prosjekt.
-2. Registrér din implementering i _Program.cs_-klassen.
+2. Registrer din implementering i _Program.cs_-klassen.
    `C#
  services.AddTransient<IPdfFormatter, PdfFormatter>();
  `
@@ -374,9 +374,9 @@ Footeren vil inneholde følgende informasjon:
 
   ![PDF footer eksempel](pdf-footer-example.png)
 
-## Skjule appnavnet i PDF
+## Skjule app-navnet i PDF-en
 
-Du kan skjule appnavnet i toppteksten og bunnteksten i den genererte PDF-en ved å sette `hideAppNameInPdf` i `uiSettings` i `layout-sets.json`.
+Du kan skjule app-navnet i toppteksten og bunnteksten i den genererte PDF-en ved å sette `hideAppNameInPdf` i `uiSettings` i `layout-sets.json`.
 
 Egenskapen godtar `true`, `false`, eller et boolsk [dynamisk uttrykk](/nb/altinn-studio/v8/reference/logic/expressions/). Uttrykket må evaluere til `true` eller `false` — tekstuttrykk støttes ikke.
 
@@ -392,6 +392,6 @@ Se [dynamiske uttrykk](/nb/altinn-studio/v8/reference/logic/expressions/) for me
 
 ## Lag en PDF i Figma
 
-Hvis du vil teste og sette opp PDF-en din, kan du gjøre det her:  
+Hvis du vil teste hvordan du kan sette opp PDF-en din, kan du gjøre det her:  
 [Altinn Studio Komponenter](https://www.figma.com/community/file/1344307804742953785/altinn-studio-komponenter).  
 Merk at eksempelet ikke er identisk med den faktiske koden, men er tilpasset for å lage prototyper i Figma.

--- a/content/altinn-studio/v8/reference/ux/pdf/_index.nb.md
+++ b/content/altinn-studio/v8/reference/ux/pdf/_index.nb.md
@@ -5,8 +5,11 @@ weight: 50
 ---
 
 {{%notice warning%}}
+
 ## Ny PDF-generering
+
 ### Aktivere ny PDF-generering
+
 Fra og med versjon 7.5 av nuget-pakkene (Altinn.App.Api og Altinn.App.Core) er det lansert en ny måte å generere PDF-er på. Denne nye måten kan skrus av og på ved å legge til følgende seksjon og innstilling i _appsettings.json_.
 
 ```json
@@ -18,6 +21,7 @@ Fra og med versjon 7.5 av nuget-pakkene (Altinn.App.Api og Altinn.App.Core) er d
 Dette vil sørge for at den nye PDF-tjenesten kalles. Denne aksepterer en URL som peker tilbake til en automatisk generert side i appen. Siden bygges opp og danner grunnlaget for PDF-en. Grensesnittet `IPdfFormatter` som dokumentert nedenfor er fortsatt relevant hvis du trenger spesiallogikk for å skjule komponenter/sider fra PDF-en.
 
 ### Innstillinger
+
 Selv om standardinnstillingene for den nye tjenesten skal være nok for de fleste applikasjoner, kan de overstyres ved å legge til en PdfGeneratorSettings-seksjon i _appsettings.json_ (standardinnstillinger vises under).
 
 ```json
@@ -58,17 +62,16 @@ Dette kan konfigureres på to ulike måter:
 Avhengig av hvilken versjon du kjører setter man opp den programmatiske metoden litt forskjellig, men logikken er helt lik. Oversikten under viser hvordan det settes opp for versjonen du kjører:
 {{<content-version-selector classes="border-box">}}
 
-
 {{<content-version-container version-label="v7">}}
 
 1. Opprett en klasse som implementerer `IPdfFormatter`-grensesnittet som ligger i `Altinn.App.Core.Features`-navnerommet.  
-    Du kan navngi og plassere filene i den mappestrukturen du selv ønsker i prosjektet ditt. Men vi anbefaler at du benytter meningsfulle navnerom som i et hvilket som helst annet .Net-prosjekt.
+   Du kan navngi og plassere filene i den mappestrukturen du selv ønsker i prosjektet ditt. Men vi anbefaler at du benytter meningsfulle navnerom som i et hvilket som helst annet .Net-prosjekt.
 2. Registrér din implementering i _Program.cs_-klassen.
-    ```C#
-    services.AddTransient<IPdfFormatter, PdfFormatter>();
-    ```
-    Dette sørger for at din kode er kjent for applikasjonen og at koden blir kjørt når den skal.
-{{</content-version-container>}}
+   `C#
+ services.AddTransient<IPdfFormatter, PdfFormatter>();
+ `
+   Dette sørger for at din kode er kjent for applikasjonen og at koden blir kjørt når den skal.
+   {{</content-version-container>}}
 
 {{<content-version-container version-label="v4, v5, v6">}}
 Endre `PdfHandler.cs`-filen under `App/logic/Print`-mappen.
@@ -84,11 +87,11 @@ Legg til en liste med sidenavn som skal eksluderes på `excludeFromPdf` under `p
 
 ```json {linenos=false,hl_lines=["5"]}
 {
-   "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
-   "pages": {
-      "order": ["side1", "side2"],
-      "excludeFromPdf": ["side2"]
-   }
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": ["side1", "side2"],
+    "excludeFromPdf": ["side2"]
+  }
 }
 ```
 
@@ -104,6 +107,7 @@ public async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, objec
   return await Task.FromResult(layoutSettings);
 }
 ```
+
 <br>
 
 **NB**: Du trenger kun å velge én av disse metodene.
@@ -117,13 +121,13 @@ Legg til en liste over komponent-ID-er som skal ekskluderes på `excludeFromPdf`
 
 ```json {linenos=false,hl_lines=["7"]}
 {
-   "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
-   "pages": {
-      "order": ["side1"]
-   },
-   "components": {
-      "excludeFromPdf": ["bilde-komponent-id"]
-   }
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": ["side1"]
+  },
+  "components": {
+    "excludeFromPdf": ["bilde-komponent-id"]
+  }
 }
 ```
 
@@ -139,6 +143,7 @@ public async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, objec
   return await Task.FromResult(layoutSettings);
 }
 ```
+
 <br>
 
 **NB**: Du trenger kun å velge én av disse metodene.
@@ -153,13 +158,13 @@ Formatet er: `komponentID-<rad-nummer>`.
 
 ```json {linenos=false,hl_lines=["7"]}
 {
-   "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
-   "pages": {
-      "order": ["side1"]
-   },
-   "components": {
-      "excludeFromPdf": ["komponent-i-gruppe-1"]
-   }
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": ["side1"]
+  },
+  "components": {
+    "excludeFromPdf": ["komponent-i-gruppe-1"]
+  }
 }
 ```
 
@@ -175,6 +180,7 @@ public async Task<LayoutSettings> FormatPdf(LayoutSettings layoutSettings, objec
   return await Task.FromResult(layoutSettings);
 }
 ```
+
 <br>
 
 **NB**: Du trenger kun å velge én av disse metodene.
@@ -193,6 +199,7 @@ Du kan bruke komponenten [Oppsummering]({{< ref "altinn-studio/v8/reference/ux/c
 ![Skjermbilde av en oppsummeringskomponent i en PDF-oppsett-side](pdf-summary-component.png)
 
 ### Manual configuration
+
 {{%notice warning%}}
 
 Denne metoden er kun tilgjengelig i versjon 7.5 og høyere.
@@ -202,13 +209,14 @@ Denne metoden er kun tilgjengelig i versjon 7.5 og høyere.
 Denne metoden lar deg spesifisere en helt egendefinert PDF ved å definere en layout-fil som bestemmer hva den skal inneholde.
 
 For å ta i bruk denne metoden må du opprette en ny layout-fil for PDF-en og sette `pdfLayoutName` i `Settings.json` til å peke til den filen:
+
 ```json {linenos=false,hl_lines=["5"]}
 {
-   "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
-   "pages": {
-      "order": ["side1"],
-      "pdfLayoutName": "minPdfLayout"
-   }
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layoutSettings.schema.v1.json",
+  "pages": {
+    "order": ["side1"],
+    "pdfLayoutName": "minPdfLayout"
+  }
 }
 ```
 
@@ -258,23 +266,23 @@ Du kan spesifisere at en komponent skal starte på en ny side eller at et sidesk
 
 ```json {linenos=false,hl_lines=["12-15"]}
 {
-   "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layout.schema.v1.json",
-   "data": {
-      "layout": [
-         {
-            "id": "pdf-header",
-            "type": "Header",
-            "textResourceBindings": {
-               "title": "Dette er en ny seksjon"
-            },
-            "size": "L",
-            "pageBreak": {
-               "breakBefore": "always",
-               "breakAfter": "avoid"
-            }
-         }
-      ]
-   }
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layout.schema.v1.json",
+  "data": {
+    "layout": [
+      {
+        "id": "pdf-header",
+        "type": "Header",
+        "textResourceBindings": {
+          "title": "Dette er en ny seksjon"
+        },
+        "size": "L",
+        "pageBreak": {
+          "breakBefore": "always",
+          "breakAfter": "avoid"
+        }
+      }
+    ]
+  }
 }
 ```
 
@@ -287,19 +295,17 @@ Det er mulig å ekskludere enkeltkomponenter inne i en gruppe ved å bruke `excl
 
 ```json {linenos=false,hl_lines=["10"]}
 {
-   "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layout.schema.v1.json",
-   "data": {
-      "layout": [
-         {
-            "id": "pdf-group-summary",
-            "type": "Summary",
-            "componentRef": "en-gruppe-komponent",
-            "excludedChildren": [
-               "en-komponent-i-gruppen"
-            ]
-         }
-      ]
-   }
+  "$schema": "https://altinncdn.no/toolkits/altinn-app-frontend/4/schemas/json/layout/layout.schema.v1.json",
+  "data": {
+    "layout": [
+      {
+        "id": "pdf-group-summary",
+        "type": "Summary",
+        "componentRef": "en-gruppe-komponent",
+        "excludedChildren": ["en-komponent-i-gruppen"]
+      }
+    ]
+  }
 }
 ```
 
@@ -366,8 +372,26 @@ Footeren vil inneholde følgende informasjon:
 - Altinn referanse-ID
 - Sidenummer
 
-   ![PDF footer eksempel](pdf-footer-example.png)
+  ![PDF footer eksempel](pdf-footer-example.png)
+
+## Skjule appnavnet i PDF
+
+Du kan skjule appnavnet i toppteksten og bunnteksten i den genererte PDF-en ved å sette `hideAppNameInPdf` i `uiSettings` i `layout-sets.json`.
+
+Egenskapen godtar `true`, `false`, eller et boolsk [dynamisk uttrykk](/nb/altinn-studio/v8/reference/logic/expressions/). Uttrykket må evaluere til `true` eller `false` — tekstuttrykk støttes ikke.
+
+```json {linenos=false,hl_lines=["3"]}
+{
+  "uiSettings": {
+    "hideAppNameInPdf": true
+  }
+}
+```
+
+Se [dynamiske uttrykk](/nb/altinn-studio/v8/reference/logic/expressions/) for mer informasjon.
+
 ## Lag en PDF i Figma
+
 Hvis du vil teste og sette opp PDF-en din, kan du gjøre det her:  
 [Altinn Studio Komponenter](https://www.figma.com/community/file/1344307804742953785/altinn-studio-komponenter).  
 Merk at eksempelet ikke er identisk med den faktiske koden, men er tilpasset for å lage prototyper i Figma.


### PR DESCRIPTION
Added documentation describing how to hide the app name in the PDF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised PDF reference pages for clearer structure and formatting
  * Enhanced examples for excluding pages/components (including repeating-group scenarios) and for manual PDF layout
  * Added guidance and a visual example for PDF footer usage
  * Introduced a configuration option to hide the app name in the PDF footer
  * Reformatted the “Prototype PDF in Figma” section and adjusted related enablement instructions for consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->