### PR TITLE
Improve Authorization landing page and user journeys

### DIFF
--- a/content/authorization/_index.en.md
+++ b/content/authorization/_index.en.md
@@ -1,7 +1,8 @@
 ---
 title: Authorization
-description: The authorization components provide access management and control functionality for digital and analog services hosted in the Altinn Platform or other places.
+description: Altinn Authorization provides shared authentication, representation, access management and access control for public services and systems.
 toc: false
+layout: authorization-landing
 weight: 1
 aliases:
   - /technology/solutions/altinn-platform/authorization/
@@ -10,57 +11,4 @@ cascade:
     product: product_authorization
 ---
 
-{{<children />}}
-
- <!-- <div class="row adocs-featuredBlocks">
-    <div class="col-12 col-lg-6 mb-5">
-        <div style="text-align: center;">
-            <h2 class="a-h3">Find out more</h2>
-            <p class="a-js-truncate-2">Read more about Altinn Authorization</p>
-            <div class="a-illustration-icon">
-                <img src="./authorization-1.drawio.svg">
-                <div class="a-illustration-overlay">
-                    <span class="sr-only">About Altinn Authorization</span>
-                </div>
-            </div>
-        </div>
-        <div class="a-list-container mb-2 mx-auto mx-lg-6">
-            <ul class="a-list a-list-noIcon">
-             <li class="a-dotted a-clickable a-list-hasRowLink">
-                    <a href="about" class="a-list-rowLink">
-                        <div class="row">
-                            <div class="col">
-                                About Altinn Authorization
-                            </div>
-                        </div>
-                    </a>
-                </li>
-                <li class="a-dotted a-clickable a-list-hasRowLink">
-                    <a href="what-do-you-get" class="a-list-rowLink">
-                        <div class="row">
-                            <div class="col">
-                                What do you get?
-                            </div>
-                        </div>
-                    </a>
-                </li>
-            </ul>
-        </div>
-    </div>
-    <div class="col-12 col-lg-6 mb-5">
-        <div style="text-align: center;">
-            <h2 class="a-h3">Get started</h2>
-            <p class="a-js-truncate-2">Create your first resource</p>
-            <div class="a-illustration-icon">
-              <img src="./authorization-1.drawio.svg">
-                <div class="a-illustration-overlay">
-                    <span class="sr-only">Create your first resource</span>
-                </div>
-            </div>
-        </div>
-        <div class="a-list-container mb-2 mx-auto mx-lg-6">
-            <ul class="a-list a-list-noIcon">
-            </ul>
-        </div>
-    </div>
-</div> -->
+{{< authorization-landing >}}

--- a/content/authorization/_index.nb.md
+++ b/content/authorization/_index.nb.md
@@ -1,7 +1,8 @@
 ---
 title: Autorisasjon
-description: Altinn Autorisasjon er en samling løsninger som gir tilgangsstyring og tilgangskontroll for digitale og analoge tjenester som kjører i Altinn-plattformen eller andre steder.
+description: Altinn Autorisasjon gir offentlige tjenester og systemer felles løsninger for autentisering, representasjon, tilgangsstyring og tilgangskontroll.
 toc: false
+layout: authorization-landing
 weight: 1
 aliases:
   - /authorization/
@@ -11,93 +12,4 @@ cascade:
     product: product_authorization
 ---
 
-{{<children />}}
-
- <!-- <div class="row adocs-featuredBlocks">
-    <div class="col-12 col-lg-6 mb-5">
-        <div style="text-align: center;">
-            <h2 class="a-h3">Finn ut mer</h2>
-            <p class="a-js-truncate-2"></p>
-            <div class="a-illustration-icon">
-                <img src="./authorization-1.drawio.svg">
-                <div class="a-illustration-overlay">
-                    <span class="sr-only">Om Altinn Autorisasjon</span>
-                </div>
-            </div>
-        </div>
-        <div class="a-list-container mb-2 mx-auto mx-lg-6">
-            <ul class="a-list a-list-noIcon">
-             <li class="a-dotted a-clickable a-list-hasRowLink">
-                    <a href="about" class="a-list-rowLink">
-                        <div class="row">
-                            <div class="col">
-                                Om Altinn Autorisasjon
-                            </div>
-                        </div>
-                    </a>
-                </li>
-                <li class="a-dotted a-clickable a-list-hasRowLink">
-                    <a href="what-do-you-get" class="a-list-rowLink">
-                        <div class="row">
-                            <div class="col">
-                                Hva får du
-                            </div>
-                        </div>
-                    </a>
-                </li>
-            </ul>
-        </div>
-    </div>
-    <div class="col-12 col-lg-6 mb-5">
-        <div style="text-align: center;">
-            <h2 class="a-h3">Kom i gang</h2>
-            <p class="a-js-truncate-2"></p>
-            <div class="a-illustration-icon">
-              <img src="./authorization-1.drawio.svg">
-                <div class="a-illustration-overlay">
-                    <span class="sr-only">Create your first resource</span>
-                </div>
-            </div>
-        </div>
-        <div class="a-list-container mb-2 mx-auto mx-lg-6">
-            <ul class="a-list a-list-noIcon">
-                <li class="a-dotted a-clickable a-list-hasRowLink">
-                    <a href="getting-started/resource-registry" class="a-list-rowLink">
-                        <div class="row">
-                            <div class="col">
-                                Ressursregister
-                            </div>
-                        </div>
-                    </a>
-                </li>
-                <li class="a-dotted a-clickable a-list-hasRowLink">
-                    <a href="getting-started/consent" class="a-list-rowLink">
-                        <div class="row">
-                            <div class="col">
-                                Samtykke
-                            </div>
-                        </div>
-                    </a>
-                </li>
-                <li class="a-dotted a-clickable a-list-hasRowLink">
-                    <a href="getting-started/systemuser" class="a-list-rowLink">
-                        <div class="row">
-                            <div class="col">
-                                Systembruker
-                            </div>
-                        </div>
-                    </a>
-                </li>
-                <li class="a-dotted a-clickable a-list-hasRowLink">
-                    <a href="getting-started/access-list" class="a-list-rowLink">
-                        <div class="row">
-                            <div class="col">
-                                Tilgangslister
-                            </div>
-                        </div>
-                    </a>
-                </li>
-            </ul>
-        </div>
-    </div>
-</div> -->
+{{< authorization-landing >}}

--- a/content/authorization/getting-started/_index.en.md
+++ b/content/authorization/getting-started/_index.en.md
@@ -1,12 +1,20 @@
 ---
 title: Getting started with Altinn Authorization
 linktitle: Getting started
