### PR TITLE
Add info notice about access policies

### DIFF
--- a/content/api/profile/reference/favorites/_index.en.md
+++ b/content/api/profile/reference/favorites/_index.en.md
@@ -14,6 +14,10 @@ All available endpoints require authentication. To use the API, you must be a lo
 
 In the path for favorites, you must indicate which party you want to add or delete. This is identified with `partyUuid`, which must be a valid value and which the user must have in their party list.
 
+{{% notice info %}}
+This API resource is restricted by access rules and can only be used with a valid end-user token.
+{{% /notice %}}
+
 ### Response model
 ```json
 {

--- a/content/api/profile/reference/favorites/_index.nb.md
+++ b/content/api/profile/reference/favorites/_index.nb.md
@@ -14,6 +14,10 @@ Alle tilgjengelige endepunkter krever autentisering. For å bruke API-et må man
 
 I stien for favoritter må man indikere hvilken aktør man ønsker å legge til eller slette. Denne identifiseres med `partyUuid`, som må være en gyldig verdi og som brukeren må ha i sin aktørliste. 
 
+{{% notice info %}}
+Denne API-ressursen er begrenset av tilgangsregler og kan kun benyttes med et gyldig sluttbruker-token. 
+{{% /notice %}}
+
 ### Respons-modell
 ```json
 {

--- a/content/api/profile/reference/organization-notification-addresses/_index.en.md
+++ b/content/api/profile/reference/organization-notification-addresses/_index.en.md
@@ -4,7 +4,7 @@ description: This API allows you to manage organizations' notification addresses
 weight: 30
 ---
 {{% notice info %}}
-This API resource is restricted by access rules and cannot be delegated using scopes. The access rules grant access to end users with the correct roles or access packages in their organization.
+This API resource is restricted by access rules and cannot be delegated using scopes. The access rules grant access to end users with the correct roles or access packages in their organisation.
 {{% /notice %}}
 
 ## What are notification addresses for organizations?

--- a/content/api/profile/reference/organization-notification-addresses/_index.en.md
+++ b/content/api/profile/reference/organization-notification-addresses/_index.en.md
@@ -3,6 +3,9 @@ title: Organization notification addresses
 description: This API allows you to manage organizations' notification addresses
 weight: 30
 ---
+{{% notice info %}}
+This API resource is restricted by access rules and cannot be delegated using scopes. The access rules grant access to end users with the correct roles or access packages in their organization.
+{{% /notice %}}
 
 ## What are notification addresses for organizations?
 For organizations to be notified of new messages in Altinn, they must register at least one notification address. This must be a mobile number or an email address.

--- a/content/api/profile/reference/organization-notification-addresses/_index.nb.md
+++ b/content/api/profile/reference/organization-notification-addresses/_index.nb.md
@@ -4,6 +4,10 @@ description: Dette API-et gir mulighet til å administrere virksomheters varslin
 weight: 30
 ---
 
+{{% notice info %}}
+Denne API-ressursen er begrenset av tilgangsregler og kan ikke delegeres med scopes. Tilgangsreglene gir tilgang til sluttbrukere med riktige roller eller tilgangspakker i sin virksomhet.
+{{% /notice %}}
+
 ## Hva er varslingsadresser for virksomheter
 For at virksomheter skal bli varslet om nye meldinger i altinn må de registrere minst en varslingsadresse. Dette må være et mobilnummer eller en e-postadresse. 
 Disse brukes også av Brønnøysundregistrene og holdes i synk gjennom jevnlige oppdateringer mellom systemene. 

--- a/content/api/profile/reference/personal-notification-addresses/_index.en.md
+++ b/content/api/profile/reference/personal-notification-addresses/_index.en.md
@@ -13,6 +13,10 @@ To use the API, you must be a logged-in end user. It is important that the acces
 
 In the path, you must indicate which party you want to manage addresses on behalf of. This is identified with `partyUuid`.
 
+{{% notice info %}}
+This API resource is restricted by access rules and can only be used with a valid end-user token.
+{{% /notice %}}
+
 ### Model
 
 ```json

--- a/content/api/profile/reference/personal-notification-addresses/_index.nb.md
+++ b/content/api/profile/reference/personal-notification-addresses/_index.nb.md
@@ -13,6 +13,10 @@ For å bruke API-et må man være en innlogget sluttbruker. Det er viktig at til
 
 I stien må man angi hvilken aktør man ønsker å administrere adresser for. Denne identifiseres med `partyUuid`. 
 
+{{% notice info %}}
+Denne API-ressursen er begrenset av tilgangsregler og kan kun benyttes med et gyldig sluttbruker-token. 
+{{% /notice %}}
+
 ## Modell
 
 ```json

--- a/content/api/profile/reference/users/_index.en.md
+++ b/content/api/profile/reference/users/_index.en.md
@@ -12,6 +12,10 @@ Profile fetches updates from the Contact and Reservation Register every ten minu
 A logged-in user can change display settings in the Altinn workspace, for example the language and which parties should appear in the party list.
 The API supports both PUT (replaces the entire object) and PATCH (updates parts of the object).
 
+{{% notice info %}}
+This API resource is restricted by access rules and can only be used with a valid end-user token.
+{{% /notice %}}
+
 ### Response model
 ```json
 {

--- a/content/api/profile/reference/users/_index.nb.md
+++ b/content/api/profile/reference/users/_index.nb.md
@@ -12,6 +12,10 @@ Profil-APIet kan ikke registrere en brukers folkeregistrerte adresse eller varsl
 En innlogget bruker kan endre innstillinger for visning i Altinns arbeidsflate, for eksempel språk og hvilke aktører som skal vises i aktørlisten.
 API-et støtter både PUT (erstatter hele objektet) og PATCH (oppdaterer deler av objektet).
 
+{{% notice info %}}
+Denne API-ressursen er begrenset av tilgangsregler og kan kun benyttes med et gyldig sluttbruker-token. 
+{{% /notice %}}
+
 ### Response model
 ```json
 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation to clarify that the Favorites, Personal Notification Addresses, Users, and Organisation Notification Addresses resources require valid end-user tokens for access and are restricted by access rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->