### PR TITLE
docs: clarify SBS Altinn token exchange

### DIFF
--- a/content/altinn-studio/v8/guides/integration/sbs/setup/_index.en.md
+++ b/content/altinn-studio/v8/guides/integration/sbs/setup/_index.en.md
@@ -20,12 +20,18 @@ the vendor's system and the app. There are mainly two ways to create this integr
   - Vendor creates a system in the system registry of Altinn Authorization (in the system definition, you specify the need for access to resources, e.g., an app)
   - Customer registers a system user. The rights are then delegated.
   - Vendor authenticates with Maskinporten client
-  - When integrating with Altinn apps, the system authenticates with Maskinporten and uses this token when submitting to Altinn
+  - When integrating with Altinn apps, the system authenticates with Maskinporten and then exchanges the Maskinporten token for an Altinn token before submitting to Altinn
   - For more information, see [Altinn Authorization user guide for system users](/en/authorization/guides/system-vendor/)
   - Suitable for systems with a higher degree of automation (and less need for contact/connection to the end-user), and for submissions on behalf of organizations.
 
 {{% notice warning %}}
 System user support towards an Altinn Studio app requires `Altinn.App.Api` and `Altinn.App.Core` version `v8.6.0` or later.
+{{% /notice %}}
+
+{{% notice info %}}
+Maskinporten tokens from system users cannot be used directly with Altinn apps or platform services that require Altinn tokens.
+The token must first be exchanged for an Altinn token through Altinn Authentication.
+Use the Altinn token in the `Authorization` header towards app and platform APIs.
 {{% /notice %}}
 
 ## Integration using ID-porten
@@ -430,7 +436,8 @@ POST https://test.maskinporten.no/token
 }
 ```
 
-Now that we have the system user token from Maskinporten, we currently need to exchange it for an Altinn token before it can be used with an app.
+Now that we have the system user token from Maskinporten, we need to exchange it for an Altinn token before it is used with Altinn apps and platform services that require Altinn tokens.
+The Maskinporten token is used as input to the exchange, while the Altinn token from the response is used in the `Authorization` header afterwards.
 In the future, this will no longer be necessary, and this documentation will be updated accordingly.
 
 ```http
@@ -446,7 +453,7 @@ Content-Type: text/plain; charset=utf-8
 
 #### 7. Fiken can instantiate in the app
 
-We use the `access_token` from the response in the previous step to create an empty instance in the `aarsregnskap` app.
+We use the Altinn token from the response in the previous step to create an empty instance in the `aarsregnskap` app.
 
 ```http
 POST https://brg.apps.tt02.altinn.no/brg/aarsregnskap/instances/create

--- a/content/altinn-studio/v8/guides/integration/sbs/setup/_index.en.md
+++ b/content/altinn-studio/v8/guides/integration/sbs/setup/_index.en.md
@@ -453,7 +453,7 @@ Content-Type: text/plain; charset=utf-8
 
 #### 7. Fiken can instantiate in the app
 
-We use the Altinn token from the response in the previous step to create an empty instance in the `aarsregnskap` app.
+We use the `access_token` from the response in the previous step, meaning the exchanged Altinn token, to create an empty instance in the `aarsregnskap` app.
 
 ```http
 POST https://brg.apps.tt02.altinn.no/brg/aarsregnskap/instances/create

--- a/content/altinn-studio/v8/guides/integration/sbs/setup/_index.nb.md
+++ b/content/altinn-studio/v8/guides/integration/sbs/setup/_index.nb.md
@@ -20,12 +20,18 @@ leverandørens system og appen. Det er i hovedsak 2 måter å lage denne integra
   - Leverandør lager system i systemregisteret til Altinn Autorisasjon (i systemdefinisjonen uttrykker man behov for tilgang til ressurser, f. eks. en app)
   - Kunde registrerer systembruker. Dermed blir rettighetene delegert.
   - Leverandør autentiserer med Maskinporten klient