-description: Getting started
+description: Choose an integration method and follow the main journey for service owners or system integrators.
 toc: false
 weight: 3
 cascade:
   params:
     diataxis: diataxis_tutorials
 ---
+
+Start with your role:
+
+- [Service owner: Protect an API with Altinn Authorization.](./service-owner/)
+- [System integrator: Integrate a system with Altinn Authorization.](./system-integrator/)
+- [Choose the right integration method if you are unsure.](./choose-authentication/)
+
+Use the topic pages below when the main journey directs you to them.
 
 {{<children />}}

--- a/content/authorization/getting-started/_index.nb.md
+++ b/content/authorization/getting-started/_index.nb.md
@@ -1,12 +1,20 @@
 ---
 title: Kom i gang med Altinn Autorisasjon
 linktitle: Kom i gang
-description: Her finner informasjon om hvordan komme i gang med Altinn autorisasjon
+description: Velg integrasjonsmåte og følg hovedløpet for tjenesteeiere eller systemintegratorer.
 toc: false
 weight: 3
 cascade:
   params:
     diataxis: diataxis_tutorials
 ---
+
+Start med rollen din:
+
+- [Tjenesteeier: Beskytt et API med Altinn Autorisasjon.](./service-owner/)
+- [Systemintegrator: Integrer et system med Altinn Autorisasjon.](./system-integrator/)
+- [Velg riktig integrasjonsmåte hvis du er usikker.](./choose-authentication/)
+
+Du kan deretter bruke temasidene nedenfor når hovedløpet peker til dem.
 
 {{<children />}}

