### PR TITLE
Add missing default parameter for status feed order by

### DIFF
--- a/static/swagger/altinn-notifications-v1.json
+++ b/static/swagger/altinn-notifications-v1.json
@@ -461,7 +461,7 @@
     "/future/log": {
       "get": {
         "tags": [
-          "Notification Log"
+          "NotificationLog"
         ],
         "summary": "Retrieves notification log entries filtered by dialog identifier, transmission identifier, or both.",
         "parameters": [
@@ -944,7 +944,8 @@
                 "Asc",
                 "Desc"
               ],
-              "type": "string"
+              "type": "string",
+              "default": "Asc"
             }
           }
         ],
@@ -2931,10 +2932,6 @@
     {
       "name": "Instant Orders",
       "description": "Create and immediately send a notification to a single recipient"
-    },
-    {
-      "name": "Notification Log",
-      "description": "Retrieves notification log entries filtered by dialog identifier, transmission identifier, or both"
     }
   ]
 }


### PR DESCRIPTION
Swagger doc for Notifications api is missing default parameter for status feed GET endpoint where order by parameter defaults to ASC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API documentation for notification log operations.
  * Set the status-feed `OrderBy` parameter’s default value to ascending order.
  * Standardised notification log tagging in the API specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->