### PR TITLE
Document authorization runtime architecture

### DIFF
--- a/content/authorization/reference/system/flows/authorization-decision/_index.en.md
+++ b/content/authorization/reference/system/flows/authorization-decision/_index.en.md
@@ -51,7 +51,7 @@ Do not change shared test data without agreement.
 5. On `NotApplicable`, relevant delegations are loaded and evaluated.
 6. A preliminary `Permit` may become `Deny` when a required access list rejects the party.
 7. Event Log creates the event when enabled.
-8. the Audit Log function consumes `authorizationeventlog` and calls the Audit Log API.
+8. The Audit Log function consumes `authorizationeventlog` and calls the Audit Log API.
 
 ## Run locally
 

--- a/content/authorization/reference/system/onboarding/_index.nb.md
+++ b/content/authorization/reference/system/onboarding/_index.nb.md
@@ -60,7 +60,7 @@ Integrasjonstester krever en containermotor. Et grønt enhetstestsett dekker ikk
 
 Følg [én autorisasjonsbeslutning ende til ende](../flows/authorization-decision/). Gjør øvelsen sammen med en fadder første gang dersom du trenger testmiljø, abonnementnøkkel eller testdata.
 
-Ikke kopier tokens, nøkler eller personopplysninger til dokumentasjon, terminalhistorikk, skjermbilder eller pull requester.
+Ikke kopier tokens, nøkler eller personopplysninger til dokumentasjon, terminalhistorikk, skjermbilder eller pull requests.
 
 ## Første kodeendring
 

--- a/content/authorization/reference/system/operations/_index.en.md
+++ b/content/authorization/reference/system/operations/_index.en.md
@@ -8,6 +8,8 @@ toc: true
 
 Components have separate deployment and operational models. This page provides the cross-cutting view; concrete runbooks belong close to the operated code.
 
+[See the logical runtime architecture, component profiles and delivery model.](./runtime-architecture/)
+
 ## Runtime
 
 Core services are primarily containerised .NET APIs. Access Management UI consists of a React client and .NET BFF. Audit Log uses Azure Storage Queue, a Function App, a container application and PostgreSQL. Databases and schemas are internal component contracts, not integration surfaces.

--- a/content/authorization/reference/system/operations/_index.nb.md
+++ b/content/authorization/reference/system/operations/_index.nb.md
@@ -6,7 +6,9 @@ weight: 9
 toc: true
 ---
 
-Komponentene har egne deploy- og driftsmodeller. Denne siden beskriver det tverrgående perspektivet; konkrete runbooks skal ligge nær koden som driftes.
+Komponentene har egne leveranse- og driftsmodeller. Denne siden beskriver det tverrgående perspektivet; konkrete driftsprosedyrer skal ligge nær koden som driftes.
+
+[Se den logiske kjøremiljøarkitekturen, komponentprofilene og leveransemodellen.](./runtime-architecture/)
 
 ## Runtime
 

