### PR TITLE
Add developer onboarding and authorization golden path

### DIFF
--- a/content/authorization/reference/system/_index.en.md
+++ b/content/authorization/reference/system/_index.en.md
@@ -16,6 +16,8 @@ Altinn Authorization combines identity, party, resource, rights and context to d
 
 ## Reading guide
 
+- [New to the team](onboarding/) provides a plan for a developer's first day and first week.
+
 - [Architecture](architecture/) describes the system context, responsibilities and overall construction.
 - [Application architecture](application-architecture/) describes internal structure, technologies and data ownership.
 - [Development architecture](development-architecture/) describes how the source code is divided, built, tested and delivered.

--- a/content/authorization/reference/system/_index.nb.md
+++ b/content/authorization/reference/system/_index.nb.md
@@ -16,6 +16,8 @@ Altinn Autorisasjon knytter sammen identitet, part, ressurs, rettighet og kontek
 
 ## Leseguide
 
+- [Ny i teamet](onboarding/) gir nye utviklere en plan for første dag og første uke.
+
 - [Arkitektur](architecture/) beskriver systemkontekst, ansvar og overordnet oppbygning.
 - [Applikasjonsarkitektur](application-architecture/) beskriver intern oppbygning, teknologier og dataeierskap.
 - [Utviklingsarkitektur](development-architecture/) beskriver hvordan kildekoden er fordelt, bygd, testet og levert.

--- a/content/authorization/reference/system/flows/_index.en.md
+++ b/content/authorization/reference/system/flows/_index.en.md
@@ -6,7 +6,7 @@ weight: 6
 toc: true
 ---
 
-The flows highlight transitions of responsibility between components. Detailed API contracts and integration steps belong in the API and guide sections.
+The flows highlight transitions of responsibility between components. [Trace an executable authorisation decision end to end](./authorization-decision/) as the main exercise. Detailed API contracts and integration steps belong in the API and guide sections.
 
 ## Interactive authentication
 

--- a/content/authorization/reference/system/flows/_index.nb.md
+++ b/content/authorization/reference/system/flows/_index.nb.md
@@ -6,7 +6,7 @@ weight: 6
 toc: true
 ---
 
-Flytene viser ansvarsovergangene mellom komponenter. Detaljerte API-kontrakter og integrasjonstrinn dokumenteres i API- og veiledningsseksjonene.
+Flytene viser ansvarsovergangene mellom komponenter. [Følg en kjørbar autorisasjonsbeslutning ende til ende](./authorization-decision/) som hovedøvelse. Detaljerte API-kontrakter og integrasjonstrinn dokumenteres i API- og veiledningsseksjonene.
 
 ## Interaktiv autentisering
 

