### PR TITLE
Document roles from the Central Coordinating Register

### DIFF
--- a/content/authorization/what-do-you-get/accesspackages/register_ER/_index.en.md
+++ b/content/authorization/what-do-you-get/accesspackages/register_ER/_index.en.md
@@ -1,8 +1,8 @@
 ---
-title: Fullmakter fra Enhetsregisteret
-linktitle: Fra Enhetsregisteret
-description: Altinn bruker Enhetsregisteret som kilde for hvem som har fullmakter på vegne av en virksomhet fra Enhetsregistert
-tags: [architecture, security, authorization, needstranslation]
+title: Roles from the Central Coordinating Register for Legal Entities
+linktitle: From the Central Coordinating Register
+description: How roles from the Central Coordinating Register give access packages and authority to act for an organisation
+tags: [architecture, security, authorization]
 toc: true
 weight: 200
 hidden: true
@@ -10,122 +10,70 @@ aliases:
   - /authorization/what-do-you-get/accessgroups/register_er/
 ---
 
-*Innhold på siden er under arbeid. Innholdet vil ikke være gjeldende før nye [tilgangspakker](/en/authorization/what-do-you-get/accesspackages/business/) trer i kraft. Dette må derfor ikke ansees som en fasit pr nå*
+Altinn obtains information about roles in organisations from the Central Coordinating Register for Legal Entities. A role may give its holder access packages and the ability to delegate access on behalf of the organisation.
 
-## Enhetsregisteret som fullmaktskilde
-Alle virksomheter i Norge registeres i [Enhetsregisteret](https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/) og får et organisasjonsnummer som de identifiseres ved.
-I den forbindelse registreres også personer eller virksomheter som har ulike roller og med det fullmakt til å opptre på vegene av virksomheten i ulike sammenhenger. 
+The organisation type determines which roles an organisation can register. The Brønnøysund Register Centre determines who holds the role. Altinn determines which access packages the role provides.
 
-Ulike organisasjonsformer kan registrere ulike roller og hvilke fullmakter disse har vil være avhengig av lovverket som regulerer de ulike organisasjonsformene. 
+## How a role gives access
 
-## Rolletyper fra Enhetsregisteret
-Følgende rolletyper finnes i enhetsregisteret: 
-|Kode   |Navn                           |Kommentar|
-|-------|-------------------------------|---------|
-|ADOS|Administrativ enhet - offentlig sektor|Ingen fullmakter|
-|BEST|Bestyrende reder|Nøkkelrolle, har de fleste fullmakter|
-|BOBE|Bostyrer|Nøkkelrolle, har de fleste fullmakter|
-|DAGL|Daglig leder|Nøkkelrolle, har de fleste fullmakter|
-|DTPR|Deltaker med proratarisk ansvar (delt ansvar)|Nøkkelrolle når rollen er registrert på fnr, har de fleste fullmakter|
-|DTSO|Deltaker med solidarisk ansvar (fullt ansvarlig)|Nøkkelrolle når rollen er registrert på fnr, har de fleste fullmakter|
-|EIKM|Eierkommune|Ingen fullmakter|
-|FFØR|Forretningsfører|Forretningsfører for Borettslag og Eierseksjonssameier har fullmakter, øvrige FFØR ingen fullmakter|
-|HFOR|Opplysninger om foretaket i hjemlandet|Ingen fullmakter|
-|HLSE|Helseforetak|Ingen fullmakter|
-|INNH|Innehaver|Nøkkelrolle, har de fleste fullmakter|
-|KDEB|Konkursdebitor|Ingen fullmakter|
-|KENK|Den personlige konkursen angår|Ingen fullmakter|
-|KIRK|Inngår i kirkelig fellesråd|Ingen fullmakter|
-|KOMP|Komplementar (i kommandittselskap?)|Ingen fullmakter|
-|KONT|Kontaktperson|Ingen fullmakter|
-|KTRF|Inngår i kontorfellesskap|Ingen fullmakter|
-|LEDE|Styrets leder|Nøkkelrolle, har de fleste fullmakter|
-|MEDL|Styremedlem|Ingen fullmakter|
-|NEST|Nestleder|Ingen fullmakter|
-|OBS|Observatør|Ingen fullmakter|
-|OPMV|er særskilt oppdelt enhet til|Ingen fullmakter|
-|ORGL|Organisasjonsledd i offentlig sektor|Ingen fullmakter|
-|REGN|Regnskapsfører|Utvalgte fullmakter for klienter/kunder|
-|REPR|Norsk representant for utenlandsk enhet|Ingen fullmakter|
-|REVI|Revisor|Utvalgte fullmakter for klienter/kunder|
-|VARA|Varamedlem|Ingen fullmakter|
+1. The organisation registers an individual or another organisation in a role in the Central Coordinating Register.
+2. Altinn Register retrieves the role relationship.
+3. Altinn Access Management maps the role to one or more access packages.
+4. The service owner links actions in the service to an access package through the service policy.
 
-# Organisasjonsformer og roller som Altinn leser inn fra Enhetsregisteret
+The role does not therefore contain a fixed list of services. Access follows from the combination of the role, its mapping to an access package and the policy that the service owner has set for the service.
 
+## Distinguish access from administration
 
-## Organisasjonsformer for selskap med begrenset ansvar
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Aksjeselskap (AS)|En organisasjonsform med begrenset ansvar for eierne (aksjonærene).|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Allmennaksjeselskap (ASA)|Et aksjeselskap med begrenset ansvar for eierne. Denne organisasjonsformen kan brukes av selskaper som har mange aksjonærer, og/eller ønsker mulighet til å innhente kapital fra allmennheten|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Europeisk selskap (SE)|En transnasjonal europeisk selskapsform av allmennaksjeselskapstypen.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Selskap med begrenset ansvar (BA)|Samvirkeforetak opprettet før 1.januar 2008|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Samvirkeforetak (SA)|Har som hovedformål å fremme medlemmenes økonomiske interesser ved at de deltar i foretakets aktiviteter, enten som forbrukere, leverandører eller på annen lignende måte. Det må være en form for utveksling av varer eller tjenester mellom foretaket og medlemmene. Medlemmene har begrenset økonomisk ansvar. Det vil si at de ikke har ansvar for foretakets gjeld utover den innskutte andelskapitalen. Foretakets overskudd blir enten stående i foretaket eller fordelt mellom medlemmene ut fra den enkeltes andel i omsetningen.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-## Organisasjonsformer for selskap med ubegrenset ansvar 
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Enkeltpersonforetak (ENK)|I et enkeltpersonforetak er én person fullt økonomisk ansvarlig for den næringsaktiviteten som drives.|KONT, FFØR, REGN, REVI|DAGL, LEDE, *INNH|NEST, MEDL, VARA, OBS|
-|Ansvarlig selskap med delt ansvar (DA)|Et ansvarlig selskap med delt ansvar er et selskap med to eller flere eiere (deltakere). Deltakerne har til sammen et personlig ansvar for hele gjelden, men hver enkelt deltaker er bare ansvarlig for sin ansvarsandel.|KONT, FFØR, REGN, REVI|DAGL, LEDE, **DTPR|NEST, MEDL, VARA, OBS, *DTPR|
-|Ansvarlig selskap med solidarisk ansvar (ANS)|Ansvarlig selskap er et selskap med to eller flere eiere (deltakere). Deltakerne har et ubegrenset personlig ansvar for hele gjelden.|KONT, FFØR, REGN, REVI|DAGL, LEDE, **DTSO|NEST, MEDL, VARA, OBS, *DTSO|
-|Kommandittselskap (KS)|Et kommandittselskap er et selskap hvor minst en deltaker hefter ubegrenset for selskapsforpliktelsene (komplementar), og minst en deltaker har begrenset sitt ansvar til et nærmere fastsatt innskudd (kommandittist)|KONT, FFØR, REGN, REVI|DAGL, LEDE, **KOMP|NEST, MEDL, VARA, OBS, *KOMP|
+A role mapping may provide different capabilities:
 
-Roller merket * betyr at andre organisasjoner/personer som har en spesial rolle for denne organisasjonsformen. 
+- **Has access** means that the role holder can use services included in the package.
+- **Can delegate** means that the role holder can give the package to others.
+- **Can assign** is used for some administrative mappings and means that the role holder can assign access within the relevant area.
 
