### PR TITLE
Notifications missing default param

### DIFF
--- a/static/swagger/altinn-notifications-v1.json
+++ b/static/swagger/altinn-notifications-v1.json
@@ -461,7 +461,7 @@
     "/future/log": {
       "get": {
         "tags": [
-          "NotificationLog"
+          "Notification Log"
         ],
         "summary": "Retrieves notification log entries filtered by dialog identifier, transmission identifier, or both.",
         "parameters": [
@@ -2932,6 +2932,10 @@
     {
       "name": "Instant Orders",
       "description": "Create and immediately send a notification to a single recipient"
+    },
+    {
+      "name": "Notification Log",
+      "description": "Retrieves notification log entries filtered by dialog identifier, transmission identifier, or both"
     }
   ]
 }

--- a/static/swagger/altinn-notifications-v1.json
+++ b/static/swagger/altinn-notifications-v1.json
@@ -461,7 +461,7 @@
     "/future/log": {
       "get": {
         "tags": [
-          "Notification Log"
+          "NotificationLog"
         ],
         "summary": "Retrieves notification log entries filtered by dialog identifier, transmission identifier, or both.",
         "parameters": [
@@ -944,7 +944,8 @@
                 "Asc",
                 "Desc"
               ],
-              "type": "string"
+              "type": "string",
+              "default": "Asc"
             }
           }
         ],
@@ -2931,10 +2932,6 @@
     {
       "name": "Instant Orders",
       "description": "Create and immediately send a notification to a single recipient"
-    },
-    {
-      "name": "Notification Log",
-      "description": "Retrieves notification log entries filtered by dialog identifier, transmission identifier, or both"
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API documentation to use the clearer “Notification Log” endpoint category name.
  * Added the corresponding category definition to the OpenAPI specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->