--- a/content/authorization/reference/system/flows/authorization-decision/_index.en.md
+++ b/content/authorization/reference/system/flows/authorization-decision/_index.en.md
@@ -1,0 +1,70 @@
+---
+title: Trace an authorisation decision end to end
+linktitle: Executable authorisation flow
+description: Run, trace and troubleshoot a representative PDP decision.
+weight: 1
+toc: true
+---
+
+This exercise uses an existing Bruno test for a system user with a directly delegated access package. It expects `Permit` for `read`. Paths are based on [source commit `20fcb3f`](https://github.com/Altinn/altinn-authorization-tmp/tree/20fcb3f06a20b93ba7bba04a2fa8f55b57d033cb).
+
+## What the exercise shows
+
+The request calls `POST /authorization/api/v1/decision` with the system-user UUID, `read`, resource identifier and resource-party organisation number. Authorization enriches context, loads policy, evaluates roles and delegations, checks any access list and creates an audit event.
+
+## Prerequisites and execution
+
+You need `altinn-authorization-tmp`, Bruno or Bruno CLI, access to an agreed test environment, a valid subscription key and approved test data. Retrieve secrets through the approved solution and never commit them.
+
+Open:
+
+```text
+src/apps/Altinn.Authorization/test/Bruno/Altinn.Authorization
+```
+
+Choose the agreed environment and run:
+
+```text
+shared/Decision/SystemUser_AccPkg_ToDo_Scenarios/
+  SysUser_DirectDelg_AccPkg_Permit.bru
+```
+
+The pre-request script supplies `subjectSystemUser`, `resourceId` and `resourceOrgno`. Success is HTTP `200` with `response[0].decision` equal to `Permit`.
+
+## Request attributes
+
+| Category | Attribute | Meaning |
+|---|---|---|
+| AccessSubject | `urn:altinn:systemuser:uuid` | acting system user |
+| Action | `urn:oasis:names:tc:xacml:1.0:action:action-id` | `read` |
+| Resource | `urn:altinn:resource` | protected resource |
+| Resource | `urn:altinn:organization:identifier-no` | resource party |
+
+Do not change shared test data without agreement.
+
+## Follow the code
+
+1. [`DecisionController.Post`](https://github.com/Altinn/altinn-authorization-tmp/blob/20fcb3f06a20b93ba7bba04a2fa8f55b57d033cb/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs) receives internal JSON or XML.
+2. Context Handler enriches party, role and resource context.
+3. PRP loads the resource policy.
+4. PDP evaluates the policy.
+5. On `NotApplicable`, relevant delegations are loaded and evaluated.
+6. A preliminary `Permit` may become `Deny` when a required access list rejects the party.
+7. Event Log creates the event when enabled.
+8. the Audit Log function consumes `authorizationeventlog` and calls the Audit Log API.
+
+## Run locally
+
+```powershell
+just dev
+dotnet build Altinn.Authorization.sln
+dotnet run --project src/apps/Altinn.Authorization/src/Altinn.Authorization
+```
+
+Follow the repository README for database and secret configuration. A local process using shared backends is a hybrid test. A full `Permit` requires consistent resource, policy, party and delegation data across dependencies.
+
+## Interpret and troubleshoot
+
+`Permit` must still be enforced by the PEP. `Deny` is explicit refusal, `NotApplicable` means no relevant rule produced a decision, and `Indeterminate` means evaluation failed. `401` or `403` before the XACML response usually concerns API access.
+
+Check environment and subscription key; subject, resource party, resource and action; current policy; role or delegation; access list; feature flags and test data. Use trace or correlation ID across dependencies and Audit Log. Never log complete tokens or unnecessary decision context.

--- a/content/authorization/reference/system/flows/authorization-decision/_index.nb.md
+++ b/content/authorization/reference/system/flows/authorization-decision/_index.nb.md
@@ -1,0 +1,70 @@
+---
+title: Følge en autorisasjonsbeslutning ende til ende
+linktitle: Kjørbar autorisasjonsflyt
+description: Slik kjører, følger og feilsøker du en representativ PDP-beslutning.
+weight: 1
+toc: true
+---
+
+Denne øvelsen bruker en eksisterende Bruno-test for en systembruker med direkte delegert tilgangspakke. Testen forventer `Permit` for `read`. Filstiene bygger på [kildecommit `20fcb3f`](https://github.com/Altinn/altinn-authorization-tmp/tree/20fcb3f06a20b93ba7bba04a2fa8f55b57d033cb).
+
+## Hva øvelsen viser
+
+Forespørselen går til `POST /authorization/api/v1/decision` med systembrukerens UUID, handlingen `read`, ressursidentifikatoren og ressurspartens organisasjonsnummer. Authorization beriker konteksten, henter policyen, evaluerer roller og delegeringer, kontrollerer eventuell tilgangsliste og oppretter en audit-hendelse.
+
+## Forutsetninger
+
+Du trenger repoet `altinn-authorization-tmp`, Bruno eller Bruno CLI, tilgang til avtalt testmiljø, gyldig abonnementnøkkel og miljøets testdata. Hent hemmeligheter gjennom teamets godkjente løsning. Ikke legg dem i Git.
+
+Åpne samlingen:
+
+```text
+src/apps/Altinn.Authorization/test/Bruno/Altinn.Authorization
+```
+
+Velg avtalt miljø og kjør:
+
+```text
+shared/Decision/SystemUser_AccPkg_ToDo_Scenarios/
+  SysUser_DirectDelg_AccPkg_Permit.bru
+```
+
+Forhåndsskriptet setter `subjectSystemUser`, `resourceId` og `resourceOrgno` fra miljøets testdata. Testen er vellykket når HTTP-status er `200` og `response[0].decision` er `Permit`.
+
+## Les forespørselen
+
+| XACML-kategori | Attributt | Betydning |
+|---|---|---|
+| AccessSubject | `urn:altinn:systemuser:uuid` | systembrukeren |
+| Action | `urn:oasis:names:tc:xacml:1.0:action:action-id` | `read` |
+| Resource | `urn:altinn:resource` | beskyttet ressurs |
+| Resource | `urn:altinn:organization:identifier-no` | ressursparten |
+
+Endre ikke delte testdata uten avtale.
+
+## Følg koden
+
+1. [`DecisionController.Post`](https://github.com/Altinn/altinn-authorization-tmp/blob/20fcb3f06a20b93ba7bba04a2fa8f55b57d033cb/src/apps/Altinn.Authorization/src/Altinn.Authorization/Controllers/DecisionController.cs) tar imot intern JSON eller XML.
+2. Context Handler beriker parts-, rolle- og ressurskonteksten.
+3. PRP henter ressurspolicyen.
+4. PDP evaluerer policyen.
+5. Ved `NotApplicable` hentes og evalueres relevante delegeringer.
+6. Et foreløpig `Permit` kan bli `Deny` dersom en påkrevd tilgangsliste ikke godkjenner parten.
+7. Event Log oppretter hendelsen når logging er aktivert.
+8. Audit Log-funksjonen leser `authorizationeventlog` og kaller Audit Log-API-et.
+
+## Kjør lokalt
+
+```powershell
+just dev
+dotnet build Altinn.Authorization.sln
+dotnet run --project src/apps/Altinn.Authorization/src/Altinn.Authorization
+```
+
+Følg repoets README for database og hemmeligheter. En lokal Authorization-prosess med delte backendtjenester er en hybrid test. Et fullstendig `Permit` krever konsistente ressurs-, policy-, parts- og delegeringsdata i avhengighetene.
+
+## Tolk og feilsøk
+
+`Permit` må fortsatt håndheves av PEP. `Deny` er et eksplisitt avslag, `NotApplicable` betyr at ingen relevant regel ga en beslutning, og `Indeterminate` betyr at evalueringen feilet. `401` eller `403` før XACML-svaret gjelder normalt API-tilgang.
+
+Kontroller miljø og abonnementnøkkel, subjekt, ressursparti, ressurs og handling, gjeldende policy, rolle eller delegering, tilgangsliste, funksjonsflagg og testdata. Bruk trace- eller korrelasjons-ID på tvers av avhengigheter og Audit Log. Logg aldri hele tokens eller unødvendig beslutningskontekst.

--- a/content/authorization/reference/system/onboarding/_index.en.md
+++ b/content/authorization/reference/system/onboarding/_index.en.md
@@ -1,0 +1,173 @@
+---
+title: New developer in Altinn Authorization
+linktitle: New to the team
+description: Learn the system, codebases and development workflow during your first week.
+weight: 1
+toc: true
+---
+
+This guide helps you understand ownership boundaries, build relevant code and trace an authorisation decision. Ask your buddy to confirm which environments and components you will work with.
+
+## Outcomes
+
+You should be able to explain identity, party, representation, resource, right, PDP and PEP; find the repository that owns a change; build and test relevant code; trace `Permit` and `Deny`; and find the correct logs and owner.
+
+## Your first day
+
+Confirm access to GitHub repositories, team work surfaces, the relevant Azure account and test environment, observability tools and approved secret management. Production access is not required to begin.
+
+Read [system architecture](../architecture/), [information model](../information-model/), [components](../components/), [the executable authorisation flow](../flows/authorization-decision/) and [security](../security/) in that order.
+
+Ask: who is acting, which party is represented, what resource and action are requested, where does the right originate, who enforces the decision, and where can the event be traced?
+
+## Find the repository
+
+| Area | Repository |
+|---|---|
+| Sign-in, sessions and tokens | `altinn-authentication` |
+| Party and representation | `altinn-register` |
+| Resource metadata and policy | `altinn-resource-registry` |
+| Access, delegation and PDP | `altinn-authorization-tmp` |
+| UI and BFF | `altinn-access-management-frontend` |
+| Audit events | `altinn-auth-audit-log` |
+
+Resource Registry is planned to move into the monorepo. Always confirm the authoritative copy.
+
+## Build before changing anything
+
+The repository README is authoritative. A short monorepo baseline is:
+
+```powershell
+dotnet build Altinn.Authorization.sln
+dotnet test -- --filter-trait "Category=Unit"
+```
+
+Integration tests require a container runtime. Green unit tests do not cover the complete integration.
+
+## First main exercise
+
+Follow [one authorisation decision end to end](../flows/authorization-decision/). Complete it with your buddy the first time if you need a test environment, subscription key or test data.
+
+Never copy tokens, keys or personal data into documentation, terminal history, screenshots or pull requests.
+
+## First code change and first week
+
+Choose a small change within one component boundary, with a clear test and safe rollback. Run relevant tests, describe changed behaviour and delivery order, and check artifacts for secrets.
+
+During the first week, trace `Permit` and `Deny`, inspect resource-policy registration and a delegation, follow an event to Audit Log, identify key dashboard signals, read the component patterns and persistence model, and join a real code review.
+
+## Suggested five-day onboarding plan
+
+Adjust the order if your first assignment requires a different component.
+
+### Day one: System and language
+
+**Goal:** Explain Altinn Authorization without starting with repository or class names.
+
+1. Read system architecture, information model and components.
+2. Restate the chain of trust: identity, representation, resource, right, decision and traceability.
+3. Choose one story, such as a system user reading a resource for an organisation.
+4. Place PDP, PEP and authoritative data sources in the story.
+5. Review the model with your buddy.
+
+**Output:** A short explanation and a list of concepts that remain unclear.
+
+**Checkpoint:** You distinguish the acting identity from the represented party, and know that PDP decides whilst PEP enforces.
+
+### Day two: Repository and development environment
+
+**Goal:** Build the relevant code and understand repository boundaries.
+
+1. Clone or update the repository.
+2. Read `README.md`, solution structure and relevant `AGENTS.md` files.
+3. Locate the application, domain core, integrations, persistence and tests.
+4. Run the build and shortest unit-test suite.
+5. Find the pull-request workflow and its checks.
+6. Note dependencies requiring containers, Azure or a shared environment.
+
+For the monorepo, start with:
+
+```powershell
+dotnet build Altinn.Authorization.sln
+dotnet test -- --filter-trait "Category=Unit"
+```
+
+**Output:** A successful build and a simple map of folders you expect to change.
+
+**Checkpoint:** You know which code is authoritative and which tests the short check did not run.
+
+### Day three: Decision in practice
+
+**Goal:** Run and explain one permitted and one denied decision.
+
+1. Complete [the executable authorisation flow](../flows/authorization-decision/).
+2. Inspect subject, resource, action and resource party.
+3. Follow `DecisionController`, Context Handler, PRP and PDP.
+4. Find the transition from role evaluation to delegations.
+5. Find where an access list may change preliminary `Permit` to `Deny`.
+6. Run an existing negative Bruno test or agree a safe negative scenario.
+7. Compare result and status code.
+
+**Output:** A table of input, data sources, decision and explanation for both tests.
+
+**Checkpoint:** You distinguish a domain decision from missing API access and technical evaluation failure.
+
+### Day four: Data, integrations and observability
+
+**Goal:** Locate decision data and follow it through operational surfaces.
+
+1. Open the persistence model for your component.
+2. Find the table, blob, queue or external API supplying each key value.
+3. Choose one integration and record owner, contract, authentication, timeout and failure behaviour.
+4. Run the golden path with a trace or correlation ID.
+5. Find relevant logs, traces and metrics.
+6. Follow the audit event as far as your access permits.
+7. Confirm observability data does not expose complete tokens or unnecessary personal data.
+
+**Output:** A short troubleshooting log showing where you looked, signals found and ownership transitions.
+
+**Checkpoint:** You distinguish authoritative data, cache and data read from another service.
+
+### Day five: First safe change
+
+**Goal:** Deliver a small real improvement through the normal workflow.
+
+Choose with your buddy a test clarifying behaviour, better error handling or observability, documentation close to code, or a small defect with known expected behaviour.
+
+1. Describe expected behaviour before editing.
+2. Create or identify the protecting test.
+3. Make the smallest necessary change.
+4. Run relevant unit and integration tests.
+5. Check contracts, migrations and delivery order.
+6. Open a pull request with test evidence and rollback assessment.
+7. Review feedback with your buddy.
+
+**Output:** A small pull request meeting team quality requirements.
+
+**Checkpoint:** Another developer can understand why it is safe, how it was tested and which components it affects.
+
+## Review with your buddy
+
+| Area | I can do this | I need practice |
+|---|---|---|
+| Explain domain concepts |  |  |
+| Find the correct component and repository |  |  |
+| Build and run relevant tests |  |  |
+| Trace `Permit` and `Deny` |  |  |
+| Locate decision data |  |  |
+| Use logs, traces and metrics |  |  |
+| Make a small safe change |  |  |
+
+Agree one area to deepen during the next month and one concrete task where you can apply it.
+## When you get stuck
+
+| Symptom | First check |
+|---|---|
+| `401` or `403` before PDP response | token, scope, subscription key and API boundary |
+| `Deny` | subject, represented party, resource, action and access list |
+| `NotApplicable` | no policy rule matches |
+| `Indeterminate` | invalid context, missing policy or evaluation failure |
+| different result between environments | test data, policy version, delegations, feature flags and configuration |
+| missing audit event | feature flag, queue, processor and correlation |
+
+Never edit a shared database directly to make a test pass. Use the supported API or test-data flow.

--- a/content/authorization/reference/system/onboarding/_index.nb.md
+++ b/content/authorization/reference/system/onboarding/_index.nb.md
@@ -1,0 +1,202 @@
+---
+title: Ny utvikler i Altinn Autorisasjon
+linktitle: Ny i teamet
+description: Slik blir du kjent med systemet, kodebasene og utviklingsarbeidet den første uken.
+weight: 1
+toc: true
+---
+
+Målet med denne veiledningen er at du skal forstå ansvarsgrensene, kunne bygge relevant kode og følge en autorisasjonsbeslutning gjennom systemet. Be fadderen din bekrefte hvilke miljøer og komponenter du skal arbeide med.
+
+## Når du er ferdig
+
+Du skal kunne
+
+- forklare identitet, part, representasjon, ressurs, rettighet, PDP og PEP
+- finne komponenten og repoet som eier en endring
+- bygge og teste minst ett relevant repo
+- følge en `Permit` og en forventet `Deny`
+- finne logger, spor og riktig eier
+
+## Første dag
+
+Avklar tilgang til GitHub-repoene, teamets arbeidsflater, relevant Azure-konto og testmiljø, observabilitetsverktøy og godkjent hemmelighetshåndtering. Du trenger ikke produksjonstilgang for å begynne.
+
+Les i denne rekkefølgen:
+
+1. [Systemarkitekturen](../architecture/).
+2. [Informasjonsmodellen](../information-model/).
+3. [Komponentoversikten](../components/).
+4. [Den kjørbare autorisasjonsflyten](../flows/authorization-decision/).
+5. [Sikkerhet og tillit](../security/).
+
+Bruk kontrollspørsmålene: Hvem handler, hvilken part representeres, hvilken ressurs og handling gjelder det, hvor kommer rettigheten fra, hvem håndhever beslutningen, og hvor kan hendelsen spores?
+
+## Finn riktig repo
+
+| Område | Repo |
+|---|---|
+| Innlogging, sesjon og token | `altinn-authentication` |
+| Part og representasjon | `altinn-register` |
+| Ressursmetadata og policy | `altinn-resource-registry` |
+| Tilgang, delegering og PDP | `altinn-authorization-tmp` |
+| Brukerflate og BFF | `altinn-access-management-frontend` |
+| Audit-hendelser | `altinn-auth-audit-log` |
+
+Resource Registry skal flyttes til monorepoet. Bekreft alltid hvilken kopi som er autoritativ.
+
+## Bygg før du endrer
+
+Repoets README er fasiten. For monorepoet er en kort grunnkontroll:
+
+```powershell
+dotnet build Altinn.Authorization.sln
+dotnet test -- --filter-trait "Category=Unit"
+```
+
+Integrasjonstester krever en containermotor. Et grønt enhetstestsett dekker ikke hele integrasjonen.
+
+## Første hovedøvelse
+
+Følg [én autorisasjonsbeslutning ende til ende](../flows/authorization-decision/). Gjør øvelsen sammen med en fadder første gang dersom du trenger testmiljø, abonnementnøkkel eller testdata.
+
+Ikke kopier tokens, nøkler eller personopplysninger til dokumentasjon, terminalhistorikk, skjermbilder eller pull requester.
+
+## Første kodeendring
+
+Velg en liten endring innenfor én komponentgrense med en tydelig test og trygg tilbakerulling. Før pull requesten skal du kjøre relevante tester, beskrive endret oppførsel, oppgi eventuell leveranserekkefølge og kontrollere at artefaktene ikke inneholder hemmeligheter.
+
+## Første uke
+
+- følg en `Permit` og en `Deny`
+- se hvordan en ressurs og policy registreres
+- finn en delegering i Access Management-modellen
+- følg en hendelse til Audit Log
+- finn komponentens dashbord og viktigste signaler
+- les komponentens mønstre og persistensmodell
+- delta i en reell kodegjennomgang
+
+## Forslag til femdagers onboardingløp
+
+Planen er et utgangspunkt. Bytt rekkefølge dersom den første arbeidsoppgaven din krever en annen komponent.
+
+### Dag én: Systemet og språket
+
+**Mål:** Forklar hva Altinn Autorisasjon gjør uten å begynne med repo- eller klassenavn.
+
+1. Les systemarkitekturen, informasjonsmodellen og komponentoversikten.
+2. Tegn tillitskjeden med egne ord: identitet, representasjon, ressurs, rettighet, beslutning og sporbarhet.
+3. Velg én brukerhistorie, for eksempel at en systembruker leser en ressurs på vegne av en virksomhet.
+4. Plasser PDP, PEP og de autoritative datakildene i historien.
+5. Gå gjennom modellen med fadderen.
+
+**Leveranse:** En kort muntlig forklaring og en liste over begreper du fortsatt er usikker på.
+
+**Kontrollpunkt:** Du skiller identiteten som handler fra parten den handler på vegne av, og du vet at PDP beslutter mens PEP håndhever.
+
+### Dag to: Repoet og utviklingsmiljøet
+
+**Mål:** Bygg den relevante koden og forstå repoets grenser.
+
+1. Klon eller oppdater repoet du skal arbeide i.
+2. Les `README.md`, løsningsstrukturen og relevante `AGENTS.md`-filer.
+3. Finn applikasjonsprosjektet, domenekjernen, integrasjonene, persistenslaget og testene.
+4. Kjør bygging og det korteste enhetstestsettet.
+5. Finn pull request-arbeidsflyten og se hvilke kontroller som kjøres.
+6. Noter hvilke avhengigheter som krever containere, Azure eller et delt miljø.
+
+For monorepoet kan du begynne med:
+
+```powershell
+dotnet build Altinn.Authorization.sln
+dotnet test -- --filter-trait "Category=Unit"
+```
+
+**Leveranse:** Et vellykket lokalt bygg og en enkel skisse av mappene du forventer å endre.
+
+**Kontrollpunkt:** Du vet hvilken kode som er autoritativ, og hvilke tester som ikke ble kjørt av den korte kontrollen.
+
+### Dag tre: Beslutningen i praksis
+
+**Mål:** Kjør og forklar både en tillatt og en avslått beslutning.
+
+1. Gjennomfør [den kjørbare autorisasjonsflyten](../flows/authorization-decision/).
+2. Undersøk forespørselens subjekt, ressurs, handling og ressursparti.
+3. Følg `DecisionController`, Context Handler, PRP og PDP.
+4. Finn hvor rollebeslutningen går videre til delegeringer.
+5. Finn hvor en tilgangsliste kan endre et foreløpig `Permit` til `Deny`.
+6. Kjør en eksisterende negativ Bruno-test eller avtal et trygt negativt scenario med fadderen.
+7. Sammenlign resultat og statuskode.
+
+**Leveranse:** En tabell med inngangsdata, datakilder, beslutning og begrunnelse for de to testene.
+
+**Kontrollpunkt:** Du kan skille en domenebeslutning fra manglende API-tilgang og fra teknisk evalueringsfeil.
+
+### Dag fire: Data, integrasjoner og observabilitet
+
+**Mål:** Finn hvor beslutningsgrunnlaget kommer fra, og følg det gjennom driftsflatene.
+
+1. Åpne persistensmodellen til komponenten du arbeider med.
+2. Finn tabellen, blobben, køen eller det eksterne API-et som leverer hvert viktig datapunkt.
+3. Velg én integrasjon og dokumenter eier, kontrakt, autentisering, timeout og feiloppførsel.
+4. Kjør golden path på nytt med en trace- eller korrelasjons-ID.
+5. Finn relevante logger, spor og målinger.
+6. Følg audit-hendelsen så langt tilgangen din tillater.
+7. Kontroller at observabilitetsdataene ikke eksponerer hele tokens eller unødvendige personopplysninger.
+
+**Leveranse:** En kort feilsøkingslogg som viser hvor du lette, hvilke signaler du fant og hvor eierskapet skiftet.
+
+**Kontrollpunkt:** Du vet forskjellen mellom komponentens autoritative data, hurtigbuffer og data som leses fra en annen tjeneste.
+
+### Dag fem: Første trygge endring
+
+**Mål:** Levere en liten, reell forbedring gjennom den vanlige arbeidsflyten.
+
+Velg sammen med fadderen en endring som kan være
+
+- en test som tydeliggjør eksisterende oppførsel
+- bedre feilhåndtering eller observabilitet
+- en avgrenset dokumentasjonsrettelse nær koden
+- en liten feil med kjent forventet resultat
+
+Gjør deretter følgende:
+
+1. Beskriv forventet oppførsel før du endrer koden.
+2. Lag eller identifiser testen som beskytter oppførselen.
+3. Gjør den minste nødvendige endringen.
+4. Kjør relevante enhets- og integrasjonstester.
+5. Kontroller om kontrakter, migreringer eller leveranserekkefølge påvirkes.
+6. Åpne en pull request med testbevis og tilbakerullingsvurdering.
+7. Gå gjennom tilbakemeldingene sammen med fadderen.
+
+**Leveranse:** En liten pull request som følger teamets kvalitetskrav.
+
+**Kontrollpunkt:** En annen utvikler kan forstå hvorfor endringen er trygg, hvordan den ble prøvd og hvilke komponenter den påvirker.
+
+## Oppsummering med fadderen
+
+Avslutt uken med å vurdere disse punktene:
+
+| Område | Jeg kan selv | Jeg trenger mer øvelse |
+|---|---|---|
+| Forklare domenebegrepene |  |  |
+| Finne riktig komponent og repo |  |  |
+| Bygge og kjøre relevante tester |  |  |
+| Følge en `Permit` og en `Deny` |  |  |
+| Finne beslutningsgrunnlaget |  |  |
+| Bruke logger, spor og målinger |  |  |
+| Gjøre en trygg liten endring |  |  |
+
+Avtal ett fagområde du skal fordype deg i den neste måneden, og én konkret oppgave der du kan bruke kunnskapen.
+## Når du står fast
+
+| Symptom | Første kontroll |
+|---|---|
+| `401` eller `403` før PDP-svar | token, scope, abonnementnøkkel og API-grense |
+| `Deny` | subjekt, representert part, ressurs, handling og tilgangsliste |
+| `NotApplicable` | ingen policyregel passer |
+| `Indeterminate` | ugyldig kontekst, manglende policy eller evalueringsfeil |
+| ulikt resultat mellom miljøer | testdata, policyversjon, delegeringer, funksjonsflagg og konfigurasjon |
+| manglende audit-hendelse | funksjonsflagg, kø, prosessor og korrelasjon |
+
+Ikke endre en delt database direkte for å få testen til å virke. Bruk det støttede API-et eller testdataflyten.


### PR DESCRIPTION
## Summary
- add a five-day onboarding plan for new Authorization developers
- add an executable end-to-end PDP exercise using the maintained Bruno collection
- cover code navigation, data ownership, observability and a first safe change
- link onboarding and the golden path from the system documentation

## Verification
- hugo --renderToMemory
- source Bruno request verified at commit 20fcb3f
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added onboarding guides for new developers, including a structured first-week plan, setup guidance, learning objectives and troubleshooting support.
  - Added an end-to-end authorisation decision exercise covering execution, expected outcomes, tracing and troubleshooting.
  - Added links to the onboarding and executable authorisation decision guides in the reading guides.

- **Documentation**
  - Clarified the purpose of authorisation flow documentation and directed readers to API and integration guidance for further detail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->