-Roller merket ** betyr at bare når rolleinnehaver er en person så får denne nøkkelrolle for virksomheten. Hvis rolleinnehaver er en organisasjon så får man en knytning uten fullmakter til organisasjonen. 
+These capabilities do not always accompany each other. For example, an accountant may receive accounting packages without being able to delegate them.
 
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Tingsrettslig sameie (SAM)|Et tingsrettslig sameie er en måte to eller flere personer kan eie en eller flere formuesgjenstander på. Eksempel: når to eller flere eier en hytte, en vei, en russebuss eller lignende sammen. |KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Borettslag (BRL)|Et borettslag eies av de som bor der. Når du kjøper en bolig i et borettslag, blir du samtidig andelseier. Andelseierne i borettslaget eier bygninger og tomt i fellesskap, og tar beslutninger om oppussing, vedlikehold og påkostninger av bygninger og fellesarealer. Som andelseier er du ikke ansvarlig for lagets forpliktelser overfor kreditorer.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Boligbyggelag (BBL)|Et boligbyggelag har til hovedformål å bygge, omsette og forvalte boliger for sine andelseiere. Et boligbyggelag kan gjerne bestå av flere borettslag.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Eierseksjonssameie (ESEK)|Et eierseksjonssameie er en bebygd eiendom som er seksjonert og tinglyst på et gårds- og bruksnummer. Eiendommen eies i fellesskap, men eierne har enerett til å bruke sin seksjon. Et eierseksjonssameie kan ha både boligseksjoner og næringsseksjoner.|KONT, FFØR, REGN, REVI|LEDE|NEST, MEDL, VARA, OBS|
-## Organisasjonsformer for spesielle bransjer
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Sparebank (SPA)|En sparebank er en bank som er organisert som en selveiende institusjon, det vil si uten eksterne eiere. Dette til forskjell fra en forretningsbank organisert som et aksjeselskap og altså med aksjonærene som eiere. |KONT, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Pensjonskasse (PK)|Pensjonskasse er en annen form for pensjonsforsikringshåndtering. Enkelte større selskaper velger å ha sin egen pensjonskasse i stedet for å tegne en kollektiv pensjonsavtale med et forsikringsselskap. Forvaltning av pensjonskasser gjøres av forsikringsselskaper, egne spesialiserte selskaper eller for noen av de større av seg selv. Eksempler på det siste er Statens pensjonskasse og Telenor Pensjonskasse.|KONT, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Gjensidig forsikringsselskap (GFS)|Gjensidig forsikringsselskap en offentlig selskaps-/organisasjonsform som ofte nyttes ved organisering av forsikringsselskap. Selskapsformen innebærer at forsikringstagerne danner og eier selskapet, dets eventuelle aktiva og også deler den risikoen selskapet har påtatt seg. Dette innebærer altså at kunde- og eiergruppen er sammenfallende.|KONT, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Partrederi (PRE)|Et partrederi er et selskap som har til formål å drive rederivirksomhet. I et partrederi med solidarisk ansvar har alle deltakerne et personlig ansvar for hele gjelden. Det en deltaker ikke kan betale, kan kreves helt og fullt fra de andre deltakerne. I et partrederi med delt ansvar har deltakerne et personlig ansvar for hele gjelden, men hver enkelt deltaker er bare ansvarlig for sin ansvarsdel.|KONT, FFØR, REGN, REVI|LEDE, *BEST|NEST, MEDL, VARA, OBS, *DTPR|
-|Verdipapirfond (VPFO)|I et verdipapirfond går andelseiere sammen om å plassere sine midler i verdipapirmarkedet. Fondet forvaltes av et forvaltningsselskap med konsesjon fra Finanstilsynet.Verdipapirfond deles inn i fem hovedgrupper etter hvilke verdier de investerer i: aksjefond, obligasjonsfond, pengemarkedsfond, kombinasjonsfond og spesialfond.|KONT, FFØR, REGN, REVI|DAGL|(ingen)|
-|Annen juridisk person (ANNA)|Annen juridisk person er en virksomhet som kan påta seg rettigheter og plikter. Denne organisasjonsformen skal brukes for en svært begrenset gruppe virksomheter, og bare når ingen av de andre organisasjonsformene er aktuelle. Eksempler på virksomheter som kan registreres som annen juridisk person er ambassader, bygdeallmenninger, fjellstyre, katolske menigheter, reinbeitedistrikt, statsallmenninger, stortingsgrupper, interkommunale politiske råd og kommunalt oppgavefellesskap.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-## Organisasjoner for frivillig sektor
-|Navn|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med enkel knytning uten fullmakter|
-|----|-----------|------------------------------|-------------|------------------------------------------|
-|Forening/lag/innretning (FLI)|En forening er en selveiende sammenslutning med medlemmer, som skal fremme ett eller flere formål av ideelt, politisk eller annen art. Rettsforholdet i foreninger er ikke regulert i lov, men det har over tid utviklet seg foreningsrettslige prinsipper.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Stiftelse (STI)|En stiftelse er en formuesverdi som ved testamente, gave eller annen rettslig disposisjon selvstendig er stilt til rådighet for et bestemt formål. Formålet kan være av ideell, humanitær, kulturell, sosial, utdanningsmessig, økonomisk eller annen art. Stiftelser må ha en grunnkapital. Kravet til minste grunnkapital er 100 000 kroner for alminnelige stiftelser og 200 000 kroner for stiftelser som driver næringsaktivitet.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-## Organisasjonsformer for offentlig sektor
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Kommune (KOMM)|(mangler)|KONT, REGN, REVI, FFØR|DAGL|(ingen)|
-|Staten (STAT)|(mangler)|KONT, REGN, REVI, FFØR|DAGL|(ingen)|
-|Fylkeskommune (FYLK)|(mangler)|KONT, REGN, REVI, FFØR|DAGL|(ingen)|
-|Organisasjonsledd (ORGL)|(mangler)|KONT, REGN, REVI, FFØR|DAGL, LEDE|NEST, MEDL, VARA, OBS, *ORGL|
-|Administrativ enhet -offentlig sektor (ADOS)|(mangler)|KONT,REGN, REVI|LEDE|NEST, MEDL, VARA, OBS, *ADOS|
-|Interkommunalt selskap (IKS)|Er en norsk organisasjonsform for selskaper innen offentlig sektor der flere kommuner og/eller fylkeskommuner er eiere. Selskapsdriften reguleres av Lov om interkommunale selskaper. Interkommunale vannverk, arkivdrift og regionmuseer er typiske funksjonsområder for interkommunale selskaper.|KONT, FFØR, REGN, REVI|DAGL,LEDE|*DTPR, NEST, MEDL, VARA, OBS, |
-|Kommunalt foretak (KF)|er betegnelse for en selskapsform som brukes for virksomheter som er eid av norske kommuner.|KONT, FFØR, REGN, REVI,|DAGL, LEDE,|NEST, MEDL, VARA, OBS, *EIKM|
-|Fylkeskommunalt foretak (FKF)|er betegnelse for en selskapsform som brukes for virksomheter som er eid av fylkeskommune .|KONT, FFØR, REGN, REVI,|DAGL, LEDE,|NEST, MEDL, VARA, OBS, *EIKM|
-|Statsforetak (SF)|er en norsk selskapsform regulert av lov om statsforetak av 30. august 1991. Statsforetak stiftes av Kongen i statsråd og eies av den norske stat i sin helhet, representert ved et departement.|KONT, REGN, REVI,|DAGL, LEDE,|NEST, MEDL, VARA, OBS|
+## Examples of roles and pre-assigned packages
 
-Roller merket * betyr at andre organisasjoner/personer som har en spesial rolle for denne organisasjonsformen. 
-## Organisasjonsformer for utenlandske virksomheter
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Norskregistrert utenlandsk foretak (NUF)|Norskregistrert utenlandsk foretak er en norsk filial av et utenlandskregistrert selskap. I denne sammenheng må det skilles mellom «utenlandsk selskap» i selskapsrettslig og skatterettslig forstand. NUF er norske avdelinger av utenlandske selskap i en selskapsrettslig forstand, og kan derfor godt være skattemessig tilhørende til Norge. Ordningen blir anvendt av flere større selskaper som driver på tvers av landegrensene. Innføringen av selskapsformen NUF i norsk selskapsrett var et resultat av EØS-avtalen, ettersom fri etableringsrett på tvers av landegrenser er et prinsipp i EU-retten.|KONT, FFØR, REGN, REVI,|DAGL, LEDE, *REPR| NEST, MEDL, VARA, OBS|
-|Europeisk selskap (SE)|Europeisk selskap er en transnasjonal europeisk selskapsform av allmennaksjeselskapstypen. Selskapsformen ble etablert fra og med 8. oktober 2004. Rettsgrunnlaget er EU-forordning 2157/2001.|KONT, FFØR, REGN, REVI,|DAGL,  LEDE| NEST, MEDL, VARA, OBS|
-|Utenlandsk enhet (UTLA)|(mangler)|KONT, FFØR|DAGL|(ingen)|
-|Europeisk økonomisk foretaksgruppe (EOFG)|(mangler)|KONT, FFØR, REGN, REVI,|DAGL, LEDE| NEST, MEDL, VARA, OBS|
+The table shows key examples. Mappings may change when packages or services change.
 