-  - Ved integrasjon mot Altinn apper så vil systemet autentisere mot Maskinporten og så bruke dette tokenet ved innsending til Altinn
+  - Ved integrasjon mot Altinn apper så vil systemet autentisere mot Maskinporten og deretter veksle Maskinporten-tokenet inn til et Altinn-token før innsending til Altinn
   - For mer informasjon, se [Altinn Autorisasjon brukerguide for systembrukere](/nb/authorization/guides/system-vendor/)
   - Egner seg godt for systemer der det er større grad av automasjon (og mindre behov for kontakt/kobling til sluttbruker), og det er snakk om innsendinger på vegne av organisasjoner.
 
 {{% notice warning %}}
 Systembruker mot Altinn Studio-app krever `Altinn.App.Api` og `Altinn.App.Core` `v8.6.0` eller nyere.
+{{% /notice %}}
+
+{{% notice info %}}
+Maskinporten-token fra systembruker kan ikke brukes direkte mot Altinn-apper eller plattformtjenester som krever Altinn-token.
+Tokenet må først veksles inn til et Altinn-token via Altinn Authentication.
+Bruk Altinn-tokenet i `Authorization`-headeren mot app- og plattform-API-er.
 {{% /notice %}}
 
 ## Integrasjon med ID-porten
@@ -432,7 +438,8 @@ POST https://test.maskinporten.no/token
 }
 ```
 
-Når vi nå har systembruker token fra Maskinporten, må vi foreløpig veksle inn denne til et Altinn token for å bruke den mot en app.
+Når vi nå har systembruker-token fra Maskinporten, må vi veksle det inn til et Altinn-token før det brukes mot Altinn-apper og plattformtjenester som krever Altinn-token.
+Maskinporten-tokenet brukes som input til innvekslingen, mens Altinn-tokenet fra responsen brukes videre i `Authorization`-headeren.
 I fremtiden vil dette ikke være nødvendig, og denne dokumentasjonen vil oppdateres.
 
 ```http
@@ -448,7 +455,7 @@ Content-Type: text/plain; charset=utf-8
 
 #### 7. Fiken kan instansiere i appen
 
-Vi bruker `access_token` fra responsen i forrige steg til å lage en tom instans i `aarsregnskap`-appen.
+Vi bruker Altinn-tokenet fra responsen i forrige steg til å lage en tom instans i `aarsregnskap`-appen.
 
 ```http
 POST https://brg.apps.tt02.altinn.no/brg/aarsregnskap/instances/create

--- a/content/altinn-studio/v8/guides/integration/sbs/setup/_index.nb.md
+++ b/content/altinn-studio/v8/guides/integration/sbs/setup/_index.nb.md
@@ -455,7 +455,7 @@ Content-Type: text/plain; charset=utf-8
 
 #### 7. Fiken kan instansiere i appen
 
-Vi bruker Altinn-tokenet fra responsen i forrige steg til å lage en tom instans i `aarsregnskap`-appen.
+Vi bruker `access_token` fra responsen i forrige steg, altså det innvekslede Altinn-tokenet, til å lage en tom instans i `aarsregnskap`-appen.
 
 ```http
 POST https://brg.apps.tt02.altinn.no/brg/aarsregnskap/instances/create


### PR DESCRIPTION
## Summary

- Clarify that system-user Maskinporten tokens must be exchanged for Altinn tokens before they are used with Altinn apps.
- Add an explicit note that this also applies to platform services that require Altinn tokens.
- Keep the Norwegian and English SBS setup guides aligned.

## Screenshot

![Updated SBS setup guide showing token exchange notice](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio-docs/pr-assets/sbs-token-exchange-doc/.github/pr-screenshots/sbs-token-exchange-doc.png)

## Testing

- `hugo --printPathWarnings --printUnusedTemplates`
  - Passed. Hugo reported existing deprecation, duplicate target path and unused template warnings.
- `hugo server --bind 127.0.0.1 --port 1313 --disableFastRender`
- Opened `http://localhost:1313/nb/altinn-studio/v8/guides/integration/sbs/setup/` with Playwright and verified the new notice renders.
  - Local console errors were limited to missing `pagefind` assets and blocked Google Tag Manager in the local docs server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system-user integration guides to clarify the Maskinporten-to-Altinn token exchange flow, emphasising use of the exchanged Altinn token in the Authorization header.
  * Revised integration examples to demonstrate correct token usage and minimum API version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->