--- a/content/authorization/getting-started/choose-authentication/_index.en.md
+++ b/content/authorization/getting-started/choose-authentication/_index.en.md
@@ -1,0 +1,38 @@
+---
+title: Choose the right integration method
+linktitle: Choose integration method
+description: How to choose authentication, representation and authorisation for your service or system.
+weight: 1
+toc: true
+---
+
+Start by deciding who will act, which party the action concerns and whether a person is present. The choice determines which tokens, authorisations and APIs you need.
+
+## Choose by situation
+
+| Situation | Start with | What the choice provides |
+|---|---|---|
+| A person uses your system and can sign in | [ID-porten](../authentication/id-porten/) | Confirms the person's identity |
+| A system calls an API as its own organisation | [Maskinporten](../authentication/maskinporten/) | Confirms the organisation or client calling the API |
+| A system acts with access approved by an organisation | [System user](../../guides/system-vendor/system-user/) | Connects the system to approved access |
+| A system works for customers or clients | [System user for clients](../../guides/system-vendor/system-user/#system-user-for-client-system) | Connects the system to client relationships and access packages |
+| A data consumer needs permission to retrieve specific data | [Consent](../consent/) | Records what the person or organisation has consented to |
+| A service decides whether an identity may perform an action | [PDP access control](../../guides/resource-owner/generic-access-resource/integrating-link-service/#integration-with-pdp) | Checks identity, resource, action and affected party |
+
+You may need several choices together. A system user, for example, uses Maskinporten for authentication whilst the service owner uses Altinn Authorization to check access.
+
+## Separate authentication from authorisation
+
+**Authentication** confirms the identity of a person or system. ID-porten and Maskinporten issue tokens that the service can verify.
+
+**Representation** describes the party on whose behalf the identity acts. This may be the person, their own organisation or a client.
+
+**Authorisation** decides whether the identity may perform a particular action on a resource for the affected party. A valid token alone does not grant access.
+
+**Consent** permits a data consumer to retrieve or use specific data. Consent does not replace authentication or access control.
+
+## Continue with your role
+
+- [Follow the main journey for service owners.](../service-owner/)
+- [Follow the main journey for system integrators.](../system-integrator/)
+- [Check current status and planned work.](../../reference/status/)

--- a/content/authorization/getting-started/choose-authentication/_index.nb.md
+++ b/content/authorization/getting-started/choose-authentication/_index.nb.md
@@ -1,0 +1,73 @@
+---
+title: Velg riktig integrasjonsmåte
+linktitle: Velg integrasjonsmåte
+description: Slik velger du autentisering, representasjon og autorisasjon for tjenesten eller systemet ditt.
+weight: 1
+toc: true
+---
+
+Start med å avklare hvem som skal handle, hvem handlingen gjelder for, og om en person er til stede. Valget avgjør hvilke token, fullmakter og API-er du trenger.
+
+## Velg ut fra situasjonen
+
+| Situasjon | Start med | Dette løser valget |
+|---|---|---|
+| En person bruker systemet ditt og kan logge inn | [ID-porten](../authentication/id-porten/) | Bekrefter hvem personen er |
+| Et system kaller et API som virksomheten selv | [Maskinporten](../authentication/maskinporten/) | Bekrefter hvilken virksomhet eller klient som kaller API-et |
+| Et system skal handle med fullmakter fra en virksomhet | [Systembruker](../../guides/system-vendor/system-user/) | Knytter systemet til tilganger som virksomheten har godkjent |
+| Et system skal arbeide for kunder eller klienter | [Systembruker for klientsystem](../../guides/system-vendor/system-user/#systembruker-for-klientsystem) | Knytter systemet til klientforhold og tilgangspakker |
+| En datakonsument må få tillatelse til å hente bestemte data | [Samtykke](../consent/) | Dokumenterer hva personen eller virksomheten har samtykket til |
+| Tjenesten skal avgjøre om en identitet kan utføre en handling | [Tilgangskontroll med PDP](../../guides/resource-owner/generic-access-resource/integrating-link-service/#integrasjon-med-pdp) | Kontrollerer identitet, ressurs, handling og parten handlingen gjelder for |
+
+Du kan trenge flere av valgene samtidig. Systembruker bruker for eksempel Maskinporten til autentisering, mens tjenesteeieren bruker Altinn Autorisasjon til å kontrollere tilgangen.
+
+## Skill autentisering fra autorisasjon
+
+**Autentisering** bekrefter hvem personen eller systemet er. ID-porten og Maskinporten utsteder token som tjenesten kan kontrollere.
+
+**Representasjon** beskriver hvem identiteten handler på vegne av. Det kan være personen selv, egen virksomhet eller en klient.
+
+**Autorisasjon** avgjør om identiteten kan utføre en bestemt handling på en bestemt ressurs for den aktuelle parten. Et gyldig token er derfor ikke nok til å gi tilgang.
+
+**Samtykke** gir en datakonsument tillatelse til å hente eller bruke bestemte data. Samtykket erstatter ikke autentisering eller tilgangskontroll.
+
+## Hvis en person er til stede
+
+Bruk ID-porten når personen skal logge inn og systemet skal utføre handlinger på vegne av den innloggede personen.
+
+Avklar
+
+- hvilke ID-porten-scopes systemet trenger
+- hvordan access-tokenet skal veksles til et Altinn-token
+- hvordan systemet finner partene personen kan representere
+- hvordan tjenesten kontrollerer tilgang til hver handling
+
+[Følg veiledningen for autentisering med ID-porten.](../authentication/id-porten/)
+
+## Hvis systemet kjører uten en person
+
+Bruk Maskinporten når et system kaller et API uten at en person er innlogget. Maskinporten bekrefter klienten og virksomheten, men gir ikke automatisk fullmakt til å utføre alle handlinger.
+
+Bruk systembruker i tillegg når systemet trenger tilganger som en virksomhet har godkjent. Velg mellom
+
+- systembruker for egen virksomhet
+- systembruker for kunder eller klienter
+
+[Følg hovedløpet for systemintegratorer.](../system-integrator/)
+
+## Hvis du eier API-et
+
+Tjenesten må håndheve tilgangen uavhengig av hvordan klienten autentiserer seg. Definer ressursen og handlingene, kontroller tokenet, bygg riktig beslutningsforespørsel og håndhev resultatet fra PDP.
+
+[Følg hovedløpet for tjenesteeiere.](../service-owner/)
+
+## Kontroller gjeldende status
+
+Noen veiledninger beskriver overgang fra Altinn 2, funksjonalitet i test eller funksjonalitet som fortsatt utvikles. Før du velger løsning, må du kontrollere
+
+- om funksjonen er tilgjengelig i miljøet du skal bruke
+- om tjenesteeieren støtter den aktuelle identiteten
+- hvilke scopes, tilgangspakker og ressurser som gjelder
+- om veiledningen beskriver en overgangsløsning
+
+[Se status og planlagte oppgaver for Altinn Autorisasjon.](../../reference/status/)

--- a/content/authorization/getting-started/service-owner/_index.en.md
+++ b/content/authorization/getting-started/service-owner/_index.en.md
@@ -1,0 +1,34 @@
+---
+title: Protect an API with Altinn Authorization
+linktitle: For service owners
+description: How to register a resource, define rules and enforce an authorisation decision in your API.
+weight: 2
+toc: true
+---
+
+This guide gives service owners one main journey for protecting an API outside Altinn. Register what the API protects, define who may perform each action and check every request with Altinn Authorization.
+
+Use the linked guides for screenshots, API contracts and examples.
+
+## Before you start
+
+Decide which service and actions you will protect, which party each action concerns, whether a person is present and whether access can be delegated.
+
+[Use the integration chooser if authentication or representation is unclear.](../choose-authentication/)
+
+## Follow the journey
+
+1. **Clarify ownership and agreements.** Identify who owns the service, resource, rules, API and production approval. [Set up access to Resource Administration.](../resourceadministration/)
+2. **Describe the resource and actions.** Use a stable resource identifier and actions that match the operations exposed by the API.
+3. **Create the resource and policy.** Connect resource, action and the role or access package that grants access. [Create and publish the resource.](../../guides/resource-owner/create-resource-resource-admin/)
+4. **Choose optional mechanisms.** Add [system users](../../guides/resource-owner/system-user/), [consent](../../guides/resource-owner/consent/), [access lists](../../guides/resource-owner/accesslist/) or [guardianship](../guardianship/) only when required.
+5. **Authenticate the client.** Verify the ID-porten or Maskinporten token before using its contents. [See the authentication guides.](../authentication/)
+6. **Find represented parties when required.** Authorized Parties may help the client choose a party, but it does not replace the final decision. [Integrate with Authorized Parties.](../../guides/resource-owner/generic-access-resource/integrating-link-service/#integration-with-api-for-authorized-parties-issuers)
+7. **Request a PDP decision.** Supply the identity, resource, action and affected party. [Integrate with the PDP.](../../guides/resource-owner/generic-access-resource/integrating-link-service/#integration-with-pdp)
+8. **Enforce the result.** Grant access only for an explicit `Permit`. Treat `Deny` and `NotApplicable` as no access and `Indeterminate` as a technical evaluation failure.
+9. **Test the complete journey.** Cover expected permit and deny results, invalid tokens, wrong parties and resources, withdrawn access and unavailable dependencies.
+10. **Prepare production.** Verify production resources, policies, scopes, clients, logging, tracing, rollback and contact information.
+
+Never place tokens, national identity numbers, keys or personal data in documentation or defect reports.
+
+[Check the current status of Altinn Authorization before production.](../../reference/status/)

--- a/content/authorization/getting-started/service-owner/_index.nb.md
+++ b/content/authorization/getting-started/service-owner/_index.nb.md
@@ -1,0 +1,145 @@
+---
+title: Beskytt et API med Altinn Autorisasjon
+linktitle: For tjenesteeiere
+description: Slik registrerer du en ressurs, definerer regler og håndhever en autorisasjonsbeslutning i API-et ditt.
+weight: 2
+toc: true
+---
+
+Denne veiledningen gir tjenesteeiere ett hovedløp for å beskytte et API som kjører utenfor Altinn. Du registrerer det som skal beskyttes, definerer hvem som kan gjøre hva, og lar API-et kontrollere hver forespørsel mot Altinn Autorisasjon.
+
+Detaljsidene inneholder skjermbilder, API-kontrakter og eksempler. Bruk denne siden til å følge riktig rekkefølge.
+
+## Før du starter
+
+Du må kunne svare på følgende:
+
+- Hvilken tjeneste eller hvilket API skal beskyttes?
+- Hvilke handlinger skal klientene kunne utføre?
+- Gjelder handlingen en person, en virksomhet eller en klient?
+- Skal en person være innlogget, eller skal et system kjøre uten en person?
+- Skal tilgangen kunne delegeres?
+- Trenger tjenesten samtykke, tilgangslister eller støtte for vergemål?
+
+[Bruk valgveiviseren hvis du er usikker på autentisering og representasjon.](../choose-authentication/)
+
+## 1. Avklar ansvar og avtaler
+
+Avklar hvem som
+
+- eier tjenesten og ressursdefinisjonen
+- forvalter reglene og tilgangspakkene
+- utvikler og drifter API-et
+- godkjenner tilgang til test og produksjon
+- følger opp endringer etter at tjenesten er tatt i bruk
+
+Du trenger tilgang til Ressursadministrasjon for organisasjonen. Enkelte integrasjoner krever også avtale og scopes i Maskinporten.
+
+[Sett opp tilgangen til Ressursadministrasjon.](../resourceadministration/)
+
+## 2. Beskriv ressursen og handlingene
+
+Gi ressursen en stabil identifikator. Beskriv navnet og formålet på bokmål, nynorsk og engelsk. Velg handlinger som samsvarer med operasjonene API-et faktisk tilbyr, for eksempel `read` eller `write`.
+
+Unngå å bruke ett vidt tilgangskrav for hele API-et hvis operasjonene har forskjellig risiko. Klienten skal bare få tilgang til handlingene den trenger.
+
+## 3. Opprett ressursen og reglene
+
+Opprett ressursen i Altinn Studio Ressursadministrasjon. Definer minst én regel som kobler sammen
+
+- ressursen
+- handlingen
+- rollen eller tilgangspakken som gir tilgang
+
+Publiser først til testmiljøet. Kontroller ressursdefinisjonen og policyen før du bruker dem i integrasjonstesten.
+
+[Følg veiledningen for å opprette og publisere en ressurs.](../../guides/resource-owner/create-resource-resource-admin/)
+
+## 4. Velg tilleggsmekanismer
+
+Bruk bare mekanismene tjenesten trenger:
+
+- [Systembruker](../../guides/resource-owner/system-user/) når et system skal bruke fullmakter som en virksomhet har godkjent.
+- [Samtykke](../../guides/resource-owner/consent/) når en datakonsument trenger tillatelse til å hente bestemte data.
+- [Tilgangslister](../../guides/resource-owner/accesslist/) når tjenesten bare skal være tilgjengelig for utvalgte virksomheter.
+- [Vergemål](../guardianship/) når en verge skal kunne handle innenfor vergefullmakten.
+
+Tilleggsmekanismene erstatter ikke tjenestens egen kontroll av token og autorisasjon.
+
+## 5. Autentiser klienten
+
+Kontroller tokenet før du gjør autorisasjonsoppslaget.
+
+- Bruk ID-porten når en person er innlogget.
+- Bruk Maskinporten når et system kaller API-et.
+- Kontroller systembrukerinformasjonen i Maskinporten-tokenet når klienten bruker systembruker.
+
+Kontroller alltid utsteder, mottaker, levetid og relevante claims etter reglene for tokenet. Ikke bruk innholdet i et token som du ikke har validert.
+
+[Se veiledningene for ID-porten og Maskinporten.](../authentication/)
+
+## 6. Finn hvem identiteten kan representere
+
+Når klienten skal velge eller oppgi en part, kan Authorized Parties brukes til å finne personene og virksomhetene identiteten kan representere.
+
+Ikke bruk listen alene som endelig tilgangskontroll. Tilgangen kan avhenge av ressursen, handlingen og andre forhold som først vurderes i PDP.
+
+[Se hvordan du integrerer med Authorized Parties.](../../guides/resource-owner/generic-access-resource/integrating-link-service/#integrasjon-med-api-for-autoriserte-parter-avgivere)
+
+## 7. Be PDP om en beslutning
+
+Bygg en beslutningsforespørsel med riktig
+
+- identitet eller systembruker
+- ressurs
+- handling
+- part som handlingen gjelder for
+
+PDP returnerer blant annet `Permit`, `Deny`, `NotApplicable` eller `Indeterminate`. API-et ditt er Policy Enforcement Point (PEP) og må håndheve resultatet.
+
+[Se forespørsler, svar og integrasjon med PDP.](../../guides/resource-owner/generic-access-resource/integrating-link-service/#integrasjon-med-pdp)
+
+## 8. Håndhev resultatet
+
+Gi bare tilgang når svaret uttrykkelig er `Permit` og alle andre kontroller i API-et er oppfylt.
+
+Behandle
+
+- `Deny` som avvist tilgang
+- `NotApplicable` som at ingen relevant regel ga tilgang
+- `Indeterminate` som en teknisk feil i evalueringen
+- manglende eller ugyldig svar som teknisk feil
+
+Ikke la tekniske feil gi tilgang. Skill samtidig mellom avvist tilgang og driftsfeil i responsen og loggene.
+
+## 9. Test hele løpet
+
+Test minst
+
+- en forventet `Permit`
+- en forventet `Deny`
+- en bruker eller systembruker uten nødvendig fullmakt
+- feil ressurs eller handling
+- feil part
+- utløpt eller ugyldig token
+- utilgjengelig avhengighet
+- endret eller trukket tilbake tilgang
+
+Bruk bare godkjente testdata. Ikke legg token, fødselsnummer, nøkler eller personopplysninger i dokumentasjon eller feilrapporter.
+
+## 10. Klargjør produksjon
+
+Før produksjonssetting skal du kontrollere at
+
+- produksjonsressursen og policyen er publisert
+- riktige scopes og klienter er godkjent
+- API-et avviser alle resultater som ikke er `Permit`
+- logger og spor kan følge en forespørsel uten unødvendige personopplysninger
+- teamet kan trekke tilbake tilgang og rulle tilbake en endring
+- tjenestebeskrivelsen og kontaktinformasjonen er oppdatert
+
+[Kontroller gjeldende status for Altinn Autorisasjon før produksjonssetting.](../../reference/status/)
+
+## Forvalt integrasjonen
+
+Oppdater ressursen og reglene når API-et endrer handlinger eller ansvar. Test alltid eksisterende klienter før du fjerner eller endrer tilganger. Tjenesteeieren har ansvar for at API-et fortsetter å håndheve beslutningen riktig.

--- a/content/authorization/getting-started/system-integrator/_index.en.md
+++ b/content/authorization/getting-started/system-integrator/_index.en.md
@@ -1,0 +1,45 @@
+---
+title: Integrate a system with Altinn Authorization
+linktitle: For system integrators
+description: How to choose an identity, set up a system user and call a service on behalf of people or organisations.
+weight: 3
+toc: true
+---
+
+This guide gives system integrators one main journey from choosing an identity to a production-ready call. It is intended for system suppliers and organisations developing their own integrations.
+
+Use the linked pages for API contracts and complete examples.
+
+## Before you start
+
+Confirm whether a person is signed in, whether the system acts for its own organisation or for clients, which API you will call, which access it requires and who can approve that access.
+
+[Use the integration chooser if the method is unclear.](../choose-authentication/)
+
+## Choose the main journey
+
+- Use [ID-porten](../authentication/id-porten/) when a person is present and the system acts on behalf of that person.
+- Use Maskinporten when the system runs without a signed-in person.
+- Add a system user when the API requires access approved by an organisation.
+- Use a client system user when a service provider acts for customers. [Follow the security requirements for shared systems.](../../guides/system-vendor/system-user/access-control/)
+
+## Set up a system user
+
+1. **Create a Maskinporten client.** Obtain the scopes required for the system registry, system users and the service owner's API. [Set up a Maskinporten client.](../maskinportenclient/)
+2. **Register the system.** Define the system identifier, supplier, text, resources or access packages, clients and redirect addresses. [Register the system.](../../guides/system-vendor/system-user/systemregistration/)
+3. **Choose own organisation or clients.** [See the difference between system user types.](../../guides/system-vendor/system-user/#system-user-for-own-system)
+4. **Choose supplier-led or user-led creation.** [Create a system user.](../../guides/system-vendor/system-user/systemuserrequest/)
+5. **Wait for approval.** Treat rejected, expired and deleted requests as separate states. [Retrieve an existing system user.](../../guides/system-vendor/system-user/byquery/)
+6. **Connect clients when required.** A client system requires a client relationship, access packages and delegation. [Set up client delegation.](../../guides/system-vendor/system-user/client-delegation/)
+7. **Retrieve and verify the token.** Verify the system, system user, organisation, client, scope and environment. [Use the system user token.](../../guides/system-vendor/system-user/usetoken/)
+8. **Call the service owner's API.** Supply the correct party, resource and action. The service owner performs the final access check.
+
+Never use one customer's token context for another customer. Do not log complete tokens or unnecessary personal data.
+
+## Test and prepare production
+
+Test approval and rejection, expired requests and tokens, wrong customers, withdrawn access, retries and unavailable dependencies. Verify production scopes, registration values, exact redirect addresses, tenant separation, key rotation and user-facing errors.
+
+- [Troubleshoot the System User integration.](../../guides/system-vendor/system-user/troubleshooting/)
+- [Check the current status of Altinn Authorization.](../../reference/status/)
+- [Delete a system user.](../../guides/system-vendor/system-user/deleterequest/)

--- a/content/authorization/getting-started/system-integrator/_index.nb.md
+++ b/content/authorization/getting-started/system-integrator/_index.nb.md
@@ -1,0 +1,170 @@
+---
+title: Integrer et system med Altinn Autorisasjon
+linktitle: For systemintegratorer
+description: Slik velger du identitet, setter opp systembruker og kaller en tjeneste på vegne av personer eller virksomheter.
+weight: 3
+toc: true
+---
+
+Denne veiledningen gir systemintegratorer ett hovedløp fra valg av identitet til produksjonsklart kall. Den passer for systemleverandører og virksomheter som utvikler egne integrasjoner.
+
+Detaljsidene inneholder API-kontrakter og komplette eksempler. Bruk denne siden til å velge riktig løp og rekkefølge.
+
+## Før du starter
+
+Avklar
+
+- om en person er innlogget når systemet kaller tjenesten
+- om systemet handler for egen virksomhet eller for kunder
+- hvilken tjenesteeier og hvilket API dere skal integrere med
+- hvilke ressurser, handlinger, scopes og tilgangspakker API-et krever
+- hvem som kan godkjenne tilgangen
+- hvilke testdata og miljøer dere kan bruke
+
+Tjenesteeieren må bekrefte hvilke tilganger API-et krever. Ikke utled kravene bare fra navnet på en tilgangspakke eller et scope.
+
+[Bruk valgveiviseren hvis du er usikker på integrasjonsmåten.](../choose-authentication/)
+
+## Velg hovedløp
+
+### En person er innlogget
+
+Bruk ID-porten når en person er til stede og systemet skal handle på vegne av personen.
+
+1. Registrer klienten etter kravene fra ID-porten.
+2. Be bare om scopene systemet trenger.
+3. La personen logge inn og godkjenne scopene.
+4. Bruk access-tokenet, ikke ID-tokenet, i den videre tokenflyten.
+5. Veksle tokenet hvis Altinn-API-et krever Altinn-token.
+6. Finn aktuelle parter når brukeren skal velge hvem handlingen gjelder for.
+7. Kall API-et med riktig part og ressurs.
+8. Håndter avvist tilgang uten å skjule den som en teknisk feil.
+
+[Følg veiledningen for autentisering med ID-porten.](../authentication/id-porten/)
+
+### Systemet handler for egen virksomhet
+
+Bruk Maskinporten når systemet kjører uten en innlogget person. Bruk systembruker i tillegg når API-et krever tilganger som virksomheten har godkjent.
+
+Følg systembrukerløpet nedenfor og velg **systembruker for eget system**.
+
+### Systemet handler for kunder
+
+Bruk systembruker for klientsystem når en regnskapsfører, revisor eller annen tjenestetilbyder skal bruke systemet på vegne av kunder.
+
+Dette løpet krever tilgangspakker og klientforhold. Systemet må skille kundene og kontrollere at en innlogget bruker bare kan bruke riktig systembruker for kunder vedkommende kan arbeide for.
+
+[Se sikkerhetskravene for delte systemer.](../../guides/system-vendor/system-user/access-control/)
+
+## Sett opp systembruker
+
+### 1. Opprett Maskinporten-klient
+
+Opprett en Maskinporten-klient for systemintegrasjonen. Skaff scopene som trengs for å registrere systemet, administrere systembrukere og kalle tjenesteeierens API.
+
+[Sett opp en Maskinporten-klient.](../maskinportenclient/)
+
+### 2. Registrer systemet
+
+Registrer systemet i Altinns systemregister. Systemdefinisjonen angir blant annet
+
+- system-ID og leverandør
+- navn og beskrivelse
+- ressurser eller tilgangspakker
+- Maskinporten-klienter
+- tillatte omdirigeringsadresser
+- om systemet skal være synlig for brukerstyrt opprettelse
+
+Be bare om tilganger som systemet faktisk trenger.
+
+[Følg veiledningen for å registrere systemet.](../../guides/system-vendor/system-user/systemregistration/)
+
+### 3. Velg eget system eller klientsystem
+
+**Eget system** brukes når virksomheten skal hente eller sende data for seg selv. Det kan bruke enkeltrettigheter eller tilgangspakker som ressursen støtter.
+
+**Klientsystem** brukes når tjenestetilbyderen handler for kunder. Dette løpet bruker tilgangspakker og krever at klientforholdet og videredelegeringen er på plass.
+
+[Se forskjellen mellom de to typene systembruker.](../../guides/system-vendor/system-user/#systembruker-for-eget-system)
+
+### 4. Velg hvem som starter opprettelsen
+
+Ved **leverandørstyrt opprettelse** sender systemleverandøren en forespørsel og gir kunden en sikker lenke til godkjenning.
+
+Ved **brukerstyrt opprettelse** finner og oppretter kunden systembrukeren fra Altinn. Systemet må være registrert som synlig og støtte denne flyten.
+
+[Følg veiledningen for å opprette en systembruker.](../../guides/system-vendor/system-user/systemuserrequest/)
+
+### 5. Vent på godkjenning
+
+Ikke behandle en sendt forespørsel som en opprettet systembruker. Følg statusen til forespørselen er godkjent og systembrukeren finnes.
+
+Håndter avvist, utløpt og slettet forespørsel som egne tilstander. Ikke gjenta opprettelsen ukontrollert hvis svaret er uklart.
+
+[Se hvordan du henter en eksisterende systembruker.](../../guides/system-vendor/system-user/byquery/)
+
+### 6. Knytt til kunder når det er nødvendig
+
+For et klientsystem må tjenestetilbyderen ha fullmakten fra kunden, og klienten må knyttes til systembrukeren. Hvilke klienter som kan knyttes til, avhenger av klientforholdet og tilgangspakkene.
+
+[Se hvordan klientdelegering fungerer for systemleverandører.](../../guides/system-vendor/system-user/client-delegation/)
+
+### 7. Hent og kontroller tokenet
+
+Hent systembrukertokenet gjennom Maskinporten. Kontroller at tokenet gjelder riktig
+
+- system
+- systembruker
+- virksomhet
+- klient
+- scope
+- miljø
+
+Ikke bruk én kundes identitet eller tokenkontekst til å utføre handlinger for en annen kunde.
+
+[Se hvordan du henter og bruker systembrukertokenet.](../../guides/system-vendor/system-user/usetoken/)
+
+### 8. Kall tjenesteeierens API
+
+Følg kontrakten og sikkerhetskravene fra tjenesteeieren. Oppgi riktig part, ressurs og handling. Et gyldig systembrukertoken betyr ikke at alle operasjoner er tillatt; tjenesteeierens API gjør den endelige tilgangskontrollen.
+
+Logg tekniske identifikatorer og korrelasjons-ID-er som gjør feilsøking mulig, men ikke komplette token eller unødvendige personopplysninger.
+
+## Test integrasjonen
+
+Test minst
+
+- opprettelse og godkjenning
+- avvist og utløpt forespørsel
+- eget system og klientsystem der begge støttes
+- kunde uten nødvendig fullmakt
+- feil kunde eller systembruker
+- trukket tilbake tilgang
+- utløpt eller ugyldig token
+- gjentatt forespørsel og usikkert svar
+- utilgjengelig Altinn- eller tjenesteeier-API
+
+[Bruk feilsøkingsveiledningen for Systembruker.](../../guides/system-vendor/system-user/troubleshooting/)
+
+## Klargjør produksjon
+
+Før produksjonssetting skal du kontrollere at
+
+- produksjonsklienten har riktige scopes
+- systemet er registrert med riktige produksjonsverdier
+- omdirigeringsadressene er eksakte og godkjente
+- systemet skiller virksomheter og kunder i alle lag
+- hemmeligheter og nøkler kan roteres
+- integrasjonen håndterer avvist, utløpt og trukket tilbake tilgang
+- logger og spor ikke inneholder komplette token eller unødvendige personopplysninger
+- brukeren får forståelig beskjed når en godkjenning eller fullmakt mangler
+
+[Kontroller gjeldende status for Altinn Autorisasjon før produksjonssetting.](../../reference/status/)
+
+## Forvalt integrasjonen
+
+Oppdater systemregistreringen når systemet trenger andre ressurser eller tilgangspakker. Bruk endringsløpet som dokumentasjonen støtter, og test eksisterende kunder før du erstatter en systembruker.
+
+- [Endre rettigheter for en systembruker.](../../guides/system-vendor/system-user/changerequest/)
+- [Slette en systembruker.](../../guides/system-vendor/system-user/deleterequest/)
+- [Se aktuelle brukerscenarioer.](../../guides/system-vendor/system-user/userscenarios/)

--- a/content/authorization/guides/resource-owner/_index.en.md
+++ b/content/authorization/guides/resource-owner/_index.en.md
@@ -1,8 +1,14 @@
 ---
 title: Service owner
 linktitle: Service owner
-description: Read more about how service owners can leverage the different solutions from Altinn Authorization
+description: Guides for service owners registering resources, defining policies and protecting services with Altinn Authorization.
 toc: false
 ---
+
+Is this your first integration?
+
+[Follow the main journey for protecting an API with Altinn Authorization.](../../getting-started/service-owner/)
+
+Use the guides below for individual tasks.
 
 {{<children />}}

--- a/content/authorization/guides/resource-owner/_index.nb.md
+++ b/content/authorization/guides/resource-owner/_index.nb.md
@@ -1,8 +1,14 @@
 ---
 title: Tjenesteeier
 linktitle: Tjenesteeier
-description: Les om hvordan tjenesteeier kan bruke Altinn Autorisasjon innenfor forskjellige områder.
+description: Veiledninger for tjenesteeiere som skal registrere ressurser, definere regler og beskytte tjenester med Altinn Autorisasjon.
 toc: false
 ---
+
+Er dette den første integrasjonen din?
+
+[Følg hovedløpet for å beskytte et API med Altinn Autorisasjon.](../../getting-started/service-owner/)
+
+Bruk veiledningene nedenfor når du skal utføre en konkret oppgave.
 
 {{<children />}}

--- a/content/authorization/guides/system-vendor/_index.en.md
+++ b/content/authorization/guides/system-vendor/_index.en.md
@@ -1,8 +1,14 @@
 ---
-title: System vendor
-linktitle: System vendor
-description: Read about how you as a vendor can integrate with, and use Altinn Authorization
+title: System integrator
+linktitle: System integrator
+description: Guides for system suppliers and organisations integrating systems with Altinn Authorization.
 toc: false
 ---
+
+Is this your first integration?
+
+[Follow the main journey for integrating a system with Altinn Authorization.](../../getting-started/system-integrator/)
+
+Use the guides below for individual tasks.
 
 {{<children />}}

--- a/content/authorization/guides/system-vendor/_index.nb.md
+++ b/content/authorization/guides/system-vendor/_index.nb.md
@@ -1,8 +1,14 @@
 ---
-title: Sluttbrukersystemleverandør
-linktitle: Systemleverandør
-description: Les om hvordan du som sluttbrukersystemleverandør kan integrere mot våre API og bruke Altinn Autorisasjon gjennom dine systemer
+title: Systemintegrator
+linktitle: Systemintegrator
+description: Veiledninger for systemleverandører og virksomheter som integrerer systemer med Altinn Autorisasjon.
 toc: false
 ---
+
+Er dette den første integrasjonen din?
+
+[Følg hovedløpet for å integrere et system med Altinn Autorisasjon.](../../getting-started/system-integrator/)
+
+Bruk veiledningene nedenfor når du skal utføre en konkret oppgave.
 
 {{<children />}}

--- a/layouts/_default/authorization-landing.html
+++ b/layouts/_default/authorization-landing.html
@@ -1,0 +1,42 @@
+{{ partial "header.html" . }}
+
+<style>
+  /* This layout is selected only by the Altinn Authorization landing page. */
+  #sidebar,
+  #top-bar,
+  .last-modified,
+  .adocs-scrollcontainer > .row > .col-md-2,
+  #body-inner > h1,
+  #body-inner > #leadText {
+    display: none !important;
+  }
+
+  #body {
+    margin-left: 0 !important;
+  }
+
+  .a-page > .container {
+    max-width: 1380px;
+  }
+
+  .adocs-scrollcontainer > .row > .col-md-10 {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+
+  .adocs-content {
+    padding: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  @media (min-width: 768px) {
+    .adocs-content {
+      padding: 0;
+    }
+  }
+</style>
+
+{{ .Content | safeHTML }}
+
+{{ partial "footer.html" . }}

--- a/layouts/shortcodes/authorization-landing.html
+++ b/layouts/shortcodes/authorization-landing.html
@@ -1,0 +1,222 @@
+<style>
+.authorization-landing {
+  --authz-ink: #1e2b3c;
+  --authz-muted: #526173;
+  --authz-border: #d8e0e8;
+  --authz-blue: #eaf4ff;
+  --authz-green: #eaf7ef;
+  --authz-warm: #fff4e5;
+  margin: 0 0 3rem;
+}
+.authorization-landing * { box-sizing: border-box; }
+.authorization-landing__hero {
+  padding: clamp(1.5rem, 4vw, 3.5rem);
+  margin: 0 0 2rem;
+  border: 1px solid var(--authz-border);
+  border-radius: 1rem;
+  background: linear-gradient(135deg, #f5f9ff 0%, #eef8f2 100%);
+}
+.authorization-landing__eyebrow {
+  margin: 0 0 .5rem;
+  color: #075985;
+  font-size: .9rem;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+.authorization-landing__hero h2 {
+  max-width: 46rem;
+  margin: 0 0 .75rem;
+  color: var(--authz-ink);
+  font-size: clamp(1.75rem, 4vw, 2.75rem);
+  line-height: 1.12;
+}
+.authorization-landing__lead {
+  max-width: 48rem;
+  margin: 0;
+  color: var(--authz-muted);
+  font-size: 1.1rem;
+}
+.authorization-landing__heading {
+  margin: 2rem 0 1rem;
+  color: var(--authz-ink);
+}
+.authorization-landing__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+.authorization-landing__grid--three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.authorization-landing__card {
+  display: flex;
+  min-height: 13rem;
+  flex-direction: column;
+  padding: 1.5rem;
+  border: 1px solid var(--authz-border);
+  border-radius: .85rem;
+  color: var(--authz-ink) !important;
+  text-decoration: none !important;
+  transition: border-color .15s ease, box-shadow .15s ease, transform .15s ease;
+}
+.authorization-landing__card:nth-child(1) { background: var(--authz-blue); }
+.authorization-landing__card:nth-child(2) { background: var(--authz-green); }
+.authorization-landing__grid--three .authorization-landing__card { min-height: 10rem; background: #fff; }
+.authorization-landing__card:hover {
+  border-color: #67809a;
+  box-shadow: 0 .5rem 1.25rem rgba(30, 43, 60, .10);
+  transform: translateY(-2px);
+}
+.authorization-landing__card:focus-visible,
+.authorization-landing__chooser:focus-visible {
+  outline: 3px solid #0062ba;
+  outline-offset: 3px;
+}
+.authorization-landing__card-label {
+  margin-bottom: .75rem;
+  color: #075985;
+  font-size: .85rem;
+  font-weight: 700;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+}
+.authorization-landing__card h3 { margin: 0 0 .65rem; color: var(--authz-ink); }
+.authorization-landing__card p { margin: 0 0 1.25rem; color: var(--authz-muted); }
+.authorization-landing__card-link { margin-top: auto; font-weight: 700; }
+.authorization-landing__chooser {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1.5rem;
+  align-items: center;
+  margin: 1.25rem 0 2.5rem;
+  padding: 1.35rem 1.5rem;
+  border: 1px solid #e5c07b;
+  border-radius: .85rem;
+  background: var(--authz-warm);
+  color: var(--authz-ink) !important;
+  text-decoration: none !important;
+}
+.authorization-landing__chooser h3 { margin: 0 0 .35rem; color: var(--authz-ink); }
+.authorization-landing__chooser p { margin: 0; color: var(--authz-muted); }
+.authorization-landing__chooser-action { font-weight: 700; white-space: nowrap; }
+@media (max-width: 760px) {
+  .authorization-landing__grid,
+  .authorization-landing__grid--three { grid-template-columns: 1fr; }
+  .authorization-landing__chooser { grid-template-columns: 1fr; gap: .75rem; }
+  .authorization-landing__card { min-height: auto; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .authorization-landing__card { transition: none; }
+}
+</style>
+
+{{- if eq .Page.Language.Lang "nb" -}}
+<div class="authorization-landing">
+  <section class="authorization-landing__hero" aria-labelledby="authorization-landing-title">
+    <p class="authorization-landing__eyebrow">Altinn Autorisasjon</p>
+    <h2 id="authorization-landing-title">Finn riktig vei fra behov til fungerende integrasjon</h2>
+    <p class="authorization-landing__lead">Velg rollen din. Du får ett hovedløp som samler stegene og peker videre til detaljene du trenger.</p>
+  </section>
+
+  <h2 class="authorization-landing__heading">Hva skal du gjøre?</h2>
+  <div class="authorization-landing__grid">
+    <a class="authorization-landing__card" href="{{ "authorization/getting-started/service-owner/" | relLangURL }}">
+      <span class="authorization-landing__card-label">For tjenesteeiere</span>
+      <h3>Beskytt et API</h3>
+      <p>Registrer ressursen, definer reglene og håndhev beslutningen fra Altinn Autorisasjon.</p>
+      <span class="authorization-landing__card-link">Følg tjenesteeierløpet →</span>
+    </a>
+    <a class="authorization-landing__card" href="{{ "authorization/getting-started/system-integrator/" | relLangURL }}">
+      <span class="authorization-landing__card-label">For systemintegratorer</span>
+      <h3>Integrer et system</h3>
+      <p>Velg identitet, sett opp systembruker og kall tjenester på vegne av personer eller virksomheter.</p>
+      <span class="authorization-landing__card-link">Følg integratorløpet →</span>
+    </a>
+  </div>
+
+  <a class="authorization-landing__chooser" href="{{ "authorization/getting-started/choose-authentication/" | relLangURL }}">
+    <span>
+      <h3>Usikker på hvilken løsning du trenger?</h3>
+      <p>Sammenlign ID-porten, Maskinporten, systembruker, samtykke og tilgangskontroll.</p>
+    </span>
+    <span class="authorization-landing__chooser-action">Velg integrasjonsmåte →</span>
+  </a>
+
+  <h2 class="authorization-landing__heading">Finn mer informasjon</h2>
+  <div class="authorization-landing__grid authorization-landing__grid--three">
+    <a class="authorization-landing__card" href="{{ "authorization/what-do-you-get/" | relLangURL }}">
+      <span class="authorization-landing__card-label">Forstå</span>
+      <h3>Hva får du?</h3>
+      <p>Se funksjonene og bruksområdene i Altinn Autorisasjon.</p>
+      <span class="authorization-landing__card-link">Se mulighetene →</span>
+    </a>
+    <a class="authorization-landing__card" href="{{ "authorization/guides/" | relLangURL }}">
+      <span class="authorization-landing__card-label">Utfør</span>
+      <h3>Guider</h3>
+      <p>Finn trinnvise veiledninger for konkrete oppgaver.</p>
+      <span class="authorization-landing__card-link">Finn en guide →</span>
+    </a>
+    <a class="authorization-landing__card" href="{{ "authorization/reference/" | relLangURL }}">
+      <span class="authorization-landing__card-label">Slå opp</span>
+      <h3>Referanse</h3>
+      <p>Finn API-er, kontrakter, arkitektur og tekniske detaljer.</p>
+      <span class="authorization-landing__card-link">Åpne referansen →</span>
+    </a>
+  </div>
+</div>
+{{- else -}}
+<div class="authorization-landing">
+  <section class="authorization-landing__hero" aria-labelledby="authorization-landing-title">
+    <p class="authorization-landing__eyebrow">Altinn Authorization</p>
+    <h2 id="authorization-landing-title">Find the right path from need to working integration</h2>
+    <p class="authorization-landing__lead">Choose your role. Each main journey collects the steps and directs you to the details you need.</p>
+  </section>
+
+  <h2 class="authorization-landing__heading">What do you need to do?</h2>
+  <div class="authorization-landing__grid">
+    <a class="authorization-landing__card" href="{{ "authorization/getting-started/service-owner/" | relLangURL }}">
+      <span class="authorization-landing__card-label">For service owners</span>
+      <h3>Protect an API</h3>
+      <p>Register the resource, define the policy and enforce the decision from Altinn Authorization.</p>
+      <span class="authorization-landing__card-link">Follow the service owner journey →</span>
+    </a>
+    <a class="authorization-landing__card" href="{{ "authorization/getting-started/system-integrator/" | relLangURL }}">
+      <span class="authorization-landing__card-label">For system integrators</span>
+      <h3>Integrate a system</h3>
+      <p>Choose an identity, set up a system user and call services on behalf of people or organisations.</p>
+      <span class="authorization-landing__card-link">Follow the integrator journey →</span>
+    </a>
+  </div>
+
+  <a class="authorization-landing__chooser" href="{{ "authorization/getting-started/choose-authentication/" | relLangURL }}">
+    <span>
+      <h3>Unsure which solution you need?</h3>
+      <p>Compare ID-porten, Maskinporten, system users, consent and access control.</p>
+    </span>
+    <span class="authorization-landing__chooser-action">Choose an integration method →</span>
+  </a>
+
+  <h2 class="authorization-landing__heading">Find more information</h2>
+  <div class="authorization-landing__grid authorization-landing__grid--three">
+    <a class="authorization-landing__card" href="{{ "authorization/what-do-you-get/" | relLangURL }}">
+      <span class="authorization-landing__card-label">Understand</span>
+      <h3>What do you get?</h3>
+      <p>Explore the capabilities and use cases in Altinn Authorization.</p>
+      <span class="authorization-landing__card-link">Explore the capabilities →</span>
+    </a>
+    <a class="authorization-landing__card" href="{{ "authorization/guides/" | relLangURL }}">
+      <span class="authorization-landing__card-label">Do</span>
+      <h3>Guides</h3>
+      <p>Find step-by-step guides for individual tasks.</p>
+      <span class="authorization-landing__card-link">Find a guide →</span>
+    </a>
+    <a class="authorization-landing__card" href="{{ "authorization/reference/" | relLangURL }}">
+      <span class="authorization-landing__card-label">Look up</span>
+      <h3>Reference</h3>
+      <p>Find APIs, contracts, architecture and technical details.</p>
+      <span class="authorization-landing__card-link">Open the reference →</span>
+    </a>
+  </div>
+</div>
+{{- end -}}


### PR DESCRIPTION
## Summary

- add a role-based Authorization landing page for service owners and system integrators
- use an Authorization-only full-width layout without the documentation sidebar
- add an integration chooser covering ID-porten, Maskinporten, system users, consent and access control
- add end-to-end getting-started journeys for service owners and system integrators
- improve the existing getting-started and audience guide entry pages
- provide Norwegian and English versions

## Isolation

The full-width layout is activated only by the Norwegian and English Authorization root pages. Child pages and other product areas retain the standard documentation sidebar and layout.

## Validation

- \hugo --renderToMemory\ completed successfully
- all six new pages return HTTP 200 in both languages
- 70 internal links and anchors on the new journey pages were checked
- full-width CSS is present on the Authorization landing page and absent from child pages
- \git diff --check\ passed

The Hugo build reports existing deprecation and unrelated missing-page warnings outside the changed Authorization documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned Authorisation landing page with role-based navigation and integration-method guidance.
  * Added getting-started journeys for service owners and system integrators.
  * Added guidance to choose authentication, representation and authorisation approaches.
  * Added detailed setup, testing and production-readiness checklists.
  * Updated guide sections with clearer links to the recommended journeys.
* **Documentation**
  * Added and updated English and Norwegian documentation throughout the Authorisation section.
  * Improved descriptions, terminology and navigation for first-time integrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->