### PR TITLE
Fixed a List definition that should not been there

### DIFF
--- a/static/swagger/altinn-platform-accessmanagement-v1-enduser.json
+++ b/static/swagger/altinn-platform-accessmanagement-v1-enduser.json
@@ -113,7 +113,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AuthorizedPartyDtoListPaginatedResult"
+                  "$ref": "#/components/schemas/AuthorizedPartyDtoPaginatedResult"
                 }
               }
             }
@@ -7344,16 +7344,13 @@
         },
         "additionalProperties": false
       },
-      "AuthorizedPartyDtoListPaginatedResult": {
+      "AuthorizedPartyDtoPaginatedResult": {
         "type": "object",
         "properties": {
           "data": {
             "type": "array",
             "items": {
-              "type": "array",
-              "items": {
                 "$ref": "#/components/schemas/AuthorizedPartyDto"
-              }
             },
             "nullable": true
           },


### PR DESCRIPTION
There is an error in the Open API specification definition in Access-Management resulting in an error when generating the specification.

See PR for fix on the generating specification
https://github.com/Altinn/altinn-authorization-tmp/pull/3551/changes

See bug report:
https://github.com/Altinn/altinn-authorization-tmp/issues/3548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the response structure for the authorised parties endpoint to use a more streamlined format. The data is now provided in a simpler, more direct structure without unnecessary nesting. This change improves clarity and consistency for API consumers and facilitates easier integration with client applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->