--- a/content/authorization/reference/system/operations/runtime-architecture/_index.en.md
+++ b/content/authorization/reference/system/operations/runtime-architecture/_index.en.md
@@ -1,0 +1,51 @@
+---
+title: Runtime architecture
+linktitle: Runtime
+description: How Altinn Authorization components run, are configured, observed and delivered.
+weight: 1
+toc: true
+---
+
+This page presents the logical runtime architecture. It explains the deployable units, their platform services and the authoritative configuration sources. The diagram is not a complete resource inventory. Read names, sizes, replica counts and network addresses from infrastructure as code and the running environment.
+
+<a href="./runtime-overview.svg" target="_blank" rel="noopener noreferrer">
+  <img src="./runtime-overview.svg" alt="Logical runtime architecture for Altinn Authorization" style="width: 100%; cursor: zoom-in;" />
+</a>
+
+*Select the diagram to open it at full size.*
+
+## Overview
+
+Most core services are built as Linux containers behind the public ingress and API boundary. Access Management UI and the Audit Log API run as Azure Container Apps. Audit Log Consumer runs as a separately delivered Azure Function App. Each component owns its PostgreSQL databases, schemas, blob containers and queues; these stores are not integration interfaces.
+
+The infrastructure in `altinn-authorization-tmp` follows a hub-and-spoke model. The hub provides shared network and platform services, whilst an environment-specific spoke hosts workloads and data services. Configuration refers to AT22, AT23, AT24, YT01, TT02 and production, but not every component necessarily runs in every environment.
+
+## Deployable units
+
+| Component | Deployable units | Persistent data and messaging | Authoritative source |
+|---|---|---|---|
+| Authentication | Containerised .NET API | Multiple PostgreSQL schemas | [altinn-authentication](https://github.com/Altinn/altinn-authentication/tree/e581d8d61542e87709f5b7292af4532693072832) |
+| Register | Containerised .NET API and background processing | PostgreSQL and import-related stores | [altinn-register](https://github.com/Altinn/altinn-register/tree/8d34dbf828e40b8d529f0ee2040aa1eeed55bd87) and [infrastructure transition](https://github.com/Altinn/altinn-authorization-tmp/tree/20fcb3f06a20b93ba7bba04a2fa8f55b57d033cb/src/apps/Altinn.Register/infra) |
+| Resource Registry | Containerised .NET API | PostgreSQL and resource-related blob data | [altinn-resource-registry](https://github.com/Altinn/altinn-resource-registry/tree/8cc78660c3650e71b48fd18587928ef8065d9ea4) |
+| Authorization (PDP) | Containerised .NET API | PostgreSQL, blobs, queue and memory cache | [application and infrastructure](https://github.com/Altinn/altinn-authorization-tmp/tree/20fcb3f06a20b93ba7bba04a2fa8f55b57d033cb/src/apps/Altinn.Authorization) |
+| Access Management | Containerised .NET APIs and background processing | PostgreSQL, Service Bus and lease storage | [application and infrastructure](https://github.com/Altinn/altinn-authorization-tmp/tree/20fcb3f06a20b93ba7bba04a2fa8f55b57d033cb/src/apps/Altinn.AccessManagement) |
+| Access Management UI | React client and .NET BFF in an Azure Container App | No authoritative business database | [altinn-access-management-frontend](https://github.com/Altinn/altinn-access-management-frontend/tree/8539d5bd44c1fbace079a65dfa42831a599f8806) |
+| Audit Log | API in an Azure Container App and Consumer in a separate Azure Function App | PostgreSQL and Azure Storage Queue | [altinn-auth-audit-log](https://github.com/Altinn/altinn-auth-audit-log/tree/c070a2c4e18ee648ed9fb8a82dc53e2889ee235e) |
+
+See the [application architecture](../../application-architecture/) for detailed database and storage models.
+
+## Delivery
+
+The new monorepo workflow builds a versioned container image, publishes it to GitHub Container Registry and applies component Terraform in sequence across test, TT02 and production. The inspected workflow does not show the mechanism that selects the new image in the running environment. Document that link when it is established or located; do not treat a published image as proof of deployment.
+
+Older component repositories have separate workflows. Access Management UI includes an explicit rollback workflow. Audit Log delivers the Consumer Function App and API Container App separately.
+
+## Configuration, security and observability
+
+Use the same image across environments. Supply ordinary configuration and feature flags through App Configuration, keep secrets in Key Vault or the approved secret store, and use managed identities with least privilege. The shared infrastructure includes Log Analytics, Application Insights and managed Grafana.
+
+Each component repository or operational tool should identify health endpoints, logs, traces, metrics, dashboards, alerts, dependency failures, rollback instructions and the owner. A decision should be traceable by trace or correlation ID from PEP through PDP and dependencies to Audit Log without logging unnecessary personal data.
+
+## Ownership
+
+System documentation owns the stable logical model and cross-component links. Component repositories own build and delivery details, health checks and operational procedures. Terraform and the running platform own resource names, network values, sizes and environment-specific settings.

--- a/content/authorization/reference/system/operations/runtime-architecture/_index.nb.md
+++ b/content/authorization/reference/system/operations/runtime-architecture/_index.nb.md
@@ -1,0 +1,85 @@
+---
+title: Kjøremiljøarkitektur
+linktitle: Kjøremiljø
+description: Slik kjører, konfigureres, overvåkes og leveres komponentene i Altinn Autorisasjon.
+weight: 1
+toc: true
+---
+
+Denne siden viser den logiske kjøremiljøarkitekturen. Den forklarer hvilke enheter som kan leveres, hvilke plattformtjenester de bruker, og hvor du finner den autoritative konfigurasjonen. Diagrammet er ikke en fullstendig ressursoversikt. Navn, størrelser, antall instanser og nettverksadresser skal leses fra infrastrukturen som kode og miljøet som kjører.
+
+<a href="./runtime-overview.svg" target="_blank" rel="noopener noreferrer">
+  <img src="./runtime-overview.svg" alt="Logisk kjøremiljøarkitektur for Altinn Autorisasjon" style="width: 100%; cursor: zoom-in;" />
+</a>
+
+*Klikk på diagrammet for å åpne det i full størrelse.*
+
+## Hovedtrekk
+
+- Klienter og andre Altinn-komponenter møter tjenestene gjennom den offentlige inngangen og API-grensen.
+- De fleste kjernetjenestene bygges som Linux-containere. Den nøyaktige plasseringen og skaleringen kan variere mellom miljøene.
+- Access Management UI og Audit Log API kjører som Azure Container Apps. Audit Log Consumer kjører som en separat Azure Function App.
+- Hver komponent eier dataene sine. PostgreSQL-databaser, skjemaer, blobcontainere og køer er interne lagringskontrakter, ikke integrasjonsflater.
+- Azure App Configuration gir konfigurasjon, mens Key Vault og administrerte identiteter beskytter hemmeligheter og tilganger.
+- Den felles plattformen tilbyr blant annet nettverk, privat navneoppslag, brannmur, lagring, Service Bus og observabilitet.
+
+Infrastrukturen i `altinn-authorization-tmp` bruker en hub- og spoke-modell. Huben samler felles nettverkstjenester. Hvert miljø har en spoke med miljøspesifikke arbeidslaster og datatjenester. Konfigurasjonen omtaler utviklings- og testmiljøene AT22, AT23, AT24 og YT01, testmiljøet TT02 og produksjon. Det betyr ikke at alle komponentene finnes i alle miljøene.
+
+## Komponentprofiler
+
+| Komponent | Enheter som kan leveres | Varige data og meldinger | Konfigurasjon og hemmeligheter | Autoritativ kilde |
+|---|---|---|---|---|
+| Authentication | .NET API som container | Flere PostgreSQL-skjemaer | Miljøkonfigurasjon og hemmeligheter utenfor containerbildet | [altinn-authentication](https://github.com/Altinn/altinn-authentication/tree/e581d8d61542e87709f5b7292af4532693072832) |
+| Register | .NET API og bakgrunnsarbeid som container | PostgreSQL og importrelaterte lagre | Applikasjonsrepoet eier koden; infrastrukturen flyttes til monorepoet | [altinn-register](https://github.com/Altinn/altinn-register/tree/8d34dbf828e40b8d529f0ee2040aa1eeed55bd87) og [Register-infrastruktur](https://github.com/Altinn/altinn-authorization-tmp/tree/20fcb3f06a20b93ba7bba04a2fa8f55b57d033cb/src/apps/Altinn.Register/infra) |
+| Resource Registry | .NET API som container | PostgreSQL og ressursrelaterte blobdata | Koden ligger fortsatt i eget repo; plasseringen vil endres ved flytting til monorepoet | [altinn-resource-registry](https://github.com/Altinn/altinn-resource-registry/tree/8cc78660c3650e71b48fd18587928ef8065d9ea4) |
+| Authorization (PDP) | .NET API som container | PostgreSQL, blobcontainere, kø og minnebuffer | App Configuration og administrert identitet settes opp fra Terraform | [applikasjon](https://github.com/Altinn/altinn-authorization-tmp/tree/20fcb3f06a20b93ba7bba04a2fa8f55b57d033cb/src/apps/Altinn.Authorization) og [infrastruktur](https://github.com/Altinn/altinn-authorization-tmp/tree/20fcb3f06a20b93ba7bba04a2fa8f55b57d033cb/src/apps/Altinn.Authorization/infra) |
+| Access Management | .NET API-er og bakgrunnsarbeid som container | PostgreSQL, Service Bus og lagring for låser | Terraform setter opp blant annet database, Key Vault, App Configuration, identitet og rolletilganger | [applikasjon](https://github.com/Altinn/altinn-authorization-tmp/tree/20fcb3f06a20b93ba7bba04a2fa8f55b57d033cb/src/apps/Altinn.AccessManagement) og [infrastruktur](https://github.com/Altinn/altinn-authorization-tmp/tree/20fcb3f06a20b93ba7bba04a2fa8f55b57d033cb/src/apps/Altinn.AccessManagement/infra) |
+| Access Management UI | React-klient og .NET BFF i en Azure Container App | Ingen autoritativ forretningsdatabase | Miljøspesifikke innstillinger for BFF og klient | [altinn-access-management-frontend](https://github.com/Altinn/altinn-access-management-frontend/tree/8539d5bd44c1fbace079a65dfa42831a599f8806) |
+| Audit Log | API i en Azure Container App og Consumer i en separat Azure Function App | PostgreSQL og Azure Storage Queue | Egne leveranseløp og miljøinnstillinger for API-et og funksjonen | [altinn-auth-audit-log](https://github.com/Altinn/altinn-auth-audit-log/tree/c070a2c4e18ee648ed9fb8a82dc53e2889ee235e) |
+
+Detaljene i [datamodellene](../../application-architecture/) forklarer tabeller, skjemaer og blobcontainere. Denne siden viser bare hvordan lagrene inngår i kjøremiljøet.
+
+## Slik leveres endringer
+
+I det nye monorepoet gjør GitHub Actions to forskjellige jobber:
+
+1. Arbeidsflyten bygger applikasjonen som et versjonert containerbilde og publiserer bildet til GitHub Container Registry.
+2. Terraform kjøres først mot utviklings- og testmiljøene, deretter TT02 og til slutt produksjon når applikasjonen har miljøspesifikk infrastruktur.
+
+Navnet `CD: Apps` kan gi inntrykk av at arbeidsflyten også oppdaterer den kjørende arbeidslasten. Den undersøkte arbeidsflyten bygger og publiserer bildet og kjører Terraform, men viser ikke koblingen som velger det nye bildet i kjøremiljøet. Dokumenter denne koblingen når den er etablert eller funnet. Ikke anta at et publisert bilde er satt i drift.
+
+De eldre komponentrepoene har egne arbeidsflyter. Access Management UI har blant annet et eksplisitt løp for tilbakerulling. Audit Log leverer Consumer som Function App og API-et som Container App i separate løp. Følg arbeidsflyten i repoet som eier komponenten før du planlegger rekkefølge eller tilbakerulling.
+
+## Konfigurasjon og sikkerhet
+
+Containerbildet skal være likt mellom miljøene. Miljøforskjeller skal komme fra konfigurasjon og plattformressurser, ikke fra manuelle endringer i bildet.
+
+- Bruk App Configuration til vanlig miljøkonfigurasjon og funksjonsbrytere.
+- Oppbevar hemmeligheter i Key Vault eller den godkjente hemmelighetsløsningen.
+- Bruk administrerte identiteter og minst mulig rolletilgang mellom arbeidslastene og Azure-ressursene.
+- Bruk private endepunkter og privat navneoppslag der infrastrukturen legger til rette for det.
+- Ikke kopier hemmeligheter, tokens, tilkoblingsstrenger eller personopplysninger inn i dokumentasjonen.
+
+## Helse og observabilitet
+
+Den felles infrastrukturen inneholder Log Analytics, Application Insights og administrert Grafana. En operativ komponentprofil bør lenke til følgende opplysninger i repoet eller driftsverktøyet:
+
+- endepunktene for oppstarts-, livstegn- og klarhetssjekker
+- logger, spor og målinger med komponent- og miljønavn
+- dashbord og varsler med navngitt eier
+- forventede avhengigheter og typiske feiltilstander
+- fremgangsmåten for tilbakerulling og kontroll etter leveranse
+
+En autorisasjonsbeslutning bør kunne følges med sporings- eller korrelasjons-ID fra PEP via PDP og avhengigheter til Audit Log, uten at unødvendige personopplysninger logges.
+
+## Ansvar og vedlikehold
+
+Systemdokumentasjonen eier den stabile, logiske modellen og lenkene mellom komponentene. Repoene eier bygging, leveranse, helsesjekker og komponentnære prosedyrer. Terraform og den faktiske plattformen eier ressursnavn, nettverk, størrelser og miljøverdier.
+
+Oppdater denne siden når en komponent
+
+- flyttes mellom repoer eller kjøremodeller
+- får en ny enhet som kan leveres
+- bytter varig lager eller meldingstjeneste
+- endrer leveranserekkefølge eller strategi for tilbakerulling
+- flytter den autoritative infrastrukturen som kode

--- a/content/authorization/reference/system/operations/runtime-architecture/runtime-overview.svg
+++ b/content/authorization/reference/system/operations/runtime-architecture/runtime-overview.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1800" height="1120" viewBox="0 0 1800 1120" role="img" aria-labelledby="title desc">
+<title id="title">Altinn Authorization logical runtime architecture</title>
+<desc id="desc">Clients enter through public ingress. Container workloads and an Azure Function use shared configuration, security, data, messaging and observability services in a hub-and-spoke environment.</desc>
+<defs>
+<style>
+.bg{fill:#f7f8fa}.zone{fill:#fff;stroke:#334155;stroke-width:2}.hub{fill:#eef2ff;stroke:#4f46e5;stroke-width:2}.work{fill:#ecfeff;stroke:#0e7490;stroke-width:2}.data{fill:#fff7ed;stroke:#c2410c;stroke-width:2}.side{fill:#f0fdf4;stroke:#15803d;stroke-width:2}.title{font:700 30px Arial;fill:#0f172a}.h{font:700 22px Arial;fill:#0f172a}.t{font:18px Arial;fill:#1e293b}.s{font:15px Arial;fill:#475569}.arrow{stroke:#475569;stroke-width:3;fill:none;marker-end:url(#a)}.dash{stroke-dasharray:8 7}
+</style>
+<marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#475569"/></marker>
+</defs>
+<rect class="bg" width="1800" height="1120"/>
+<text class="title" x="60" y="58">Altinn Authorization – logical runtime architecture</text>
+<text class="s" x="60" y="88">Stable system view. Exact placement, scaling and resource names vary by environment.</text>
+<rect class="zone" x="60" y="120" width="1680" height="115" rx="16"/><text class="h" x="90" y="158">Consumers and ingress</text>
+<rect class="hub" x="310" y="145" width="260" height="60" rx="12"/><text class="t" x="355" y="181">Users and clients</text>
+<rect class="hub" x="650" y="145" width="310" height="60" rx="12"/><text class="t" x="695" y="181">Altinn components / PEPs</text>
+<rect class="hub" x="1060" y="145" width="460" height="60" rx="12"/><text class="t" x="1110" y="181">DNS · Application Gateway · API boundary</text>
+<rect class="zone" x="60" y="275" width="1280" height="515" rx="16"/><text class="h" x="90" y="315">Environment spoke – workloads and functions</text>
+<rect class="work" x="100" y="355" width="330" height="105" rx="12"/><text class="h" x="135" y="393">Authentication</text><text class="s" x="135" y="425">.NET API container</text>
+<rect class="work" x="475" y="355" width="330" height="105" rx="12"/><text class="h" x="510" y="393">Register</text><text class="s" x="510" y="425">API + background processing</text>
+<rect class="work" x="850" y="355" width="410" height="105" rx="12"/><text class="h" x="885" y="393">Resource Registry</text><text class="s" x="885" y="425">.NET API container</text>
+<rect class="work" x="100" y="500" width="330" height="105" rx="12"/><text class="h" x="135" y="538">Authorization (PDP)</text><text class="s" x="135" y="570">.NET API container</text>
+<rect class="work" x="475" y="500" width="330" height="105" rx="12"/><text class="h" x="510" y="538">Access Management</text><text class="s" x="510" y="570">APIs + background processing</text>
+<rect class="work" x="850" y="500" width="410" height="105" rx="12"/><text class="h" x="885" y="538">Access Management UI</text><text class="s" x="885" y="570">Azure Container App · React + .NET BFF</text>
+<rect class="work" x="280" y="650" width="350" height="105" rx="12"/><text class="h" x="315" y="688">Audit Log API</text><text class="s" x="315" y="720">Azure Container App</text>
+<rect class="work" x="710" y="650" width="350" height="105" rx="12"/><text class="h" x="745" y="688">Audit Log consumer</text><text class="s" x="745" y="720">Azure Function App</text>
+<rect class="side" x="1380" y="275" width="360" height="515" rx="16"/><text class="h" x="1410" y="315">Shared platform</text>
+<text class="t" x="1410" y="365">App Configuration</text><text class="t" x="1410" y="410">Key Vault</text><text class="t" x="1410" y="455">Managed identities + RBAC</text><text class="t" x="1410" y="500">Private DNS + endpoints</text><text class="t" x="1410" y="545">Firewall + hub network</text><text class="t" x="1410" y="610">Log Analytics</text><text class="t" x="1410" y="655">Application Insights</text><text class="t" x="1410" y="700">Managed Grafana</text><text class="s" x="1410" y="750">Common services; use varies</text><text class="s" x="1410" y="772">between components.</text>
+<rect class="zone" x="60" y="830" width="1680" height="220" rx="16"/><text class="h" x="90" y="870">Component-owned state and messaging</text>
+<rect class="data" x="110" y="910" width="360" height="95" rx="12"/><text class="h" x="145" y="948">PostgreSQL</text><text class="s" x="145" y="978">Databases and schemas</text>
+<rect class="data" x="520" y="910" width="360" height="95" rx="12"/><text class="h" x="555" y="948">Azure Storage</text><text class="s" x="555" y="978">Blobs, queues and leases</text>
+<rect class="data" x="930" y="910" width="360" height="95" rx="12"/><text class="h" x="965" y="948">Service Bus</text><text class="s" x="965" y="978">Asynchronous messages</text>
+<rect class="data" x="1340" y="910" width="330" height="95" rx="12"/><text class="h" x="1375" y="948">Memory cache</text><text class="s" x="1375" y="978">Non-authoritative state</text>
+<path class="arrow" d="M570 175 H650"/><path class="arrow" d="M960 175 H1060"/><path class="arrow" d="M1290 205 V260 H700 V345"/><path class="arrow dash" d="M1380 520 H1265"/><path class="arrow" d="M700 790 V900"/><path class="arrow" d="M885 755 V900"/>
+<text class="s" x="76" y="1090">Environment configuration currently includes AT22, AT23, AT24, YT01, TT02 and production.</text>
+</svg>


### PR DESCRIPTION
## Summary

- add Norwegian and English runtime architecture documentation for Altinn Authorization
- add a clickable SVG covering workloads, shared platform services, state and messaging
- document deployable units, delivery boundaries, configuration, security, observability and ownership
- clarify that Access Management UI and Audit Log API run as Azure Container Apps, whilst Audit Log Consumer runs as an Azure Function App
- fix two minor language errors in the onboarding and authorization flow pages

## Validation

- \hugo --renderToMemory\ completed successfully in 364 seconds
- SVG parsed successfully as XML after the final runtime clarification
- \git diff --check\ passed

The Hugo build reports existing deprecation and unrelated missing-page warnings outside the changed authorization documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new English and Norwegian documentation describing the logical runtime architecture, component profiles, delivery processes, configuration, security, observability and ownership boundaries.
  * Added a cross-reference from the operations guidance to the runtime architecture documentation.
  * Clarified terminology around component delivery and operational procedures.
  * Improved authorization tracing guidance by clearly identifying the Audit Log as step 8.
  * Corrected onboarding guidance to refer to “pull requests” when discussing sensitive data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->