-Roller merket * betyr at andre organisasjoner/personer som har en spesial rolle for denne organisasjonsformen. 
-## Andre særskilte organisasjonsformer 
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Kontorfellesskap (KTRF)|(mangler)|KONT, REGN, REVI|(ingen)|*KTRF|
-|Særskilt oppdelt enhet jfr mval § 2-2 (OPMV)|(mangler)|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS, *OPMV|
-|Andre bo (BO)|Andre bo er en organisasjonsform som brukes ved registrering av dødsbo og felleseiebo.|KONT, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Konkursbo (KBO)|(mangler)|REGN, REVI|BOBE| (ingen)|
-|Tvangsregistrert for MVA (TVAM)|(mangler)|KONT, FFØR, REGN, REVI|INNH, DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Andre enkeltpersoner som registreres i tilknyttet register (PERS)|(mangler)|KONT, REGN, REVI|(ingen)|(ingen)|
-|Den norske kirke (KIRK)|Trossamfunnet Den norske kirke registreres i Enhetsregisteret med organisasjonsformen Den norske kirke. Dette gjelder både kirkelige fellesråd, soknene eller menighetene.|KONT, FFØR, REGN, REVI,|DAGL, LEDE,|NEST, MEDL, VARA, OBS, *KIRK|
-|Annet foretak iflg. særskilt lov (SÆR)|Et særlovselskap skiller seg fra andre statlige aksjeselskap og statsforetak ved at hvert enkelt av selskapene er opprettet og drives med hjemmel i en egen lov,[1] eller en lov som gjelder flere selskaper av lignende karakter. Dette omfatter blant annet helseforetak (HF), regionalt helseforetak (RHF), studentsamskipnader og enkelte folkehøgskoler. Særlovselskapene er i hovedsak opprettet der hovedvirksomheten er et monopol eller brukes som et politisk instrument. Oppgavene varierer fra pengespillforvaltning, næringsvirksomhet, bankvirksomhet til disponering av budsjettpolitiske virkemidler.|KONT, FFØR, REGN, REVI,|DAGL, LEDE,|NEST, MEDL, VARA, OBS, *HLSE|
+| Role from the register | Example packages | Can delegate the example packages? |
+|---|---|---|
+| Managing director, chair of the board and owner of a sole proprietorship | Client administrator, access management, main administrator and Maskinporten administration | Yes |
+| Accountant | Accountant with signing rights, accountant without signing rights and payroll accountant | No |
+| Auditor | Auditor in charge and assistant auditor | No |
+| Business manager for a housing cooperative or condominium | Business manager for real estate | No |
+| Estate administrator | Bankruptcy estate read access and bankruptcy estate write access | Yes |
+| Contact person for an NUF and Norwegian representative for a foreign entity | Services for NUF and selected administrative packages | Yes |
 
