### PR TITLE
Oppdaterer referanse til retningslinjer for varslingsinnhold

### DIFF
--- a/content/notifications/shared/getting-started/guidelines/guidelines.en.md
+++ b/content/notifications/shared/getting-started/guidelines/guidelines.en.md
@@ -6,5 +6,5 @@ hidden: true
 To ensure effective communication, it is essential to strictly define what qualifies as a notification 
 and avoid overwhelming users with too many messages. 
 
-Familiarize yourself with our [guidelines](https://docs.altinn.studio/en/notifications/guides/#guidelines-on-notification-content) to understand what notifications should and should not contain,
+Familiarize yourself with our [guidelines](/en/notifications/guides/#guidelines-on-notification-content) to understand what notifications should and should not contain,
 promoting digital safety and preventing notification fatigue.

--- a/content/notifications/shared/getting-started/guidelines/guidelines.en.md
+++ b/content/notifications/shared/getting-started/guidelines/guidelines.en.md
@@ -6,5 +6,5 @@ hidden: true
 To ensure effective communication, it is essential to strictly define what qualifies as a notification 
 and avoid overwhelming users with too many messages. 
 
-Familiarize yourself with our [guidelines](https://altinn.github.io/docs/utviklingsguider/varsling/) to understand what notifications should and should not contain,
+Familiarize yourself with our [guidelines](https://docs.altinn.studio/en/notifications/guides/#guidelines-on-notification-content) to understand what notifications should and should not contain,
 promoting digital safety and preventing notification fatigue.

--- a/content/notifications/shared/getting-started/guidelines/guidelines.nb.md
+++ b/content/notifications/shared/getting-started/guidelines/guidelines.nb.md
@@ -6,6 +6,6 @@ hidden: true
 For å sikre effektiv kommunikasjon er det viktig å strengt definere hva som kvalifiserer som et varsel
 og unngå å overvelde brukere med for mange meldinger.
 
-Gjør deg kjent med våre [retningslinjer](https://altinn.github.io/docs/utviklingsguider/varsling/) for å forstå hva varsler bør og ikke bør inneholde,
+Gjør deg kjent med våre [retningslinjer](https://docs.altinn.studio/nb/notifications/guides/#retningslinjer-for-varslingsinnhold) for å forstå hva varsler bør og ikke bør inneholde,
 for å fremme digital sikkerhet og forhindre varslingstretthet.
 

--- a/content/notifications/shared/getting-started/guidelines/guidelines.nb.md
+++ b/content/notifications/shared/getting-started/guidelines/guidelines.nb.md
@@ -6,6 +6,6 @@ hidden: true
 For å sikre effektiv kommunikasjon er det viktig å strengt definere hva som kvalifiserer som et varsel
 og unngå å overvelde brukere med for mange meldinger.
 
-Gjør deg kjent med våre [retningslinjer](https://docs.altinn.studio/nb/notifications/guides/#retningslinjer-for-varslingsinnhold) for å forstå hva varsler bør og ikke bør inneholde,
+Gjør deg kjent med våre [retningslinjer](/nb/notifications/guides/#retningslinjer-for-varslingsinnhold) for å forstå hva varsler bør og ikke bør inneholde,
 for å fremme digital sikkerhet og forhindre varslingstretthet.
 


### PR DESCRIPTION
The shared notification guidelines snippet (included on `/nb/notifications/getting-started/altinn-app/` and `/nb/notifications/getting-started/service-owner-system/`, plus their English counterparts) linked to the retired `altinn.github.io` docs. This updates the link to the current guidelines on docs.altinn.studio:

- `guidelines.nb.md`: → `https://docs.altinn.studio/nb/notifications/guides/#retningslinjer-for-varslingsinnhold`
- `guidelines.en.md`: → `https://docs.altinn.studio/en/notifications/guides/#guidelines-on-notification-content`

Both anchors verified against the headings in `content/notifications/guides/_index.{nb,en}.md`.

Closes digdir/digdir-ai-agents#60

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated notification guidelines links in English and Norwegian documentation to point to the current documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->