### PR TITLE
docs(v9): implicit waiting step for service tasks

### DIFF
--- a/content/altinn-studio/v9/develop-a-service/process/reference/task-types.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/process/reference/task-types.nb.md
@@ -135,7 +135,9 @@ Eksempel på betalingsoppgave:
 
 ## Systemoppgaver
 En systemoppgave er en prosessoppgave som kjører automatisk på serveren. Prosessen går som hovedregel videre til neste 
-steg når den har kjørt ferdig, men dette kan systemoppgaven definere selv. 
+steg når den har kjørt ferdig, men dette kan systemoppgaven definere selv. En systemoppgave kan også sette prosessen 
+på vent til et eksternt system svarer — se 
+[Ventesteg for systemoppgaver]({{<relref "/altinn-studio/v9/develop-a-service/process/service-task-waiting" >}}).
 
 Tjenesteeiere kan implementere sine egne systemoppgaver og legge de som steg i appens prosess.
 

--- a/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.en.md
+++ b/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.en.md
@@ -48,8 +48,9 @@ sitting on the task indefinitely.
 
 Return `ServiceTaskResult.Defer(delay, reason)` when there is nothing that can call you back and the task has
 to find out for itself. The process is put on hold, the worker is released, and the task runs again after
-`delay` — as many times as it needs to, until it returns a result that concludes it. No error is recorded
-along the way; a deferral is a wait, not a failed attempt.
+`delay` — as many times as it needs to. Two things end the deferring: a result that concludes the task, or the
+`WaitBudget` below running out, which the engine treats as a failed step. No error is recorded along the way;
+a deferral is a wait, not a failed attempt.
 
 ```C#
 public async Task<ServiceTaskResult> Execute(ServiceTaskContext context)

--- a/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.en.md
+++ b/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.en.md
@@ -11,7 +11,7 @@ A service task runs automatically on the server, and the process normally moves 
 task completes. Sometimes the result is not ready right away — for example when the app has sent a request to
 another system and is waiting for a response. The service task can then put the process on hold.
 
-The app automatically shows a waiting page to the user for as long as the process stays on the service task.
+The app automatically shows a built-in page to the user for as long as the process stays on the service task.
 You do not need to define a separate step in the process or create any pages — which is why we call it an
 *implicit* waiting step.
 
@@ -19,6 +19,11 @@ See [task types]({{<relref "/altinn-studio/v9/develop-a-service/process/referenc
 about service tasks in general.
 
 ## Putting the process on hold
+
+There are two ways for a service task to wait. Which one fits depends on how the outcome reaches you: whether
+the external system can call back, or whether the task has to go and look for itself.
+
+### Park the process until something releases it
 
 Return `ServiceTaskResult.SuccessWithoutAutoAdvance()` from the service task's `Execute` method. The task is
 considered successful, but the process does not advance by itself. It stays on the service task until someone
@@ -35,6 +40,51 @@ public async Task<ServiceTaskResult> Execute(ServiceTaskContext context)
 
 The state is stored on the server. The wait therefore survives page refreshes, and a user who returns later
 lands on the same waiting page until the process moves on.
+
+Nothing brings the process forward on its own here, so a callback that never arrives leaves the instance
+sitting on the task indefinitely.
+
+### Check again yourself until the outcome arrives
+
+Return `ServiceTaskResult.Defer(delay, reason)` when there is nothing that can call you back and the task has
+to find out for itself. The process is put on hold, the worker is released, and the task runs again after
+`delay` — as many times as it needs to, until it returns a result that concludes it. No error is recorded
+along the way; a deferral is a wait, not a failed attempt.
+
+```C#
+public async Task<ServiceTaskResult> Execute(ServiceTaskContext context)
+{
+    var status = await CheckExternalSystem(...);
+    if (status.IsFinished)
+    {
+        return ServiceTaskResult.Success();
+    }
+
+    return ServiceTaskResult.Defer(TimeSpan.FromMinutes(5), "Waiting for the external system to finish");
+}
+```
+
+Pick each `delay` to match how fast the outcome can realistically arrive — checking eagerly at first and
+backing off is usually the right shape, and it is the task's own choice every time it defers.
+
+A deferral saves nothing. The task is re-run from the start, so anything it must remember between checks —
+that a request has already been sent, above all — cannot be kept in the deferral. Give that work its own
+pipeline step that completes instead of deferring, so it is not repeated on every re-check.
+
+`context.Wait` tells the task how long it has been waiting and how many checks it has made. Use
+`context.Wait.IsFinalCheck` to recognise the last check before the allowance runs out, so the task can fail
+with its own explanation of what never arrived rather than a generic timeout.
+
+The wait is bounded, which is the other difference from a parked process: the total time a task may spend
+deferring is capped by `WaitBudget`, and the engine fails the step when it is spent. Set it from how long the
+outcome can legitimately take:
+
+```C#
+public ProcessStepOptions? StepOptions => new() { WaitBudget = TimeSpan.FromHours(2) };
+```
+
+The eFormidling service task is the built-in example: it sends the shipment, then defers until the
+integrasjonspunkt confirms delivery.
 
 ## What the user sees
 
@@ -55,6 +105,22 @@ to be slow:
 The app polls the process state while the user waits, starting at one-second intervals and gradually backing
 off to a maximum of 30 seconds. The moment the process advances, the user is automatically navigated to the
 next step.
+
+### While a deferring task waits
+
+The page above is what a *parked* process shows. A task that defers is still in the middle of a process
+transition, so the user sees the app's built-in processing page instead — the same one any slow transition
+shows. Its texts are separate resources you can override:
+
+| Key                                 | Default text (English)                                                                                                                                     |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `process_workflow.advancing_title`  | We're working on your form                                                                                                                                 |
+| `process_workflow.advancing_body`   | You don't need to do anything. We'll take you to the next step as soon as everything is ready.                                                              |
+| `process_workflow.still_working`    | This is taking longer than usual. Your information is saved, and we'll continue automatically — you can safely close this page and come back later.         |
+
+`process_workflow.still_working` appears after 30 seconds, which makes it the text that carries a long wait:
+it is worth adjusting if your task can legitimately keep the user waiting for hours. Here too the user is
+carried to the next step automatically once the process advances.
 
 ## Custom layout instead of the waiting page
 
@@ -87,6 +153,9 @@ The typical integration is that the external system calls this endpoint from its
 Maskinporten token for the service owner.
 
 ## Authorization
+
+This section is about a parked process. A deferring task does not depend on a `process/next` call at all — it
+concludes itself — so none of the below applies to it.
 
 {{% notice warning %}}
 A waiting service task is gated by authorization **only**. Nothing else stops a `process/next` call from

--- a/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.en.md
+++ b/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.en.md
@@ -1,0 +1,162 @@
+---
+draft: true
+title: Waiting step for service tasks
+linktitle: Waiting step
+description: A service task can put the process on hold until an external system responds. The app then shows a built-in waiting step to the user.
+tags: [altinn-apps, process, bpmn, service task]
+toc: true
+---
+
+A service task runs automatically on the server, and the process normally moves on to the next step when the
+task completes. Sometimes the result is not ready right away — for example when the app has sent a request to
+another system and is waiting for a response. The service task can then put the process on hold.
+
+The app automatically shows a waiting page to the user for as long as the process stays on the service task.
+You do not need to define a separate step in the process or create any pages — which is why we call it an
+*implicit* waiting step.
+
+See [task types]({{<relref "/altinn-studio/v9/develop-a-service/process/reference/task-types" >}}) for more
+about service tasks in general.
+
+## Putting the process on hold
+
+Return `ServiceTaskResult.SuccessWithoutAutoAdvance()` from the service task's `Execute` method. The task is
+considered successful, but the process does not advance by itself. It stays on the service task until someone
+moves it forward with an authorized call to `process/next`.
+
+```C#
+public async Task<ServiceTaskResult> Execute(ServiceTaskContext context)
+{
+    await SendRequestToExternalSystem(...);
+    // The external system will call back later and advance the process itself.
+    return ServiceTaskResult.SuccessWithoutAutoAdvance();
+}
+```
+
+The state is stored on the server. The wait therefore survives page refreshes, and a user who returns later
+lands on the same waiting page until the process moves on.
+
+## What the user sees
+
+The waiting page is a calm page with a spinner and no buttons:
+
+- Title: "We are processing your request"
+- Body: "This may take a little while. You do not need to do anything, we will continue automatically once
+  everything is ready."
+
+Both texts are text resources the app can override — for example to explain that an external system is known
+to be slow:
+
+| Key                          | Default text (English)                                                                                   |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `service_task.waiting_title` | We are processing your request                                                                           |
+| `service_task.waiting_body`  | This may take a little while. You do not need to do anything, we will continue automatically once everything is ready. |
+
+The app polls the process state while the user waits, starting at one-second intervals and gradually backing
+off to a maximum of 30 seconds. The moment the process advances, the user is automatically navigated to the
+next step.
+
+## Custom layout instead of the waiting page
+
+If the app has a layout folder for the service task (`App/ui/<taskId>/`), that layout is rendered instead of
+the built-in waiting page. This lets you build your own view for the wait, for example with more information
+about what is happening.
+
+The app still follows the process the same way: it polls the state and navigates the user onward
+automatically when the process advances.
+
+## Failures are always shown
+
+If the service task fails terminally, the app always renders the failure page — even when the task has a
+custom layout. A custom layout can never hide a failure.
+
+The failure page gives the user two options:
+
+- **Try again** re-runs the failed step via `POST .../process/resume`.
+- **Go back** performs the `reject` action, if the process model defines one for the task.
+
+## Releasing the process
+
+The process advances on any *authorized* call to
+
+```http
+PUT /{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/process/next
+```
+
+The typical integration is that the external system calls this endpoint from its callback handler, using a
+Maskinporten token for the service owner.
+
+## Authorization
+
+{{% notice warning %}}
+A waiting service task is gated by authorization **only**. Nothing else stops a `process/next` call from
+moving the process forward. If the wait must not be skippable by the end user, use a custom task type and
+grant access only to the service owner in the policy. Do not rely on the waiting page itself as a gate — it
+is only a user interface.
+{{% /notice %}}
+
+The action required for `process/next` is derived from the task type:
+
+| Task type                                                            | Required action                    |
+| -------------------------------------------------------------------- | ---------------------------------- |
+| `data`, `feedback`, `pdf`, `eFormidling`, `fiksArkiv`, `subformPdf`  | `write`                            |
+| `payment`                                                             | `pay` or `write`                   |
+| `signing`                                                             | `sign` or `write`                  |
+| `confirmation`                                                        | `confirm`                          |
+| Custom task type                                                      | Action with the same name as the task type |
+
+This mapping is enforced identically in the app and in the Altinn platform. It has two important
+consequences:
+
+1. **Known task types are a soft gate.** Any end user with `write` access can drive the process past a
+   waiting service task of type `data`, `feedback`, `pdf` and similar with a bare `process/next` call. The
+   user's own token is enough.
+2. **Custom task types are closed by default.** The default policy (`policy.xml` from the app template)
+   grants *no one* access to the action named after the task type — not even the service owner. The callback
+   from the external system therefore gets 403 until you add a policy rule for the action.
+
+A custom `IServiceTask` always uses a custom task type. Add a rule to `policy.xml` that grants the service
+owner (the `urn:altinn:org` subject) access to the action — not end users, unless you deliberately want them
+to be able to release the process themselves:
+
+```xml
+<xacml:Rule RuleId="urn:altinn:example:ruleid:[RULE_ID]" Effect="Permit">
+  <xacml:Description>The service owner can drive the process past the service task [TASK_TYPE].</xacml:Description>
+  <xacml:Target>
+    <xacml:AnyOf>
+      <xacml:AllOf>
+        <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+          <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[org]</xacml:AttributeValue>
+          <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+        </xacml:Match>
+      </xacml:AllOf>
+    </xacml:AnyOf>
+    <xacml:AnyOf>
+      <xacml:AllOf>
+        <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+          <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[ORG]</xacml:AttributeValue>
+          <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+        </xacml:Match>
+        <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+          <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[APP]</xacml:AttributeValue>
+          <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+        </xacml:Match>
+      </xacml:AllOf>
+    </xacml:AnyOf>
+    <xacml:AnyOf>
+      <xacml:AllOf>
+        <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+          <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[TASK_TYPE]</xacml:AttributeValue>
+          <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+        </xacml:Match>
+      </xacml:AllOf>
+    </xacml:AnyOf>
+  </xacml:Target>
+</xacml:Rule>
+```
+
+Replace `[org]`/`[ORG]`, `[APP]`, `[RULE_ID]` and `[TASK_TYPE]` with the values for your app. `[TASK_TYPE]`
+must equal the `Type` property on the `IServiceTask` implementation.
+
+See [Defining authorization policy]({{<relref "/altinn-studio/v9/develop-a-service/configuration/authorization" >}})
+for more about the policy file.

--- a/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.en.md
+++ b/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.en.md
@@ -15,8 +15,8 @@ The app automatically shows a built-in page to the user for as long as the proce
 You do not need to define a separate step in the process or create any pages — which is why we call it an
 *implicit* waiting step.
 
-See [task types]({{<relref "/altinn-studio/v9/develop-a-service/process/reference/task-types" >}}) for more
-about service tasks in general.
+See [task types](/nb/altinn-studio/v9/develop-a-service/process/reference/task-types/) for more
+about service tasks in general (documentation available in Norwegian only).
 
 ## Putting the process on hold
 
@@ -227,5 +227,5 @@ to be able to release the process themselves:
 Replace `[org]`/`[ORG]`, `[APP]`, `[RULE_ID]` and `[TASK_TYPE]` with the values for your app. `[TASK_TYPE]`
 must equal the `Type` property on the `IServiceTask` implementation.
 
-See [Defining authorization policy]({{<relref "/altinn-studio/v9/develop-a-service/configuration/authorization" >}})
-for more about the policy file.
+See [Defining authorization policy](/nb/altinn-studio/v9/develop-a-service/configuration/authorization/)
+for more about the policy file (documentation available in Norwegian only).

--- a/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.en.md
+++ b/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.en.md
@@ -138,8 +138,9 @@ custom layout. A custom layout can never hide a failure.
 
 The failure page gives the user two options:
 
-- **Try again** re-runs the failed step via `POST .../process/resume`.
-- **Go back** performs the `reject` action, if the process model defines one for the task.
+- **Try again** re-runs the failed step via `POST .../process/resume`. It requires `write` access.
+- **Go back** performs the `reject` action. The button is only shown when the user is authorized for
+  `reject`, which takes both the action on the task in the process model and a policy rule granting it.
 
 ## Releasing the process
 

--- a/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.nb.md
@@ -11,13 +11,18 @@ En systemoppgave kjører automatisk på serveren, og prosessen går normalt vide
 er ferdig. Noen ganger er ikke resultatet klart med en gang — for eksempel når appen har sendt en forespørsel
 til et annet system og venter på svar. Da kan systemoppgaven sette prosessen på vent.
 
-Appen viser automatisk en venteside til brukeren så lenge prosessen står på systemoppgaven. Du trenger ikke
+Appen viser automatisk en innebygd side til brukeren så lenge prosessen står på systemoppgaven. Du trenger ikke
 definere et eget steg i prosessen eller lage egne sider — derfor kaller vi det et *implisitt* ventesteg.
 
 Se [oppgavetyper]({{<relref "/altinn-studio/v9/develop-a-service/process/reference/task-types" >}}) for mer
 om systemoppgaver generelt.
 
 ## Sett prosessen på vent
+
+En systemoppgave kan vente på to måter. Hvilken som passer, kommer an på hvordan utfallet når deg: om det
+eksterne systemet kan kalle tilbake, eller om oppgaven selv må gå og se etter.
+
+### Parkere prosessen til noe slipper den videre
 
 Returner `ServiceTaskResult.SuccessWithoutAutoAdvance()` fra `Execute`-metoden i systemoppgaven. Oppgaven
 regnes som vellykket, men prosessen går ikke videre av seg selv. Den blir stående på systemoppgaven til noen
@@ -34,6 +39,51 @@ public async Task<ServiceTaskResult> Execute(ServiceTaskContext context)
 
 Tilstanden lagres på serveren. Ventingen overlever derfor at brukeren laster siden på nytt eller kommer
 tilbake senere — brukeren lander på den samme ventesiden helt til prosessen går videre.
+
+Ingenting driver prosessen videre av seg selv her. Kommer kallet aldri, blir instansen stående på oppgaven i
+det uendelige.
+
+### Sjekke selv til utfallet kommer
+
+Returner `ServiceTaskResult.Defer(delay, reason)` når ingenting kan kalle tilbake, og oppgaven selv må finne
+det ut. Prosessen settes på vent, arbeideren frigjøres, og oppgaven kjører igjen etter `delay` — så mange
+ganger som den trenger, til den returnerer et resultat som avslutter den. Ingen feil blir registrert
+underveis. En utsettelse er en venting, ikke et mislykket forsøk.
+
+```C#
+public async Task<ServiceTaskResult> Execute(ServiceTaskContext context)
+{
+    var status = await CheckExternalSystem(...);
+    if (status.IsFinished)
+    {
+        return ServiceTaskResult.Success();
+    }
+
+    return ServiceTaskResult.Defer(TimeSpan.FromMinutes(5), "Venter på at det eksterne systemet blir ferdig");
+}
+```
+
+Velg hver `delay` ut fra hvor raskt utfallet realistisk kan komme. Å sjekke ofte i starten og så øke
+intervallet er vanligvis riktig form, og oppgaven velger på nytt hver gang den utsetter.
+
+En utsettelse lagrer ingenting. Oppgaven kjøres på nytt fra starten, så det den må huske mellom sjekkene –
+først og fremst at en forespørsel alt er sendt – kan ikke ligge i utsettelsen. Gi det arbeidet sitt eget
+steg i systemoppgaven, et steg som fullfører i stedet for å utsette, slik at det ikke gjentas ved hver ny sjekk.
+
+`context.Wait` forteller oppgaven hvor lenge den har ventet, og hvor mange sjekker den har gjort. Bruk
+`context.Wait.IsFinalCheck` til å kjenne igjen den siste sjekken før tiden er ute, slik at oppgaven kan feile
+med sin egen forklaring på hva som aldri kom, i stedet for et generisk tidsavbrudd.
+
+Ventingen har en øvre grense, og det er den andre forskjellen fra en parkert prosess: `WaitBudget` setter tak
+på hvor lang tid en oppgave til sammen kan bruke på å utsette, og motoren feiler steget når tiden er brukt
+opp. Sett grensen ut fra hvor lang tid utfallet legitimt kan ta:
+
+```C#
+public ProcessStepOptions? StepOptions => new() { WaitBudget = TimeSpan.FromHours(2) };
+```
+
+eFormidling-systemoppgaven er det innebygde eksempelet: den sender meldingen, og utsetter deretter til
+integrasjonspunktet bekrefter at den er levert.
 
 ## Hva brukeren ser
 
@@ -53,6 +103,22 @@ erfaringsmessig bruker lang tid:
 Appen sjekker prosesstilstanden jevnlig mens brukeren venter. Den starter med å spørre hvert sekund, og øker
 gradvis intervallet opp til maksimalt 30 sekunder. I det øyeblikket prosessen går videre, sender appen
 brukeren automatisk til neste steg.
+
+### Mens en oppgave som utsetter, venter
+
+Siden over er den en *parkert* prosess viser. En oppgave som utsetter, står fortsatt midt i en
+prosessovergang, og brukeren ser derfor den innebygde behandlingssiden i appen i stedet — den samme som alle
+tregere overganger viser. Tekstene der er egne ressurser du kan overstyre:
+
+| Nøkkel                             | Standardtekst (bokmål)                                                                                                                                                       |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `process_workflow.advancing_title` | Vi jobber med skjemaet ditt                                                                                                                                                  |
+| `process_workflow.advancing_body`  | Du trenger ikke gjøre noe. Vi sender deg videre så snart alt er klart.                                                                                                        |
+| `process_workflow.still_working`   | Dette tar uvanlig lang tid. Opplysningene dine er lagret, og vi fortsetter automatisk – du kan trygt lukke siden og komme tilbake på et senere tidspunkt.                     |
+
+`process_workflow.still_working` kommer etter 30 sekunder, og er dermed teksten som bærer en lang venting. Den
+er verdt å tilpasse hvis oppgaven din kan holde brukeren ventende i timer. Også her blir brukeren sendt videre
+til neste steg automatisk når prosessen går videre.
 
 ## Egen layout i stedet for ventesiden
 
@@ -84,6 +150,10 @@ Den vanligste integrasjonen er at det eksterne systemet kaller dette endepunktet
 sin, med et Maskinporten-token for tjenesteeieren.
 
 ## Autorisasjon
+
+Denne delen handler om en parkert prosess. En oppgave som utsetter, er ikke avhengig av et
+`process/next`-kall i det hele tatt – den avslutter seg selv – så ingenting av det som står under, gjelder
+den.
 
 {{% notice warning %}}
 En systemoppgave som venter, er **bare** beskyttet av autorisasjon. Ingenting annet hindrer et

--- a/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.nb.md
@@ -135,8 +135,9 @@ En egen layout kan aldri skjule en feil.
 
 Feilsiden gir brukeren to muligheter:
 
-- **Prøv igjen** kjører det feilede steget på nytt via `POST .../process/resume`.
-- **Gå tilbake** utfører `reject`-handlingen, hvis prosessmodellen har definert den for oppgaven.
+- **Prøv igjen** kjører det feilede steget på nytt via `POST .../process/resume`. Det krever `write`-tilgang.
+- **Gå tilbake** utfører `reject`-handlingen. Knappen vises bare når brukeren har tilgang til `reject`,
+  og det krever både at handlingen er definert på oppgaven i prosessmodellen og en regel i policyen.
 
 ## Slipp prosessen videre
 

--- a/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.nb.md
@@ -47,7 +47,8 @@ det uendelige.
 
 Returner `ServiceTaskResult.Defer(delay, reason)` når ingenting kan kalle tilbake, og oppgaven selv må finne
 det ut. Prosessen settes på vent, arbeideren frigjøres, og oppgaven kjører igjen etter `delay` — så mange
-ganger som den trenger, til den returnerer et resultat som avslutter den. Ingen feil blir registrert
+ganger som den trenger. To ting stopper utsettingen: et resultat som avslutter oppgaven, eller at
+`WaitBudget` nedenfor blir brukt opp – da regner motoren steget som feilet. Ingen feil blir registrert
 underveis. En utsettelse er en venting, ikke et mislykket forsøk.
 
 ```C#
@@ -106,7 +107,7 @@ brukeren automatisk til neste steg.
 
 ### Mens en oppgave som utsetter, venter
 
-Siden over er den en *parkert* prosess viser. En oppgave som utsetter, står fortsatt midt i en
+Siden over vises når prosessen er *parkert*. En oppgave som utsetter, står fortsatt midt i en
 prosessovergang, og brukeren ser derfor den innebygde behandlingssiden i appen i stedet — den samme som alle
 tregere overganger viser. Tekstene der er egne ressurser du kan overstyre:
 

--- a/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/process/service-task-waiting/_index.nb.md
@@ -1,0 +1,158 @@
+---
+draft: true
+title: Ventesteg for systemoppgaver
+linktitle: Ventesteg
+description: En systemoppgave kan sette prosessen på vent til et eksternt system svarer. Appen viser da et innebygd ventesteg til brukeren.
+tags: [altinn-apps, process, bpmn, service task, systemoppgave]
+toc: true
+---
+
+En systemoppgave kjører automatisk på serveren, og prosessen går normalt videre til neste steg når oppgaven
+er ferdig. Noen ganger er ikke resultatet klart med en gang — for eksempel når appen har sendt en forespørsel
+til et annet system og venter på svar. Da kan systemoppgaven sette prosessen på vent.
+
+Appen viser automatisk en venteside til brukeren så lenge prosessen står på systemoppgaven. Du trenger ikke
+definere et eget steg i prosessen eller lage egne sider — derfor kaller vi det et *implisitt* ventesteg.
+
+Se [oppgavetyper]({{<relref "/altinn-studio/v9/develop-a-service/process/reference/task-types" >}}) for mer
+om systemoppgaver generelt.
+
+## Sett prosessen på vent
+
+Returner `ServiceTaskResult.SuccessWithoutAutoAdvance()` fra `Execute`-metoden i systemoppgaven. Oppgaven
+regnes som vellykket, men prosessen går ikke videre av seg selv. Den blir stående på systemoppgaven til noen
+driver den videre med et autorisert kall til `process/next`.
+
+```C#
+public async Task<ServiceTaskResult> Execute(ServiceTaskContext context)
+{
+    await SendRequestToExternalSystem(...);
+    // Det eksterne systemet kaller tilbake senere og driver prosessen videre selv.
+    return ServiceTaskResult.SuccessWithoutAutoAdvance();
+}
+```
+
+Tilstanden lagres på serveren. Ventingen overlever derfor at brukeren laster siden på nytt eller kommer
+tilbake senere — brukeren lander på den samme ventesiden helt til prosessen går videre.
+
+## Hva brukeren ser
+
+Ventesiden er en rolig side med en spinner, uten knapper:
+
+- Tittel: «Vi behandler forespørselen din»
+- Brødtekst: «Dette kan ta litt tid. Du trenger ikke å gjøre noe, vi går automatisk videre når alt er klart.»
+
+Begge tekstene er tekstressurser som appen kan overstyre — for eksempel for å forklare at et eksternt system
+erfaringsmessig bruker lang tid:
+
+| Nøkkel                       | Standardtekst (bokmål)                                                                         |
+| ---------------------------- | ---------------------------------------------------------------------------------------------- |
+| `service_task.waiting_title` | Vi behandler forespørselen din                                                                 |
+| `service_task.waiting_body`  | Dette kan ta litt tid. Du trenger ikke å gjøre noe, vi går automatisk videre når alt er klart. |
+
+Appen sjekker prosesstilstanden jevnlig mens brukeren venter. Den starter med å spørre hvert sekund, og øker
+gradvis intervallet opp til maksimalt 30 sekunder. I det øyeblikket prosessen går videre, sender appen
+brukeren automatisk til neste steg.
+
+## Egen layout i stedet for ventesiden
+
+Hvis appen har en layout-mappe for systemoppgaven (`App/ui/<taskId>/`), vises den i stedet for den innebygde
+ventesiden. Slik kan du lage en egen visning for ventingen, for eksempel med mer informasjon om hva som skjer.
+
+Appen følger fortsatt med på prosessen på samme måte: Den sjekker tilstanden jevnlig og sender brukeren
+videre automatisk når prosessen går videre.
+
+## Feil vises alltid
+
+Hvis systemoppgaven feiler permanent, viser appen alltid feilsiden — også når oppgaven har en egen layout.
+En egen layout kan aldri skjule en feil.
+
+Feilsiden gir brukeren to muligheter:
+
+- **Prøv igjen** kjører det feilede steget på nytt via `POST .../process/resume`.
+- **Gå tilbake** utfører `reject`-handlingen, hvis prosessmodellen har definert den for oppgaven.
+
+## Slipp prosessen videre
+
+Prosessen går videre ved et hvilket som helst *autorisert* kall til
+
+```http
+PUT /{org}/{app}/instances/{instanceOwnerPartyId}/{instanceGuid}/process/next
+```
+
+Den vanligste integrasjonen er at det eksterne systemet kaller dette endepunktet fra callback-håndteringen
+sin, med et Maskinporten-token for tjenesteeieren.
+
+## Autorisasjon
+
+{{% notice warning %}}
+En systemoppgave som venter, er **bare** beskyttet av autorisasjon. Ingenting annet hindrer et
+`process/next`-kall i å drive prosessen videre. Hvis ventingen ikke skal kunne hoppes over av sluttbrukeren,
+må du bruke en egendefinert oppgavetype og gi tilgang kun til tjenesteeieren i policyen. Ikke stol på selve
+ventesiden som sperre — den er bare et brukergrensesnitt.
+{{% /notice %}}
+
+Handlingen (action) som kreves for `process/next`, utledes fra oppgavetypen:
+
+| Oppgavetype                                              | Handling som kreves            |
+| -------------------------------------------------------- | ------------------------------ |
+| `data`, `feedback`, `pdf`, `eFormidling`, `fiksArkiv`, `subformPdf` | `write`             |
+| `payment`                                                 | `pay` eller `write`           |
+| `signing`                                                 | `sign` eller `write`          |
+| `confirmation`                                            | `confirm`                     |
+| Egendefinert oppgavetype                                  | Handling med samme navn som oppgavetypen |
+
+Appen og Altinn-plattformen håndhever denne koblingen likt. Den har to viktige konsekvenser:
+
+1. **Kjente oppgavetyper er en myk sperre.** Alle sluttbrukere med `write`-tilgang kan selv drive prosessen
+   forbi en ventende systemoppgave av typen `data`, `feedback`, `pdf` og lignende, med et enkelt
+   `process/next`-kall. Brukerens eget token er nok.
+2. **Egendefinerte oppgavetyper er stengt som standard.** Standardpolicyen (`policy.xml` fra appmalen) gir
+   *ingen* tilgang til handlingen med oppgavetypens navn — heller ikke til tjenesteeieren. Callback-kallet
+   fra det eksterne systemet får derfor 403 helt til du legger til en policyregel for handlingen.
+
+En egendefinert `IServiceTask` bruker alltid en egendefinert oppgavetype. Legg til en regel i `policy.xml`
+som gir tjenesteeieren (subjektet `urn:altinn:org`) tilgang til handlingen — ikke sluttbrukerne, med mindre
+du bevisst vil at de skal kunne slippe prosessen videre selv:
+
+```xml
+<xacml:Rule RuleId="urn:altinn:example:ruleid:[RULE_ID]" Effect="Permit">
+  <xacml:Description>Tjenesteeier kan drive prosessen forbi systemoppgaven [TASK_TYPE].</xacml:Description>
+  <xacml:Target>
+    <xacml:AnyOf>
+      <xacml:AllOf>
+        <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+          <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[org]</xacml:AttributeValue>
+          <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+        </xacml:Match>
+      </xacml:AllOf>
+    </xacml:AnyOf>
+    <xacml:AnyOf>
+      <xacml:AllOf>
+        <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+          <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[ORG]</xacml:AttributeValue>
+          <xacml:AttributeDesignator AttributeId="urn:altinn:org" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+        </xacml:Match>
+        <xacml:Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
+          <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[APP]</xacml:AttributeValue>
+          <xacml:AttributeDesignator AttributeId="urn:altinn:app" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:resource" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+        </xacml:Match>
+      </xacml:AllOf>
+    </xacml:AnyOf>
+    <xacml:AnyOf>
+      <xacml:AllOf>
+        <xacml:Match MatchId="urn:oasis:names:tc:xacml:3.0:function:string-equal-ignore-case">
+          <xacml:AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">[TASK_TYPE]</xacml:AttributeValue>
+          <xacml:AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:action:action-id" Category="urn:oasis:names:tc:xacml:3.0:attribute-category:action" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="false" />
+        </xacml:Match>
+      </xacml:AllOf>
+    </xacml:AnyOf>
+  </xacml:Target>
+</xacml:Rule>
+```
+
+Bytt ut `[org]`/`[ORG]`, `[APP]`, `[RULE_ID]` og `[TASK_TYPE]` med verdiene for appen din. `[TASK_TYPE]` må
+være lik `Type`-propertyen på `IServiceTask`-implementasjonen.
+
+Se [Definere autorisasjonspolicy]({{<relref "/altinn-studio/v9/develop-a-service/configuration/authorization" >}})
+for mer om policyfilen.

--- a/content/altinn-studio/v9/receive-data/eFormidling/_index.en.md
+++ b/content/altinn-studio/v9/receive-data/eFormidling/_index.en.md
@@ -376,6 +376,8 @@ The task fails if the shipment is rejected, or if the integrasjonspunkt reports 
 
 While the app waits, the end user sees the built-in processing page, which tells them that the app is working and that they do not need to do anything. After 30 seconds it adds that this is taking longer than usual and that the page can safely be closed and revisited later. The texts are text resources (`process_workflow.advancing_title`, `process_workflow.advancing_body` and `process_workflow.still_working`) that your app can override. The user is taken on to the next step automatically once the process advances.
 
+Waiting like this is not specific to eFormidling — it is the general mechanism any service task can use to put the process on hold, and eFormidling is the built-in example of it. See [Waiting step for service tasks]({{<relref "/altinn-studio/v9/develop-a-service/process/service-task-waiting" >}}) if you are writing your own.
+
 {{% notice warning %}}
 **Do not add a feedback task after the eFormidling task.** In v8 a feedback task was needed to hold the instance while delivery was pending, and a reminder built on Altinn Events moved the process past it once the shipment arrived. That reminder is gone in v9, because the service task now does the waiting itself. Nothing moves a feedback task behind the eFormidling task forward, so instances left there wait indefinitely. If you are upgrading an app from v8, remove it — `studioctl app upgrade v9` reports feedback tasks that sit behind a service task.
 {{% /notice %}}

--- a/content/altinn-studio/v9/receive-data/eFormidling/_index.nb.md
+++ b/content/altinn-studio/v9/receive-data/eFormidling/_index.nb.md
@@ -376,6 +376,8 @@ Oppgaven feiler hvis meldingen blir avvist, eller hvis integrasjonspunktet melde
 
 Mens appen venter, ser sluttbrukeren den innebygde behandlingssiden. Den forteller at appen jobber, og at brukeren ikke trenger å gjøre noe. Etter 30 sekunder legger den til at dette tar uvanlig lang tid, og at siden trygt kan lukkes og åpnes igjen senere. Tekstene er tekstressurser (`process_workflow.advancing_title`, `process_workflow.advancing_body` og `process_workflow.still_working`) som appen din kan overstyre. Brukeren blir sendt videre til neste steg automatisk når prosessen går videre.
 
+Å vente på denne måten er ikke spesielt for eFormidling – det er den generelle mekanismen enhver systemoppgave kan bruke for å sette prosessen på vent, og eFormidling er det innebygde eksempelet på den. Se [Ventesteg for systemoppgaver]({{<relref "/altinn-studio/v9/develop-a-service/process/service-task-waiting" >}}) hvis du skriver din egen.
+
 {{% notice warning %}}
 **Ikke legg en tilbakemeldingsoppgave etter eFormidling-oppgaven.** I v8 trengte du en tilbakemeldingsoppgave for å holde instansen mens leveringen sto på vent, og en påminnelse bygget på Altinn Events flyttet prosessen videre når meldingen kom fram. Denne påminnelsen er borte i v9, fordi systemoppgaven nå venter selv. Ingenting flytter en tilbakemeldingsoppgave som ligger etter eFormidling-oppgaven, videre, og instanser som blir stående der, venter i det uendelige. Oppgraderer du en app fra v8, må du fjerne den – `studioctl app upgrade v9` melder om tilbakemeldingsoppgaver som ligger etter en systemoppgave.
 {{% /notice %}}


### PR DESCRIPTION
## What this documents

Adds a new v9 page, **Ventesteg for systemoppgaver / Waiting step for service tasks** (Norwegian bokmål + English), under `develop-a-service/process/`:

- How a service task parks the process by returning `ServiceTaskResult.SuccessWithoutAutoAdvance()` from `Execute`
- The built-in waiting page the app frontend renders (spinner, no buttons), including the two overridable text resources `service_task.waiting_title` and `service_task.waiting_body`
- Polling behavior (1 s backing off to max 30 s), server-side truth (survives refresh), and automatic navigation when the process advances
- Custom layout opt-out via `App/ui/<taskId>/` (auto-follow still applies)
- Failure-beats-layout: the recoverable failure view always renders, with retry via `POST .../process/resume` and `reject` via "Go back"
- How to release a parked task: any authorized `PUT .../process/next`, typically an external system's callback with a Maskinporten service-owner token

Also adds a cross-link from the v9 task-types reference (`process/reference/task-types.nb.md`).

## Authorization caveat (called out prominently on the page)

A parked service task is gated **only by authorization** — nothing else stops a `process/next`. The required action is derived from the task type:

- Known task types (`data`, `feedback`, `pdf`, `eFormidling`, `fiksArkiv`, `subformPdf`) map to `write`, so **any end user with write access can drive the process past the wait themselves** — the waiting page is a soft gate.
- Custom task types (what an app-defined `IServiceTask` uses) require an action named after the task type, which the template `policy.xml` grants to **no one** — the external callback gets 403 until the app adds a policy rule. The page recommends scoping that rule to the service owner (`urn:altinn:org` subject) and includes a full XACML rule sketch.

## Do not publish yet

This documents behavior introduced by Altinn/altinn-studio#19636 (closes Altinn/altinn-studio#18935), building on Altinn/altinn-studio#19618 and Altinn/altinn-studio#19506. **It should not be published before that ships.** Both new pages are marked `draft: true`, consistent with the rest of the v9 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added English and Norwegian guidance for service-task waiting behaviour.
  - Explained parked and deferred execution, polling, wait limits, error handling, and process progression.
  - Documented waiting pages, custom layouts, callback endpoints, service-task examples, and authorisation requirements.
  - Clarified that eFormidling uses the general waiting mechanism and linked to implementation guidance.
  - Updated task-type guidance to note that processes may pause while awaiting external systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->