-Roller merket * betyr at andre organisasjoner/personer som har en spesial rolle for denne organisasjonsformen. 
+<a href="https://tjenesteoversikten.no/packages" target="_blank" rel="noopener noreferrer">See which services are included in the access packages in Tjenesteoversikten (opens in a new tab)</a>. Tjenesteoversikten is an unofficial information tool built by the Authorization team using open APIs.
+
+## Roles without pre-assigned packages
+
+Being registered with a role does not mean that the role automatically gives access in Altinn. Board member, deputy board member and contact person are examples of roles that do not necessarily have pre-assigned access packages.
+
+The individual may still receive access if someone who can delegate gives them an access package or access to an individual service.
+
+## The organisation type affects the result
+
+Not every role can be registered for every organisation type. Some mappings apply only to specific organisation types. For example, a business manager receives the real estate management package when the organisation is a housing cooperative or condominium.
+
+Another organisation may also hold a role. In some cases, Altinn can then pass the access on to individuals in the connected organisation. [Read how organisation connections work](./knytning_org/).
+
+## What service owners need to consider
+
+- Choose an access package that covers the task the user must perform, rather than a particular job title.
+- Check that the package does not give broader access than the service requires.
+- Do not assume that everyone with a registered role can delegate their access.
+- Test with the organisation types and roles that the target users actually have.
+- Describe any additional requirements in the guidance for the service.
+
+## Sources and maintenance
+
+The Access Management code is the technical source of truth:
+
+- [Role definitions in RoleConstants.cs](https://github.com/Altinn/altinn-authorization-tmp/blob/main/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/RoleConstants.cs)
+- [Mappings between roles and access packages in IngestRolePackage.cs](https://github.com/Altinn/altinn-authorization-tmp/blob/main/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/IngestRolePackage.cs)
+- [Access package definitions in PackageConstants.cs](https://github.com/Altinn/altinn-authorization-tmp/blob/main/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/PackageConstants.cs)
+
+[The Brønnøysund Register Centre describes the Central Coordinating Register and the information it contains](https://www.brreg.no/en/about-us-2/our-registers/about-the-central-coordinating-register-for-legal-entities-ccr/).

--- a/content/authorization/what-do-you-get/accesspackages/register_ER/_index.nb.md
+++ b/content/authorization/what-do-you-get/accesspackages/register_ER/_index.nb.md
@@ -1,7 +1,7 @@
 ---
-title: Fullmakter fra Enhetsregisteret
+title: Roller fra Enhetsregisteret
 linktitle: Fra Enhetsregisteret
-description: Altinn bruker Enhetsregisteret som kilde for hvem som har fullmakter på vegne av en virksomhet fra Enhetsregistert
+description: Slik gir roller fra Enhetsregisteret tilgangspakker og mulighet til å handle på vegne av en virksomhet
 tags: [architecture, security, authorization]
 toc: true
 weight: 200
@@ -10,122 +10,70 @@ aliases:
   - /authorization/what-do-you-get/accessgroups/register_er/
 ---
 
-*Innhold på siden er under arbeid. Innholdet vil ikke være gjeldende før nye [tilgangspakker](/nb/authorization/what-do-you-get/accesspackages/business/) trer i kraft. Dette må derfor ikke ansees som en fasit pr nå*
+Altinn henter opplysninger om roller i virksomheter fra Enhetsregisteret. En rolle kan gi innehaveren tilgangspakker og mulighet til å delegere tilganger på vegne av virksomheten.
 
-## Enhetsregisteret som fullmaktskilde
-Alle virksomheter i Norge registeres i [Enhetsregisteret](https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/) og får et organisasjonsnummer som de identifiseres ved.
-I den forbindelse registreres også personer eller virksomheter som har ulike roller og med det fullmakt til å opptre på vegene av virksomheten i ulike sammenhenger. 
+Hvilke roller en virksomhet kan registrere, avhenger av organisasjonsformen. Brønnøysundregistrene bestemmer hvem som har rollen. Altinn bestemmer hvilke tilgangspakker rollen gir.
 
-Ulike organisasjonsformer kan registrere ulike roller og hvilke fullmakter disse har vil være avhengig av lovverket som regulerer de ulike organisasjonsformene. 
+## Slik blir en rolle til tilgang
 
-## Rolletyper fra Enhetsregisteret
-Følgende rolletyper finnes i enhetsregisteret: 
-|Kode   |Navn                           |Kommentar|
-|-------|-------------------------------|---------|
-|ADOS|Administrativ enhet - offentlig sektor|Ingen fullmakter|
-|BEST|Bestyrende reder|Nøkkelrolle, har de fleste fullmakter|
-|BOBE|Bostyrer|Nøkkelrolle, har de fleste fullmakter|
-|DAGL|Daglig leder|Nøkkelrolle, har de fleste fullmakter|
-|DTPR|Deltaker med proratarisk ansvar (delt ansvar)|Nøkkelrolle når rollen er registrert på fnr, har de fleste fullmakter|
-|DTSO|Deltaker med solidarisk ansvar (fullt ansvarlig)|Nøkkelrolle når rollen er registrert på fnr, har de fleste fullmakter|
-|EIKM|Eierkommune|Ingen fullmakter|
-|FFØR|Forretningsfører|Forretningsfører for Borettslag og Eierseksjonssameier har fullmakter, øvrige FFØR ingen fullmakter|
-|HFOR|Opplysninger om foretaket i hjemlandet|Ingen fullmakter|
-|HLSE|Helseforetak|Ingen fullmakter|
-|INNH|Innehaver|Nøkkelrolle, har de fleste fullmakter|
-|KDEB|Konkursdebitor|Ingen fullmakter|
-|KENK|Den personlige konkursen angår|Ingen fullmakter|
-|KIRK|Inngår i kirkelig fellesråd|Ingen fullmakter|
-|KOMP|Komplementar (i kommandittselskap?)|Ingen fullmakter|
-|KONT|Kontaktperson|Ingen fullmakter|
-|KTRF|Inngår i kontorfellesskap|Ingen fullmakter|
-|LEDE|Styrets leder|Nøkkelrolle, har de fleste fullmakter|
-|MEDL|Styremedlem|Ingen fullmakter|
-|NEST|Nestleder|Ingen fullmakter|
-|OBS|Observatør|Ingen fullmakter|
-|OPMV|er særskilt oppdelt enhet til|Ingen fullmakter|
-|ORGL|Organisasjonsledd i offentlig sektor|Ingen fullmakter|
-|REGN|Regnskapsfører|Utvalgte fullmakter for klienter/kunder|
-|REPR|Norsk representant for utenlandsk enhet|Ingen fullmakter|
-|REVI|Revisor|Utvalgte fullmakter for klienter/kunder|
-|VARA|Varamedlem|Ingen fullmakter|
+1. Virksomheten registrerer en person eller en annen virksomhet i en rolle i Enhetsregisteret.
+2. Altinn Register henter rolleknytningen.
+3. Altinn Access Management kobler rollen til én eller flere tilgangspakker.
+4. Tjenesteeieren knytter handlingene i tjenesten til en tilgangspakke gjennom policyen for tjenesten.
 
-# Organisasjonsformer og roller som Altinn leser inn fra Enhetsregisteret
+Rollen alene inneholder derfor ikke en fast liste over tjenester. Tilgangen følger av kombinasjonen av rollen, koblingen til tilgangspakken og policyen som tjenesteeieren har satt for tjenesten.
 
+## Skille mellom tilgang og administrasjon
 
-## Organisasjonsformer for selskap med begrenset ansvar
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Aksjeselskap (AS)|En organisasjonsform med begrenset ansvar for eierne (aksjonærene).|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Allmennaksjeselskap (ASA)|Et aksjeselskap med begrenset ansvar for eierne. Denne organisasjonsformen kan brukes av selskaper som har mange aksjonærer, og/eller ønsker mulighet til å innhente kapital fra allmennheten|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Europeisk selskap (SE)|En transnasjonal europeisk selskapsform av allmennaksjeselskapstypen.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Selskap med begrenset ansvar (BA)|Samvirkeforetak opprettet før 1.januar 2008|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Samvirkeforetak (SA)|Har som hovedformål å fremme medlemmenes økonomiske interesser ved at de deltar i foretakets aktiviteter, enten som forbrukere, leverandører eller på annen lignende måte. Det må være en form for utveksling av varer eller tjenester mellom foretaket og medlemmene. Medlemmene har begrenset økonomisk ansvar. Det vil si at de ikke har ansvar for foretakets gjeld utover den innskutte andelskapitalen. Foretakets overskudd blir enten stående i foretaket eller fordelt mellom medlemmene ut fra den enkeltes andel i omsetningen.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-## Organisasjonsformer for selskap med ubegrenset ansvar 
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Enkeltpersonforetak (ENK)|I et enkeltpersonforetak er én person fullt økonomisk ansvarlig for den næringsaktiviteten som drives.|KONT, FFØR, REGN, REVI|DAGL, LEDE, *INNH|NEST, MEDL, VARA, OBS|
-|Ansvarlig selskap med delt ansvar (DA)|Et ansvarlig selskap med delt ansvar er et selskap med to eller flere eiere (deltakere). Deltakerne har til sammen et personlig ansvar for hele gjelden, men hver enkelt deltaker er bare ansvarlig for sin ansvarsandel.|KONT, FFØR, REGN, REVI|DAGL, LEDE, **DTPR|NEST, MEDL, VARA, OBS, *DTPR|
-|Ansvarlig selskap med solidarisk ansvar (ANS)|Ansvarlig selskap er et selskap med to eller flere eiere (deltakere). Deltakerne har et ubegrenset personlig ansvar for hele gjelden.|KONT, FFØR, REGN, REVI|DAGL, LEDE, **DTSO|NEST, MEDL, VARA, OBS, *DTSO|
-|Kommandittselskap (KS)|Et kommandittselskap er et selskap hvor minst en deltaker hefter ubegrenset for selskapsforpliktelsene (komplementar), og minst en deltaker har begrenset sitt ansvar til et nærmere fastsatt innskudd (kommandittist)|KONT, FFØR, REGN, REVI|DAGL, LEDE, **KOMP|NEST, MEDL, VARA, OBS, *KOMP|
+En rollekobling kan gi ulike muligheter:
 
-Roller merket * betyr at andre organisasjoner/personer som har en spesial rolle for denne organisasjonsformen. 
+- **Har tilgang** betyr at rolleinnehaveren kan bruke tjenester som inngår i pakken.
+- **Kan delegere** betyr at rolleinnehaveren kan gi pakken videre til andre.
+- **Kan tildele** brukes for enkelte administrative koblinger og betyr at rolleinnehaveren kan tildele tilgang innenfor det aktuelle området.
 
-Roller merket ** betyr at bare når rolleinnehaver er en person så får denne nøkkelrolle for virksomheten. Hvis rolleinnehaver er en organisasjon så får man en knytning uten fullmakter til organisasjonen. 
+Disse mulighetene følger ikke alltid hverandre. En regnskapsfører kan for eksempel få regnskapspakker uten å kunne delegere dem videre.
 
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Tingsrettslig sameie (SAM)|Et tingsrettslig sameie er en måte to eller flere personer kan eie en eller flere formuesgjenstander på. Eksempel: når to eller flere eier en hytte, en vei, en russebuss eller lignende sammen. |KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Borettslag (BRL)|Et borettslag eies av de som bor der. Når du kjøper en bolig i et borettslag, blir du samtidig andelseier. Andelseierne i borettslaget eier bygninger og tomt i fellesskap, og tar beslutninger om oppussing, vedlikehold og påkostninger av bygninger og fellesarealer. Som andelseier er du ikke ansvarlig for lagets forpliktelser overfor kreditorer.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Boligbyggelag (BBL)|Et boligbyggelag har til hovedformål å bygge, omsette og forvalte boliger for sine andelseiere. Et boligbyggelag kan gjerne bestå av flere borettslag.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Eierseksjonssameie (ESEK)|Et eierseksjonssameie er en bebygd eiendom som er seksjonert og tinglyst på et gårds- og bruksnummer. Eiendommen eies i fellesskap, men eierne har enerett til å bruke sin seksjon. Et eierseksjonssameie kan ha både boligseksjoner og næringsseksjoner.|KONT, FFØR, REGN, REVI|LEDE|NEST, MEDL, VARA, OBS|
-## Organisasjonsformer for spesielle bransjer
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Sparebank (SPA)|En sparebank er en bank som er organisert som en selveiende institusjon, det vil si uten eksterne eiere. Dette til forskjell fra en forretningsbank organisert som et aksjeselskap og altså med aksjonærene som eiere. |KONT, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Pensjonskasse (PK)|Pensjonskasse er en annen form for pensjonsforsikringshåndtering. Enkelte større selskaper velger å ha sin egen pensjonskasse i stedet for å tegne en kollektiv pensjonsavtale med et forsikringsselskap. Forvaltning av pensjonskasser gjøres av forsikringsselskaper, egne spesialiserte selskaper eller for noen av de større av seg selv. Eksempler på det siste er Statens pensjonskasse og Telenor Pensjonskasse.|KONT, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Gjensidig forsikringsselskap (GFS)|Gjensidig forsikringsselskap en offentlig selskaps-/organisasjonsform som ofte nyttes ved organisering av forsikringsselskap. Selskapsformen innebærer at forsikringstagerne danner og eier selskapet, dets eventuelle aktiva og også deler den risikoen selskapet har påtatt seg. Dette innebærer altså at kunde- og eiergruppen er sammenfallende.|KONT, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Partrederi (PRE)|Et partrederi er et selskap som har til formål å drive rederivirksomhet. I et partrederi med solidarisk ansvar har alle deltakerne et personlig ansvar for hele gjelden. Det en deltaker ikke kan betale, kan kreves helt og fullt fra de andre deltakerne. I et partrederi med delt ansvar har deltakerne et personlig ansvar for hele gjelden, men hver enkelt deltaker er bare ansvarlig for sin ansvarsdel.|KONT, FFØR, REGN, REVI|LEDE, *BEST|NEST, MEDL, VARA, OBS, *DTPR|
-|Verdipapirfond (VPFO)|I et verdipapirfond går andelseiere sammen om å plassere sine midler i verdipapirmarkedet. Fondet forvaltes av et forvaltningsselskap med konsesjon fra Finanstilsynet.Verdipapirfond deles inn i fem hovedgrupper etter hvilke verdier de investerer i: aksjefond, obligasjonsfond, pengemarkedsfond, kombinasjonsfond og spesialfond.|KONT, FFØR, REGN, REVI|DAGL|(ingen)|
-|Annen juridisk person (ANNA)|Annen juridisk person er en virksomhet som kan påta seg rettigheter og plikter. Denne organisasjonsformen skal brukes for en svært begrenset gruppe virksomheter, og bare når ingen av de andre organisasjonsformene er aktuelle. Eksempler på virksomheter som kan registreres som annen juridisk person er ambassader, bygdeallmenninger, fjellstyre, katolske menigheter, reinbeitedistrikt, statsallmenninger, stortingsgrupper, interkommunale politiske råd og kommunalt oppgavefellesskap.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-## Organisasjoner for frivillig sektor
-|Navn|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med enkel knytning uten fullmakter|
-|----|-----------|------------------------------|-------------|------------------------------------------|
-|Forening/lag/innretning (FLI)|En forening er en selveiende sammenslutning med medlemmer, som skal fremme ett eller flere formål av ideelt, politisk eller annen art. Rettsforholdet i foreninger er ikke regulert i lov, men det har over tid utviklet seg foreningsrettslige prinsipper.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Stiftelse (STI)|En stiftelse er en formuesverdi som ved testamente, gave eller annen rettslig disposisjon selvstendig er stilt til rådighet for et bestemt formål. Formålet kan være av ideell, humanitær, kulturell, sosial, utdanningsmessig, økonomisk eller annen art. Stiftelser må ha en grunnkapital. Kravet til minste grunnkapital er 100 000 kroner for alminnelige stiftelser og 200 000 kroner for stiftelser som driver næringsaktivitet.|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-## Organisasjonsformer for offentlig sektor
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Kommune (KOMM)|(mangler)|KONT, REGN, REVI, FFØR|DAGL|(ingen)|
-|Staten (STAT)|(mangler)|KONT, REGN, REVI, FFØR|DAGL|(ingen)|
-|Fylkeskommune (FYLK)|(mangler)|KONT, REGN, REVI, FFØR|DAGL|(ingen)|
-|Organisasjonsledd (ORGL)|(mangler)|KONT, REGN, REVI, FFØR|DAGL, LEDE|NEST, MEDL, VARA, OBS, *ORGL|
-|Administrativ enhet -offentlig sektor (ADOS)|(mangler)|KONT,REGN, REVI|LEDE|NEST, MEDL, VARA, OBS, *ADOS|
-|Interkommunalt selskap (IKS)|Er en norsk organisasjonsform for selskaper innen offentlig sektor der flere kommuner og/eller fylkeskommuner er eiere. Selskapsdriften reguleres av Lov om interkommunale selskaper. Interkommunale vannverk, arkivdrift og regionmuseer er typiske funksjonsområder for interkommunale selskaper.|KONT, FFØR, REGN, REVI|DAGL,LEDE|*DTPR, NEST, MEDL, VARA, OBS, |
-|Kommunalt foretak (KF)|er betegnelse for en selskapsform som brukes for virksomheter som er eid av norske kommuner.|KONT, FFØR, REGN, REVI,|DAGL, LEDE,|NEST, MEDL, VARA, OBS, *EIKM|
-|Fylkeskommunalt foretak (FKF)|er betegnelse for en selskapsform som brukes for virksomheter som er eid av fylkeskommune .|KONT, FFØR, REGN, REVI,|DAGL, LEDE,|NEST, MEDL, VARA, OBS, *EIKM|
-|Statsforetak (SF)|er en norsk selskapsform regulert av lov om statsforetak av 30. august 1991. Statsforetak stiftes av Kongen i statsråd og eies av den norske stat i sin helhet, representert ved et departement.|KONT, REGN, REVI,|DAGL, LEDE,|NEST, MEDL, VARA, OBS|
+## Eksempler på roller og forhåndstildelte pakker
 
-Roller merket * betyr at andre organisasjoner/personer som har en spesial rolle for denne organisasjonsformen. 
-## Organisasjonsformer for utenlandske virksomheter
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Norskregistrert utenlandsk foretak (NUF)|Norskregistrert utenlandsk foretak er en norsk filial av et utenlandskregistrert selskap. I denne sammenheng må det skilles mellom «utenlandsk selskap» i selskapsrettslig og skatterettslig forstand. NUF er norske avdelinger av utenlandske selskap i en selskapsrettslig forstand, og kan derfor godt være skattemessig tilhørende til Norge. Ordningen blir anvendt av flere større selskaper som driver på tvers av landegrensene. Innføringen av selskapsformen NUF i norsk selskapsrett var et resultat av EØS-avtalen, ettersom fri etableringsrett på tvers av landegrenser er et prinsipp i EU-retten.|KONT, FFØR, REGN, REVI,|DAGL, LEDE, *REPR| NEST, MEDL, VARA, OBS|
-|Europeisk selskap (SE)|Europeisk selskap er en transnasjonal europeisk selskapsform av allmennaksjeselskapstypen. Selskapsformen ble etablert fra og med 8. oktober 2004. Rettsgrunnlaget er EU-forordning 2157/2001.|KONT, FFØR, REGN, REVI,|DAGL,  LEDE| NEST, MEDL, VARA, OBS|
-|Utenlandsk enhet (UTLA)|(mangler)|KONT, FFØR|DAGL|(ingen)|
-|Europeisk økonomisk foretaksgruppe (EOFG)|(mangler)|KONT, FFØR, REGN, REVI,|DAGL, LEDE| NEST, MEDL, VARA, OBS|
+Tabellen viser sentrale eksempler. Koblingene kan endres når pakker eller tjenester endres.
 
-Roller merket * betyr at andre organisasjoner/personer som har en spesial rolle for denne organisasjonsformen. 
-## Andre særskilte organisasjonsformer 
-|Navn (kode)|Beskrivelse|Roller med utvalgte fullmakter|Nøkkel-roller|Roller med knytning uten fullmakter|
-|-----------|-----------|------------------------------|-------------|-----------------------------------|
-|Kontorfellesskap (KTRF)|(mangler)|KONT, REGN, REVI|(ingen)|*KTRF|
-|Særskilt oppdelt enhet jfr mval § 2-2 (OPMV)|(mangler)|KONT, FFØR, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS, *OPMV|
-|Andre bo (BO)|Andre bo er en organisasjonsform som brukes ved registrering av dødsbo og felleseiebo.|KONT, REGN, REVI|DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Konkursbo (KBO)|(mangler)|REGN, REVI|BOBE| (ingen)|
-|Tvangsregistrert for MVA (TVAM)|(mangler)|KONT, FFØR, REGN, REVI|INNH, DAGL, LEDE|NEST, MEDL, VARA, OBS|
-|Andre enkeltpersoner som registreres i tilknyttet register (PERS)|(mangler)|KONT, REGN, REVI|(ingen)|(ingen)|
-|Den norske kirke (KIRK)|Trossamfunnet Den norske kirke registreres i Enhetsregisteret med organisasjonsformen Den norske kirke. Dette gjelder både kirkelige fellesråd, soknene eller menighetene.|KONT, FFØR, REGN, REVI,|DAGL, LEDE,|NEST, MEDL, VARA, OBS, *KIRK|
-|Annet foretak iflg. særskilt lov (SÆR)|Et særlovselskap skiller seg fra andre statlige aksjeselskap og statsforetak ved at hvert enkelt av selskapene er opprettet og drives med hjemmel i en egen lov,[1] eller en lov som gjelder flere selskaper av lignende karakter. Dette omfatter blant annet helseforetak (HF), regionalt helseforetak (RHF), studentsamskipnader og enkelte folkehøgskoler. Særlovselskapene er i hovedsak opprettet der hovedvirksomheten er et monopol eller brukes som et politisk instrument. Oppgavene varierer fra pengespillforvaltning, næringsvirksomhet, bankvirksomhet til disponering av budsjettpolitiske virkemidler.|KONT, FFØR, REGN, REVI,|DAGL, LEDE,|NEST, MEDL, VARA, OBS, *HLSE|
+| Rolle fra Enhetsregisteret | Eksempler på pakker | Kan delegere eksempelpakkene? |
+|---|---|---|
+| Daglig leder, styrets leder og innehaver | Klientadministrator, tilgangsstyring, hovedadministrator og Maskinporten administrator | Ja |
+| Regnskapsfører | Regnskapsfører med signeringsrettighet, regnskapsfører uten signeringsrettighet og regnskapsfører lønn | Nei |
+| Revisor | Ansvarlig revisor og revisormedarbeider | Nei |
+| Forretningsfører for borettslag og eierseksjonssameie | Forretningsfører eiendom | Nei |
+| Bostyrer | Konkursbo lesetilgang og konkursbo skrivetilgang | Ja |
+| Kontaktperson for NUF og norsk representant for utenlandsk enhet | Tjenester for NUF og enkelte administrative pakker | Ja |
 
-Roller merket * betyr at andre organisasjoner/personer som har en spesial rolle for denne organisasjonsformen. 
+<a href="https://tjenesteoversikten.no/packages" target="_blank" rel="noopener noreferrer">Se hvilke tjenester som inngår i tilgangspakkene i Tjenesteoversikten (åpnes i ny fane)</a>. Tjenesteoversikten er et uoffisielt innsynsverktøy som team Autorisasjon har laget med åpne API-er.
+
+## Roller uten forhåndstildelte pakker
+
+At en person er registrert med en rolle i Enhetsregisteret, betyr ikke at rollen automatisk gir tilgang i Altinn. Roller som styremedlem, varamedlem og kontaktperson er eksempler på roller som ikke nødvendigvis har forhåndstildelte tilgangspakker.
+
+Personen kan likevel få tilgang hvis noen med delegasjonsrett gir personen en tilgangspakke eller tilgang til en enkelt tjeneste.
+
+## Organisasjonsformen påvirker resultatet
+
+Ikke alle roller kan registreres for alle organisasjonsformer. Enkelte koblinger gjelder bare bestemte organisasjonsformer. Forretningsfører får for eksempel pakken for eiendomsforvaltning når virksomheten er et borettslag eller et eierseksjonssameie.
+
+En rolle kan også innehas av en annen virksomhet. Da kan Altinn i enkelte tilfeller føre tilgangen videre til personer i den tilknyttede virksomheten. [Les hvordan virksomhetsknytninger virker](./knytning_org/).
+
+## Dette må tjenesteeieren ta hensyn til
+
+- Velg en tilgangspakke som dekker oppgaven brukeren skal utføre, ikke en bestemt stillingstittel.
+- Kontroller at pakken ikke gir bredere tilgang enn tjenesten krever.
+- Ikke legg til grunn at alle personer med en registrert rolle kan delegere tilgangen sin.
+- Test med de organisasjonsformene og rollene som målgruppen faktisk bruker.
+- Beskriv eventuelle tilleggskrav i veiledningen for tjenesten.
+
+## Kilder og vedlikehold
+
+Den tekniske fasiten ligger i Access Management-koden:
+
+- [Rolledefinisjonene i RoleConstants.cs](https://github.com/Altinn/altinn-authorization-tmp/blob/main/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/RoleConstants.cs)
+- [Koblingene mellom roller og tilgangspakker i IngestRolePackage.cs](https://github.com/Altinn/altinn-authorization-tmp/blob/main/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/IngestRolePackage.cs)
+- [Definisjonene av tilgangspakkene i PackageConstants.cs](https://github.com/Altinn/altinn-authorization-tmp/blob/main/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/PackageConstants.cs)
+
+[Brønnøysundregistrene beskriver Enhetsregisteret og hvilke opplysninger registeret inneholder](https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/).

--- a/content/authorization/what-do-you-get/accesspackages/register_ER/knytning_org/_index.en.md
+++ b/content/authorization/what-do-you-get/accesspackages/register_ER/knytning_org/_index.en.md
@@ -1,118 +1,70 @@
 ---
-title: Fullmakter fra Enhetsregisteret som knytter virksomheter sammen
-linktitle: Virksomhetsknytninger
-description: Virksomheter som tildeles roller i Enhetsregisteret kan også få fullmakter på vegne av virksomheten i Altinn. Her forklares hvordan dette gjøres.
-tags: [architecture, security, authorization, needstranslation]
+title: When one organisation holds a role for another
+linktitle: Organisation connections
+description: How a role from the Central Coordinating Register can pass access through a connected organisation
+tags: [architecture, security, authorization]
 toc: true
 weight: 1
 hidden: true
 aliases:
   - /authorization/what-do-you-get/accessgroups/register_er/knytning_org/
 ---
-*Innhold på siden er under arbeid. Innholdet vil ikke være gjeldende før nye [tilgangspakker](/en/authorization/what-do-you-get/accesspackages/business/) trer i kraft. Dette må derfor ikke ansees som en fasit pr nå*
 
+A role in the Central Coordinating Register may be held by an individual or an organisation. When an organisation holds the role, individuals who represent the connected organisation may in some cases act on behalf of the organisation that granted the role.
 
-I mange tilfeller er det mulig å registrere andre organisasjoner i en eller flere roller på virksomheten.
-Altinn vil i mange tilfeller da sørge for en knytning mellom disse virksomhetene slik at person som har bestemte roller i tilknyttet organisasjon da få fullmakter på vegne av den aktuelle virksomheten.
-Vi kaller dette nøsting av fullmakter.
+This is used, for example, when an organisation has another organisation as its accountant, auditor or business manager.
 
-## Hvem får fullmakt på vegne av tilknyttet virksomhet
-Det er tilknyttet virksomhet og personer reigstrert med nøkkelroller i denne som får fullmakter på vegne av den aktuelle virksomheten. I tabeller på [denne siden](/en/authorization/what-do-you-get/accesspackages/register_er/) finner du oversikt over hvilke nøkkelroller som finnes på ulike organisasjonsformer.
+## How the connection works
 
-Eksempel 1 på hvordan det fungerer:
+Example:
 
-- "Bergen AS" registrerer "Trondheim AS" i rollen som daglig leder
-- Kari er daglig leder for "Trondheim AS"
+- Fjordhandel AS has registered Regnskapspartner AS as its accountant.
+- Kari represents Regnskapspartner AS with a role that provides the relevant accounting access.
+- Kari can use the pre-assigned accounting packages on behalf of Fjordhandel AS.
 
-I dette eksemplet vil Kari få fullmakter på vegne av "Bergen AS". Kari vil kunne opptre på vegne av "Bergen AS" med samme fullmakter som en daglig leder.
+Kari does not receive every access held by Fjordhandel AS. She receives only the access that follows from the accountant role and its associated access packages.
 
-Eksempel 2 på hvordan det fungerer:
-- "Bergen AS" registrerer "Trondheim AS" i rollen som daglig leder
-- "Trondheim AS" oppretter en virksomhetsbruker og denne gis fullmakten "Fullmakt for leverandør" (ECKEY-role) på vegne av "Trondheim AS"
+## The role at each end matters
 
-I dette eksemplet vil virksomhetsbruker få fullmakter på vegne av "Bergen AS" gjennom sin knytning til "Trondheim AS". Virksomhetsbruker vil kunne opptre på vegne av "Bergen AS" med samme fullmater som en daglig leder.
+Altinn considers
 
+- the role that connects the organisations
+- the role or access held by the individual in the connected organisation
+- the access packages mapped to the role
+- the actions that the service owner has placed in the packages through the service policy
 
-### For hvor mange ledd nøstes fullmakter videre?
+A connection between two organisations is therefore not a general power of attorney by itself.
 
-Altinn nøster fullmakter kun i ett ledd.
+## Access does not pass through an unlimited chain
 
-Eksempel på hvordan det fungerer:
-- "Bergen AS" registrerer "Trondheim AS" i rollen som daglig leder
-- Daglig leder for "Trondheim AS" er "Oslo AS"
-- Ola er daglig leder for "Oslo AS"
+Organisation connections must not be understood as a chain in which access automatically passes through any number of organisations.
 
-I dette tilfellet vil ikke Ola få fullmakter på vegne av "Bergen AS".
+If Bergen AS has registered Trondheim AS as its managing director, and Oslo AS is in turn the managing director of Trondheim AS, this does not automatically mean that a representative of Oslo AS can act on behalf of Bergen AS. Check the actual access in Altinn when several organisations form a chain.
 
-### Hva med underenheter?
-Det registreres ikke roller direkte på underenheter (AAFY og BEDR) i Enhetsregisteret. Derfor styres tilgang på vegne av en underenhet gjennom roller registert på hovedenhet i Enhetsregisteret.
+## Subunits
 
-Eks 1
-- "Avdeling Salhus" er knyttet til aksjeselskapet "Brønnøysund AS"
-- Kari er registert som daglig leder for "Brønnøysund AS"
-I dette tilfellet vil Kari få samme fullmakter for "Avdeling Salhus" som hun har for "Brønnøysund AS"
+A subunit is connected to one or more main units in Register. Roles are normally registered for the main unit. Access to a subunit must therefore be assessed from its connection to the main unit and the rules for the relevant service.
 
-Eks 2
-- "Avdeling Salhus" er knyttet til aksjeselskapet "Brønnøysund AS"
-- "Regnskap AS" er registert som regnskapsfører for "Brønnøysund AS"
-- Ola er daglig leder for "Regnskap AS"
-I dette tilfellet vil Ola få regnskapsfullmakter på vegne av "Avdeling salhus" og "Brønnøysund AS"
+Service owners should test both the main unit and the subunit if subunits can use the service.
 
-## Hva med regnskapsfører og revisor for Enkeltpersonforetak?
-Enkeltpersonforetak er spesielle på den måten at det er innehaver selv som er 100% ansvarlig for virksomheten. Derfor får nøstes enkelte fullmakter videre til innehavers personnummer for regnskapsfører og revisor
+## Sole proprietorships
 
-Eks:
-- Kari har registert et ENK kalt "Kari sitt ENK"
-- "Rgnskap AS" er registert regnskapsfører for "Kari ENK"
-- Ola er daglig leder for "Regnskap AS"
-I dette tilfellet vil Ola få regnskapsfullmakter på vegne av "Kari sitt ENK" og på vegne av Kari som person.
+A sole proprietorship and its owner are closely connected, but they are separate parties in Altinn. Do not assume that access for the business always applies to the owner as a private individual, or vice versa. The service policy and the specific role relationship determine who receives access.
 
+## How to investigate specific access
 
-## Oversikt over hvilke organisasjonsformer og roller som nøster knytning mellom organisasjoner i Altinn
+1. Find the role registered between the organisations.
+2. Find the access packages provided by the role.
+3. Check whether the individual can use or administer the package through the connected organisation.
+4. Check which services and actions are included in the package.
+5. Test with representative test data before putting the service into use.
 
-|Navn (kode)|Roller som nøstes videre til nøkkelroller i tilnyttet selskap|Merknader|
-|-----------|--------------------------------------------------------------|----------|
-|Aksjeselskap (AS)|DAGL, LEDE, REVI, REGN||
-|Europeisk selskap (SE)|DAGL, LEDE, REVI, REGN||
-|Selskap med begrenset ansvar (BA)|DAGL, LEDE, REVI, REGN||
-|Samvirkeforetak (SA)|DAGL, LEDE, REVI, REGN||
-|Enkeltpersonforetak (ENK)|DAGL, LEDE, REVI, REGN||
-|Ansvarlig selskap med delt ansvar (DA)|DAGL, LEDE, *DTPR, REVI, REGN||
-|Ansvarlig selskap med solidarisk ansvar (ANS)|DAGL, LEDE, *DTSO, REVI, REGN||
-|Kommandittselskap (KS)|DAGL, LEDE, *KOMP, REVI, REGN||
-|Tingsrettslig sameie (SAM)|DAGL, LEDE, REVI, REGN||
-|Borettslag (BRL)|DAGL, LEDE, REVI, REGN||
-|Boligbyggelag (BBL)|DAGL, LEDE, REVI, REGN||
-|Eierseksjonssameie (ESEK)|LEDE, REVI, REGN||
-|Sparebank (SPA)|DAGL, LEDE, REVI, REGN||
-|Pensjonskasse (PK)|DAGL, LEDE, REVI, REGN||
-|Gjensidig forsikringsselskap (GFS)|DAGL, LEDE, REVI, REGN||
-|Partrederi(PRE)|BEST, LEDE, DTPR REVI, REGN||
-|Verdipapirfond (VPF0)|DAGL, REVI, REGN||
-|Annen juridisk person (ANNA)|DAGL, LEDE, REVI, REGN||
-|Forening/lag/innretning (FLI)|DAGL, LEDE, REVI, REGN||
-|Stiftelse (STI)|DAGL, LEDE, REVI, REGN||
-|Kommune (KOMM)|DAGL, REVI, REGN||
-|Staten (STAT)|DAGL, REVI, REGN||
-|Fylkeskommune (FYLK)|DAGL, REVI, REGN||
-|Organisasjonsledd (ORGL)|DAGL, LEDE, REVI, REGN, ORGL||
-|Administrativ enhet -offentlig sektor (ADOS)|LEDE, REVI, REGN, ADOS||
-|Statsforetak (SF)|DAGL, LEDE, REVI, REGN||
-|Fylkeskommunalt foretak (FKF)|DAGL, LEDE, REVI, REGN, EIKM||
-|Kommunalt foretak (KF)|DAGL, LEDE, REVI, REGN, EIKM||
-|Interkommunalt selskap (IKS)|DAGL, LEDE, REVI, REGN| Det ansees ikke som relevant å gi kommunedirekøtr i deltakende kommune fullmakter på vegne av IKS|
-|Den norske kirke (KIRK)|DAGL, LEDE, REVI, REGN|Det ansees ikke som relevant å gi tilknyttet kirkeorganisasjon i en eierkommune fullmakter på vegne av tilknyttet KIRK|
-|Annet foretak iflg. særskilt lov (SÆR)|DAGL, LEDE, REVI, REGN||
-|Norskregistrert utenlandsk foretak (NUF)|DAGL, LEDE, REVI, REGN||
-|Utenlandsk enhet (UTLA)|DAGL, REVI, REGN||
-|Europeisk selskap(SE)|DAGL, LEDE, REVI, REGN||
-|Europeisk økonomisk foretaksgruppe (EOFG)|DAGL, LEDE, REVI, REGN||
-|Kontorfellesskap (KTRF)|REVI, REGN||
-|Særskilt oppdelt enhet jfr mval § 2-2 (OPMV)|DAGL, REVI, REGN||
-|Andre bo (BO)|DAGL, LEDE, REVI, REGN||
-|Konkursbo (KBO)|REVI, REGN||
-|Tvangsregistrert for MVA (TVAM)|DAGL, INNH, REVI, REGN||
-|Andre enkeltpersoner som registreres i tilknyttet register (PERS)|(ingen)||
-|Andre ikke-juridiske personer (IKJP)|DAGL, LEDE, REVI, REGN||
-|Underenhet til ikke-næringsdrivende (AAFY)|Samme roller som for overordnet enhet||
-|Underenhet til næringsdrivende og offentlig forvaltning (BEDR)|Samme roller som for overordnet enhet||
+[Read how roles from the Central Coordinating Register map to access packages](../).
+
+<a href="https://tjenesteoversikten.no/packages" target="_blank" rel="noopener noreferrer">Inspect the contents of access packages in Tjenesteoversikten (opens in a new tab)</a>. Tjenesteoversikten is an unofficial information tool.
+
+## Sources and maintenance
+
+- [Register code that imports and stores roles from the Central Coordinating Register](https://github.com/Altinn/altinn-register/tree/main/src/apps/Altinn.Register)
+- [Role definitions in Access Management](https://github.com/Altinn/altinn-authorization-tmp/blob/main/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/RoleConstants.cs)
+- [Mappings between roles and access packages](https://github.com/Altinn/altinn-authorization-tmp/blob/main/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/IngestRolePackage.cs)

--- a/content/authorization/what-do-you-get/accesspackages/register_ER/knytning_org/_index.nb.md
+++ b/content/authorization/what-do-you-get/accesspackages/register_ER/knytning_org/_index.nb.md
@@ -1,7 +1,7 @@
 ---
-title: Fullmakter fra Enhetsregisteret som knytter virksomheter sammen
+title: Når en virksomhet har en rolle for en annen virksomhet
 linktitle: Virksomhetsknytninger
-description: Virksomheter som tildeles roller i Enhetsregisteret kan også få fullmakter på vegne av virksomheten i Altinn. Her forklares hvordan dette gjøres.
+description: Slik kan en rolle fra Enhetsregisteret føre tilgang videre gjennom en tilknyttet virksomhet
 tags: [architecture, security, authorization]
 toc: true
 weight: 1
@@ -9,110 +9,62 @@ hidden: true
 aliases:
   - /authorization/what-do-you-get/accessgroups/register_er/knytning_org/
 ---
-*Innhold på siden er under arbeid. Innholdet vil ikke være gjeldende før nye [tilgangspakker](/nb/authorization/what-do-you-get/accesspackages/business/) trer i kraft. Dette må derfor ikke ansees som en fasit pr nå*
 
+En rolle i Enhetsregisteret kan innehas av en person eller en virksomhet. Når en virksomhet har rollen, kan personer som representerer den tilknyttede virksomheten i enkelte tilfeller handle på vegne av virksomheten som ga rollen.
 
-I mange tilfeller er det mulig å registrere andre organisasjoner i en eller flere roller på virksomheten.
-Altinn vil i mange tilfeller da sørge for en knytning mellom disse virksomhetene slik at person som har bestemte roller i tilknyttet organisasjon da få fullmakter på vegne av den aktuelle virksomheten.
-Vi kaller dette nøsting av fullmakter.
+Dette brukes blant annet når en virksomhet har en annen virksomhet som regnskapsfører, revisor eller forretningsfører.
 
-## Hvem får fullmakt på vegne av tilknyttet virksomhet
-Det er tilknyttet virksomhet og personer reigstrert med nøkkelroller i denne som får fullmakter på vegne av den aktuelle virksomheten. I tabeller på [denne siden](/nb/authorization/what-do-you-get/accesspackages/register_er/) finner du oversikt over hvilke nøkkelroller som finnes på ulike organisasjonsformer.
+## Slik virker koblingen
 
-Eksempel 1 på hvordan det fungerer:
+Eksempel:
 
-- "Bergen AS" registrerer "Trondheim AS" i rollen som daglig leder
-- Kari er daglig leder for "Trondheim AS"
+- Fjordhandel AS har registrert Regnskapspartner AS som regnskapsfører.
+- Kari representerer Regnskapspartner AS med en rolle som gir de aktuelle regnskapstilgangene.
+- Kari kan bruke de forhåndstildelte regnskapspakkene på vegne av Fjordhandel AS.
 
-I dette eksemplet vil Kari få fullmakter på vegne av "Bergen AS". Kari vil kunne opptre på vegne av "Bergen AS" med samme fullmakter som en daglig leder.
+Kari får ikke alle tilgangene til Fjordhandel AS. Hun får bare tilgangene som følger av regnskapsførerrollen og de tilhørende tilgangspakkene.
 
-Eksempel 2 på hvordan det fungerer:
-- "Bergen AS" registrerer "Trondheim AS" i rollen som daglig leder
-- "Trondheim AS" oppretter en virksomhetsbruker og denne gis fullmakten "Fullmakt for leverandør" (ECKEY-role) på vegne av "Trondheim AS"
+## Rollen i hver ende har betydning
 
-I dette eksemplet vil virksomhetsbruker få fullmakter på vegne av "Bergen AS" gjennom sin knytning til "Trondheim AS". Virksomhetsbruker vil kunne opptre på vegne av "Bergen AS" med samme fullmater som en daglig leder.
+Altinn vurderer både
 
+- rollen som knytter virksomhetene sammen
+- rollen eller tilgangen personen har i den tilknyttede virksomheten
+- hvilke tilgangspakker som er koblet til rollen
+- hvilke handlinger tjenesteeieren har lagt i pakkene gjennom policyen for tjenesten
 
-### For hvor mange ledd nøstes fullmakter videre?
+En tilknytning mellom to virksomheter er derfor ikke i seg selv en generell fullmakt.
 
-Altinn nøster fullmakter kun i ett ledd.
+## Tilgangen føres ikke ubegrenset videre
 
-Eksempel på hvordan det fungerer:
-- "Bergen AS" registrerer "Trondheim AS" i rollen som daglig leder
-- Daglig leder for "Trondheim AS" er "Oslo AS"
-- Ola er daglig leder for "Oslo AS"
+Virksomhetsknytninger skal ikke forstås som en kjede der tilgangen automatisk går gjennom et vilkårlig antall virksomheter.
 
-I dette tilfellet vil ikke Ola få fullmakter på vegne av "Bergen AS".
+Hvis Bergen AS har registrert Trondheim AS som daglig leder, og Oslo AS igjen er daglig leder for Trondheim AS, betyr det ikke automatisk at en representant for Oslo AS kan handle på vegne av Bergen AS. Kontroller den faktiske tilgangen i Altinn når flere virksomheter inngår i kjeden.
 
-### Hva med underenheter?
-Det registreres ikke roller direkte på underenheter (AAFY og BEDR) i Enhetsregisteret. Derfor styres tilgang på vegne av en underenhet gjennom roller registert på hovedenhet i Enhetsregisteret.
+## Underenheter
 
-Eks 1
-- "Avdeling Salhus" er knyttet til aksjeselskapet "Brønnøysund AS"
-- Kari er registert som daglig leder for "Brønnøysund AS"
-I dette tilfellet vil Kari få samme fullmakter for "Avdeling Salhus" som hun har for "Brønnøysund AS"
+En underenhet er knyttet til én eller flere hovedenheter i Register. Roller registreres normalt på hovedenheten. Tilgangen til en underenhet må derfor vurderes ut fra koblingen til hovedenheten og reglene for den aktuelle tjenesten.
 
-Eks 2
-- "Avdeling Salhus" er knyttet til aksjeselskapet "Brønnøysund AS"
-- "Regnskap AS" er registert som regnskapsfører for "Brønnøysund AS"
-- Ola er daglig leder for "Regnskap AS"
-I dette tilfellet vil Ola få regnskapsfullmakter på vegne av "Avdeling salhus" og "Brønnøysund AS"
+Tjenesteeiere bør teste både hovedenheten og underenheten hvis tjenesten kan brukes av underenheter.
 
-## Hva med regnskapsfører og revisor for Enkeltpersonforetak?
-Enkeltpersonforetak er spesielle på den måten at det er innehaver selv som er 100% ansvarlig for virksomheten. Derfor får nøstes enkelte fullmakter videre til innehavers personnummer for regnskapsfører og revisor
+## Enkeltpersonforetak
 
-Eks:
-- Kari har registert et ENK kalt "Kari sitt ENK"
-- "Rgnskap AS" er registert regnskapsfører for "Kari ENK"
-- Ola er daglig leder for "Regnskap AS"
-I dette tilfellet vil Ola få regnskapsfullmakter på vegne av "Kari sitt ENK" og på vegne av Kari som person.
+Et enkeltpersonforetak og innehaveren er tett knyttet, men de er forskjellige aktører i Altinn. Ikke legg til grunn at en tilgang for foretaket alltid gjelder innehaveren som privatperson, eller omvendt. Tjenestens policy og den konkrete rollekoblingen avgjør hvem som får tilgang.
 
+## Slik undersøker du en konkret tilgang
 
-## Oversikt over hvilke organisasjonsformer og roller som nøster knytning mellom organisasjoner i Altinn
+1. Finn rollen som er registrert mellom virksomhetene.
+2. Finn hvilke tilgangspakker rollen gir.
+3. Kontroller om personen har tilgang til å bruke eller administrere pakken gjennom den tilknyttede virksomheten.
+4. Kontroller hvilke tjenester og handlinger som inngår i pakken.
+5. Test med representativ testdata før tjenesten tas i bruk.
 
-|Navn (kode)|Roller som nøstes videre til nøkkelroller i tilnyttet selskap|Merknader|
-|-----------|--------------------------------------------------------------|----------|
-|Aksjeselskap (AS)|DAGL, LEDE, REVI, REGN||
-|Europeisk selskap (SE)|DAGL, LEDE, REVI, REGN||
-|Selskap med begrenset ansvar (BA)|DAGL, LEDE, REVI, REGN||
-|Samvirkeforetak (SA)|DAGL, LEDE, REVI, REGN||
-|Enkeltpersonforetak (ENK)|DAGL, LEDE, REVI, REGN||
-|Ansvarlig selskap med delt ansvar (DA)|DAGL, LEDE, *DTPR, REVI, REGN||
-|Ansvarlig selskap med solidarisk ansvar (ANS)|DAGL, LEDE, *DTSO, REVI, REGN||
-|Kommandittselskap (KS)|DAGL, LEDE, *KOMP, REVI, REGN||
-|Tingsrettslig sameie (SAM)|DAGL, LEDE, REVI, REGN||
-|Borettslag (BRL)|DAGL, LEDE, REVI, REGN||
-|Boligbyggelag (BBL)|DAGL, LEDE, REVI, REGN||
-|Eierseksjonssameie (ESEK)|LEDE, REVI, REGN||
-|Sparebank (SPA)|DAGL, LEDE, REVI, REGN||
-|Pensjonskasse (PK)|DAGL, LEDE, REVI, REGN||
-|Gjensidig forsikringsselskap (GFS)|DAGL, LEDE, REVI, REGN||
-|Partrederi(PRE)|BEST, LEDE, DTPR REVI, REGN||
-|Verdipapirfond (VPF0)|DAGL, REVI, REGN||
-|Annen juridisk person (ANNA)|DAGL, LEDE, REVI, REGN||
-|Forening/lag/innretning (FLI)|DAGL, LEDE, REVI, REGN||
-|Stiftelse (STI)|DAGL, LEDE, REVI, REGN||
-|Kommune (KOMM)|DAGL, REVI, REGN||
-|Staten (STAT)|DAGL, REVI, REGN||
-|Fylkeskommune (FYLK)|DAGL, REVI, REGN||
-|Organisasjonsledd (ORGL)|DAGL, LEDE, REVI, REGN, ORGL||
-|Administrativ enhet -offentlig sektor (ADOS)|LEDE, REVI, REGN, ADOS||
-|Statsforetak (SF)|DAGL, LEDE, REVI, REGN||
-|Fylkeskommunalt foretak (FKF)|DAGL, LEDE, REVI, REGN, EIKM||
-|Kommunalt foretak (KF)|DAGL, LEDE, REVI, REGN, EIKM||
-|Interkommunalt selskap (IKS)|DAGL, LEDE, REVI, REGN| Det ansees ikke som relevant å gi kommunedirekøtr i deltakende kommune fullmakter på vegne av IKS|
-|Den norske kirke (KIRK)|DAGL, LEDE, REVI, REGN|Det ansees ikke som relevant å gi tilknyttet kirkeorganisasjon i en eierkommune fullmakter på vegne av tilknyttet KIRK|
-|Annet foretak iflg. særskilt lov (SÆR)|DAGL, LEDE, REVI, REGN||
-|Norskregistrert utenlandsk foretak (NUF)|DAGL, LEDE, REVI, REGN||
-|Utenlandsk enhet (UTLA)|DAGL, REVI, REGN||
-|Europeisk selskap(SE)|DAGL, LEDE, REVI, REGN||
-|Europeisk økonomisk foretaksgruppe (EOFG)|DAGL, LEDE, REVI, REGN||
-|Kontorfellesskap (KTRF)|REVI, REGN||
-|Særskilt oppdelt enhet jfr mval § 2-2 (OPMV)|DAGL, REVI, REGN||
-|Andre bo (BO)|DAGL, LEDE, REVI, REGN||
-|Konkursbo (KBO)|REVI, REGN||
-|Tvangsregistrert for MVA (TVAM)|DAGL, INNH, REVI, REGN||
-|Andre enkeltpersoner som registreres i tilknyttet register (PERS)|(ingen)||
-|Andre ikke-juridiske personer (IKJP)|DAGL, LEDE, REVI, REGN||
-|Underenhet til ikke-næringsdrivende (AAFY)|Samme roller som for overordnet enhet||
-|Underenhet til næringsdrivende og offentlig forvaltning (BEDR)|Samme roller som for overordnet enhet||
+[Les hvordan roller fra Enhetsregisteret kobles til tilgangspakker](../).
+
+<a href="https://tjenesteoversikten.no/packages" target="_blank" rel="noopener noreferrer">Undersøk innholdet i tilgangspakkene i Tjenesteoversikten (åpnes i ny fane)</a>. Tjenesteoversikten er et uoffisielt innsynsverktøy.
+
+## Kilder og vedlikehold
+
+- [Register-koden som importerer og lagrer roller fra Enhetsregisteret](https://github.com/Altinn/altinn-register/tree/main/src/apps/Altinn.Register)
+- [Rolledefinisjonene i Access Management](https://github.com/Altinn/altinn-authorization-tmp/blob/main/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Constants/RoleConstants.cs)
+- [Koblingene mellom roller og tilgangspakker](https://github.com/Altinn/altinn-authorization-tmp/blob/main/src/apps/Altinn.AccessManagement/src/Altinn.AccessMgmt.PersistenceEF/Data/IngestRolePackage.cs)


### PR DESCRIPTION
Summary: Explains how roles from the Central Coordinating Register map to access packages; distinguishes access, delegation and assignment with code-backed examples; replaces incomplete organisation matrices with maintainable guidance; documents organisation connections in Norwegian and English; and links to authoritative Register and Access Management source files. Verification: Full Hugo build passed with only existing deprecation and unrelated missing-page warnings. git diff --check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reworked English and Norwegian guidance on Enhetsregisteret roles and access packages.
  * Clarified the differences between access, administration and delegation.
  * Added examples showing how roles, organisation types and connections affect access.
  * Documented subunits, sole proprietorships and limits on access across connected organisations.
  * Added a step-by-step checklist for investigating specific access scenarios.
  * Updated page metadata, terminology and references to current source material.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->