### PR TITLE
add a deprecated table and refer to an appropriate replacement

### DIFF
--- a/content/correspondence/getting-started/developer-guides/events/_index.en.md
+++ b/content/correspondence/getting-started/developer-guides/events/_index.en.md
@@ -68,7 +68,7 @@ If you do not specify a Type Filter you will receive all the different types of 
 | `no.altinn.correspondence.attachmentuploadfailed` | Attachment failed malware scanning | Notification that the attachment has been rejected |
 | `no.altinn.correspondence.attachmentexpired` | Attachment expiration time has passed, it is no longer available to the recipient and cannot be used in new correspondences | Confirmation that attachment has expired |
 | `no.altinn.correspondence.correspondenceinitialized` | Correspondence has been initialized | Confirmation that correspondence has been initialized |
-| `no.altinn.correspondence.correspondencepublished` | Correspondence has been published and is available to the recipient | Confirmation and notification that correspondence has been successfully published |
+| `no.altinn.correspondence.correspondencepublished` * | Correspondence has been published and is available to the recipient | Confirmation and notification that correspondence has been successfully published |
 | `no.altinn.correspondence.correspondencepurged` | Correspondence has either been purged by the recipient after publishing, or by the service owner before publishing | Notification that correspondence has been purged |
 | `no.altinn.correspondence.correspondencepublishfailed` | Correspondence publish failed | Notification that correspondence failed before publish and will not be made available to the recipient |
 | `no.altinn.correspondence.notificationcreated` | Notification order has been created in Altinn Notification | Confirmation that notification has been ordered |
@@ -77,6 +77,15 @@ If you do not specify a Type Filter you will receive all the different types of 
 | `no.altinn.correspondence.correspondencenotificationallfailed` | Delivery to all notification addresses failed — recipient was not notified | Notification that the recipient was not successfully notified. Consider follow-up |
 | `no.altinn.correspondence.correspondencenotificationdelivered` | The initial notification has been confirmed delivered | Confirmation that recipient has been notified |
 | `no.altinn.correspondence.correspondencenotificationreminderdelivered` | The reminder notification has been confirmed delivered | Confirmation that reminder has been sent |
+
+`*` Event is deprecated and will be removed, refer to table below for appropriate replacement.
+
+
+**Deprecated events for service owners:**
+
+| Event | Use instead |
+|-------|------|
+| `no.altinn.correspondence.correspondencepublished` | Use the correspondencepublished event for recipients. |
 
 **For each recipient:**
 

--- a/content/correspondence/getting-started/developer-guides/events/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/events/_index.nb.md
@@ -82,9 +82,9 @@ Hvis du ikke spesifiserer et *typeFilter*, vil du motta alle forskjellige typer 
 `*` Hendelse er foreldet og vil bli fjernet, se tabellen under for en passende erstatning.
 
 
-**Deprecated events for service owners:**
+**Hendelser som er foreldet :**
 
-| Event | Use instead |
+| Hendelse | Bruk heller |
 |-------|------|
 | `no.altinn.correspondence.correspondencepublished` | Bruk correspondencepublished hendelsen som gjelder for mottaker. |
 

--- a/content/correspondence/getting-started/developer-guides/events/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/events/_index.nb.md
@@ -84,7 +84,7 @@ Hvis du ikke spesifiserer et *typeFilter*, vil du motta alle forskjellige typer 
 
 **Hendelser som er foreldet :**
 
-| Hendelse | Bruk heller |
+| Hendelse | Bruk i stedet |
 |-------|------|
 | `no.altinn.correspondence.correspondencepublished` | Bruk correspondencepublished hendelsen som gjelder for mottaker. |
 

--- a/content/correspondence/getting-started/developer-guides/events/_index.nb.md
+++ b/content/correspondence/getting-started/developer-guides/events/_index.nb.md
@@ -69,7 +69,7 @@ Hvis du ikke spesifiserer et *typeFilter*, vil du motta alle forskjellige typer 
 | `no.altinn.correspondence.attachmentuploadfailed` | Vedlegg feilet malware-skanning | Varsel på at vedlegget er avvist |
 | `no.altinn.correspondence.attachmentexpired` | Vedleggets utløpsdato er passert, er ikke lenger tilgjengelig for mottaker og kan ikke brukes i nye meldinger | Bekreftelse på at vedlegg har utløpt |
 | `no.altinn.correspondence.correspondenceinitialized` | Meldingen er opprettet | Bekreftelse på at melding er initialisert |
-| `no.altinn.correspondence.correspondencepublished` | Meldingen er publisert og tilgjengelig for mottaker | Bekreftelse og varsel på at melding er vellykket publisert |
+| `no.altinn.correspondence.correspondencepublished` * | Meldingen er publisert og tilgjengelig for mottaker | Bekreftelse og varsel på at melding er vellykket publisert |
 | `no.altinn.correspondence.correspondencepurged` | Meldingen er enten slettet av mottaker etter publisering eller av tjeneste-eier før publisering | Varsel på at melding er slettet |
 | `no.altinn.correspondence.correspondencepublishfailed` | Publisering feilet | Varsel på at melding feilet før publisering og vil ikke bli tilgjengelig for mottaker |
 | `no.altinn.correspondence.notificationcreated` | Varslingsordre er opprettet i Altinn Notification | Bekreftelse på at varsling er bestilt |
@@ -78,6 +78,15 @@ Hvis du ikke spesifiserer et *typeFilter*, vil du motta alle forskjellige typer 
 | `no.altinn.correspondence.correspondencenotificationallfailed` | Alle varselmottakere for hovedordren feilet (fullstendig feil), ikke inkludert valgfri mottakere | Mottakeren ble ikke vellykket varslet. Vurder oppfølging |
 | `no.altinn.correspondence.correspondencenotificationdelivered` | Initialvarselet er blitt bekreftet levert | Bekreftelse på at mottaker er varslet |
 | `no.altinn.correspondence.correspondencenotificationreminderdelivered` | Påminnelsesvarselet er blitt bekreftet levert | Bekreftelse på at påminnelse er sendt |
+
+`*` Hendelse er foreldet og vil bli fjernet, se tabellen under for en passende erstatning.
+
+
+**Deprecated events for service owners:**
+
+| Event | Use instead |
+|-------|------|
+| `no.altinn.correspondence.correspondencepublished` | Bruk correspondencepublished hendelsen som gjelder for mottaker. |
 
 **For hver mottaker:**
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the correspondence events guide to mark one event as deprecated.
  * Added a new section listing deprecated service-owner events and their recommended replacements.
  * Clarified which event variant should be used going forward for recipients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->