### PR TITLE
docs: document attachments in instance copies

### DIFF
--- a/content/altinn-studio/v8/reference/configuration/messagebox/create_copy/_index.en.md
+++ b/content/altinn-studio/v8/reference/configuration/messagebox/create_copy/_index.en.md
@@ -34,7 +34,7 @@ It is possible to provide a list of data types you do not want to be copied to t
 
 ### Copying attachments
 
-{{%notice warning%}}Copying attachments requires app-lib version 8.7.0 or newer.{{% /notice%}}
+{{%notice warning%}}Copying attachments requires `Altinn.App.Api` version 8.7.0 or newer.{{% /notice%}}
 
 Attachments are copied only when `includeAttachments` is set to `true`. If the setting is `false` or omitted, attachments are not copied. Attachments with a data type listed in `excludedDataTypes` are not copied either.
 
@@ -91,7 +91,7 @@ During the copying of an instance the logic will perform a method call to **IIns
 
 ## Validation
 
-{{%notice warning%}}Validation requires version 8.12.2 or newer of app-lib{{% /notice%}}
+{{%notice warning%}}Validation requires version 8.12.2 or newer of the `Altinn.App` libraries.{{% /notice%}}
 
 Validation is useful if the service owner wishes to restrict when end users can copy instances, for example based on deadlines or changes to the application.
 

--- a/content/altinn-studio/v8/reference/configuration/messagebox/create_copy/_index.en.md
+++ b/content/altinn-studio/v8/reference/configuration/messagebox/create_copy/_index.en.md
@@ -19,17 +19,24 @@ The Create new copy functionality was introduced in version 7.9.0 of the nuget p
 The configuration has a retroactive effect and will also apply to previously created instances.
 {{% /notice %}}
 
-In addition to turning the functionality on and off, it is possible to exclude data types and data fields in a schema from being copied.
+In addition to turning the functionality on and off, it is possible to choose whether attachments are copied and to exclude data types and data fields from the copy.
 
-| Name               | Description                                                                      |
-| ------------------ | -------------------------------------------------------------------------------- |
-| enabled            | true/false if its possible to create a copy of an instance.                      |
-| excludedDataTypes  | List of DataTypes that should be excluded when a new copy is made.               |
-| excludedDataFields | List of fields in the DataModel that should be excluded when a new copy is made. |
+| Name               | Description                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------- |
+| enabled            | true/false if it is possible to create a copy of an instance. Defaults to false.                  |
+| excludedDataTypes  | List of data types that should be excluded. Applies to both form data and attachments.            |
+| excludedDataFields | List of fields in the data model that should be excluded.                                         |
+| includeAttachments | true/false indicating whether attachments should be copied. Defaults to false.                    |
 
 ### Exclusion of data types
 
-It is possible to provide a list of data types you don't want to be copied over to the new instance, but which data types that can be copied are already fairly limited. The list of excluded data types have therefor limited effect. The copy feature will only copy data elements related to a schema/form. This means that no attachments will be copied. I addition to this the data types being copied needs to be associated with the first step in the process for the app.
+It is possible to provide a list of data types you do not want to be copied to the new instance. The exclusion applies to both form data and attachments. All data types to be copied must be associated with the first step in the app process.
+
+### Copying attachments
+
+{{%notice warning%}}Copying attachments requires app-lib version 8.7.0 or newer.{{% /notice%}}
+
+Attachments are copied only when `includeAttachments` is set to `true`. If the setting is `false` or omitted, attachments are not copied. Attachments with a data type listed in `excludedDataTypes` are not copied either.
 
 ### Exclusion of data fields
 
@@ -64,6 +71,20 @@ applicationmetadata.json
     ]
 }
 ```
+
+Configuration where the Create new copy feature is activated and attachments are copied to the new instance.
+
+{{< code-title >}}
+applicationmetadata.json
+{{< /code-title >}}
+
+```json
+"copyInstanceSettings": {
+    "enabled": true,
+    "includeAttachments": true
+}
+```
+
 ## Programing interface
 
 During the copying of an instance the logic will perform a method call to **IInstantiationProcessor.DataCreation**. This makes it possible to perform programmatic changes to the data as it is being copied. [Programmatic prefill](/en/altinn-studio/v8/guides/development/prefill/custom/).

--- a/content/altinn-studio/v8/reference/configuration/messagebox/create_copy/_index.nb.md
+++ b/content/altinn-studio/v8/reference/configuration/messagebox/create_copy/_index.nb.md
@@ -34,7 +34,7 @@ Det er mulig å angi en liste over datatyper man ikke ønsker at skal kopieres o
 
 ### Kopiering av vedlegg
 
-{{%notice warning%}}Kopiering av vedlegg krever versjon 8.7.0 eller nyere av app-lib.{{% /notice%}}
+{{%notice warning%}}Kopiering av vedlegg krever versjon 8.7.0 eller nyere av `Altinn.App.Api`.{{% /notice%}}
 
 Vedlegg kopieres bare når `includeAttachments` er satt til `true`. Hvis innstillingen er `false` eller utelatt, blir vedlegg ikke kopiert. Vedlegg med en datatype som er oppført i `excludedDataTypes`, blir heller ikke kopiert.
 
@@ -92,7 +92,7 @@ Under kopiering av skjema vil logikken utføre metode kall mot **IInstantiationP
 
 ## Validering
 
-{{%notice warning%}}Validering krever versjon 8.12.2 eller nyere av app-lib{{% /notice%}}
+{{%notice warning%}}Validering krever versjon 8.12.2 eller nyere av `Altinn.App`-bibliotekene.{{% /notice%}}
 
 Validering er nyttig hvis tjenesteeier ønsker å begrense når brukere kan kopiere instanser, for eksempel basert på tidsfrister eller endringer i applikasjonen.
 

--- a/content/altinn-studio/v8/reference/configuration/messagebox/create_copy/_index.nb.md
+++ b/content/altinn-studio/v8/reference/configuration/messagebox/create_copy/_index.nb.md
@@ -19,17 +19,24 @@ Lag ny kopi funksjonaliteten ble introdusert i versjon 7.9.0 av nuget pakkene.
 Konfigurasjonen har tilbakevirkende kraft på tidligere arkiverte instanser.
 {{% /notice %}}
 
-I tillegg til at funksjonaliteten kan skrues av og på er det mulig å ekskludere data typer og data felter i et skjema fra å bli kopiert.
+I tillegg til at funksjonaliteten kan skrues av og på, er det mulig å velge om vedlegg skal kopieres og å ekskludere datatyper og datafelter fra kopien.
 
-| Navn               | Beskrivelse                                                                                          |
-| ------------------ | ---------------------------------------------------------------------------------------------------- |
-| enabled            | true/false for å indikere om funksjonaliteten er skrudd på eller ikke. Standard verdi er av(false).  |
-| excludedDataTypes  | Liste med navn på data typer som ikke skal kopieres over.                                            |
-| excludedDataFields | Liste med navn på felter som ikke skal opieres over.                                                 |
+| Navn               | Beskrivelse                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------------- |
+| enabled            | true/false for å indikere om funksjonaliteten er skrudd på eller ikke. Standardverdi er av (false).       |
+| excludedDataTypes  | Liste med navn på datatyper som ikke skal kopieres over. Gjelder både skjemadata og vedlegg.              |
+| excludedDataFields | Liste med navn på felter som ikke skal kopieres over.                                                    |
+| includeAttachments | true/false for å indikere om vedlegg skal kopieres over. Standardverdi er av (false).                     |
 
 ### Ekskludering av data typer
 
-Det er mulig å angi en liste over data typer man ikke ønsker at skal kopieres over i ny instans, men hva man kan kopiere av data typer er allerede meget begrenset. Listen med ekskluderte data typer har derfor begrenset funksjon i dagens løsning. Kopierings funksjonaliteten vil bare kopiere data elementer relatert til et skjema. Dette betyr at det ikke blir laget kopier av vedlegg. I tillegg må data typene være knyttet til første steg i prosessen til appen. 
+Det er mulig å angi en liste over datatyper man ikke ønsker at skal kopieres over i den nye instansen. Ekskluderingen gjelder både skjemadata og vedlegg. Alle datatyper som skal kopieres, må være knyttet til første steg i prosessen til appen.
+
+### Kopiering av vedlegg
+
+{{%notice warning%}}Kopiering av vedlegg krever versjon 8.7.0 eller nyere av app-lib.{{% /notice%}}
+
+Vedlegg kopieres bare når `includeAttachments` er satt til `true`. Hvis innstillingen er `false` eller utelatt, blir vedlegg ikke kopiert. Vedlegg med en datatype som er oppført i `excludedDataTypes`, blir heller ikke kopiert.
 
 ### Ekskludering av felter
 
@@ -63,6 +70,19 @@ applicationmetadata.json
         "group1.felt2",
         "group23.felt21"
     ]
+}
+```
+
+Konfigurasjon hvor **Lag ny kopi** blir aktivert og vedlegg blir kopiert til den nye instansen.
+
+{{< code-title >}}
+applicationmetadata.json
+{{< /code-title >}}
+
+```json
+"copyInstanceSettings": {
+    "enabled": true,
+    "includeAttachments": true
 }
 ```
 

--- a/content/altinn-studio/v9/develop-a-service/reference/configuration/messagebox/create-copy/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/configuration/messagebox/create-copy/_index.nb.md
@@ -22,17 +22,22 @@ Lag ny kopi-funksjonaliteten ble introdusert i versjon 7.9.0 av nuget-pakkene.
 Konfigurasjonen har tilbakevirkende kraft på tidligere arkiverte instanser.
 {{% /notice%}}
 
-I tillegg til å slå funksjonaliteten av og på, er det mulig å ekskludere datatyper og datafelter i et skjema fra å bli kopiert.
+I tillegg til å slå funksjonaliteten av og på, er det mulig å velge om vedlegg skal kopieres og å ekskludere datatyper og datafelter fra kopien.
 
-| Navn               | Beskrivelse                                                                                          |
-| ------------------ | ---------------------------------------------------------------------------------------------------- |
-| enabled            | true/false for å indikere om funksjonaliteten er slått på eller ikke. Standardverdi er av (false).  |
-| excludedDataTypes  | Liste med navn på datatyper som ikke skal kopieres over.                                            |
-| excludedDataFields | Liste med navn på felter som ikke skal kopieres over.                                                 |
+| Navn               | Beskrivelse                                                                                              |
+| ------------------ | -------------------------------------------------------------------------------------------------------- |
+| enabled            | true/false for å indikere om funksjonaliteten er slått på eller ikke. Standardverdi er av (false).        |
+| excludedDataTypes  | Liste med navn på datatyper som ikke skal kopieres over. Gjelder både skjemadata og vedlegg.              |
+| excludedDataFields | Liste med navn på felter som ikke skal kopieres over.                                                    |
+| includeAttachments | true/false for å indikere om vedlegg skal kopieres over. Standardverdi er av (false).                     |
 
 ### Ekskludere datatyper
 
-Det er mulig å angi en liste over datatyper du ikke ønsker at skal kopieres over i ny instans, men hva du kan kopiere av datatyper er allerede svært begrenset. Listen med ekskluderte datatyper har derfor begrenset funksjon i dagens løsning. Kopieringsfunksjonaliteten vil bare kopiere dataelementer relatert til et skjema. Dette betyr at det ikke blir laget kopier av vedlegg. I tillegg må datatypene være knyttet til første steg i prosessen til appen.
+Det er mulig å angi en liste over datatyper du ikke ønsker at skal kopieres over i den nye instansen. Ekskluderingen gjelder både skjemadata og vedlegg. Alle datatyper som skal kopieres, må være knyttet til første steg i prosessen til appen.
+
+### Kopiere vedlegg
+
+Vedlegg kopieres bare når `includeAttachments` er satt til `true`. Hvis innstillingen er `false` eller utelatt, blir vedlegg ikke kopiert. Vedlegg med en datatype som er oppført i `excludedDataTypes`, blir heller ikke kopiert.
 
 ### Ekskludere felter
 
@@ -49,6 +54,19 @@ applicationmetadata.json
 ```json
 "copyInstanceSettings": {
     "enabled": true
+}
+```
+
+Konfigurasjon hvor **Lag ny kopi** blir aktivert og vedlegg blir kopiert til den nye instansen.
+
+{{< code-title >}}
+applicationmetadata.json
+{{< /code-title >}}
+
+```json
+"copyInstanceSettings": {
+    "enabled": true,
+    "includeAttachments": true
 }
 ```
 

--- a/content/api/models/app-metadata/_index.en.md
+++ b/content/api/models/app-metadata/_index.en.md
@@ -144,13 +144,14 @@ Only one of the two settings should be used at a time.
 
 ## CopyInstanceSettings
 
-Configure if copying data from an archived instance is allowed and what data types and data fields that should be excluded in the new instance.
+Configure if copying data from an archived instance is allowed, whether attachments should be copied, and what data types and data fields should be excluded in the new instance.
 
-| Name               | Description                                                                      |
-| ------------------ | -------------------------------------------------------------------------------- |
-| enabled            | true/false if its possible to create a copy of an instance.                      |
-| excludedDataTypes  | List of DataTypes that should be excluded when a new copy is made.               |
-| excludedDataFields | List of fields in the DataModel that should be excluded when a new copy is made.  |
+| Name               | Description                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------- |
+| enabled            | true/false if it is possible to create a copy of an instance.                                    |
+| excludedDataTypes  | List of data types that should be excluded when a new copy is made.                              |
+| excludedDataFields | List of fields in the data model that should be excluded when a new copy is made.                |
+| includeAttachments | true/false indicating whether attachments should be copied. Defaults to false.                   |
 
 The portal message box will show a link called [Create new copy](/en/altinn-studio/v8/reference/configuration/messagebox/create_copy/) when the user selects an archived instance.
 

--- a/content/api/models/app-metadata/_index.nb.md
+++ b/content/api/models/app-metadata/_index.nb.md
@@ -127,13 +127,14 @@ Only one of the two settings should be used at a time.
 
 ## CopyInstanceSettings
 
-Configure if copying data from an archived instance is allowed and what datatypes and datafields that should be excluded in the new instance
+Configure if copying data from an archived instance is allowed, whether attachments should be copied, and what data types and data fields should be excluded in the new instance.
 
-| Name               | Description                                                                      |
-| ------------------ | -------------------------------------------------------------------------------- |
-| enabled            | true/false if its possible to create a copy of an instance.                      |
-| excludedDataTypes  | List of DataTypes that should be excluded when a new copy is made.               |
-| excludedDataFields | List of fields in the DataModel that should be excluded when a new copy is made. |
+| Name               | Description                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------- |
+| enabled            | true/false if it is possible to create a copy of an instance.                                    |
+| excludedDataTypes  | List of data types that should be excluded when a new copy is made.                              |
+| excludedDataFields | List of fields in the data model that should be excluded when a new copy is made.                |
+| includeAttachments | true/false indicating whether attachments should be copied. Defaults to false.                   |
 
 Meldingsboksen i portalen vil hvise en link med teksten [Lag ny kopi](/nb/altinn-studio/v8/reference/configuration/messagebox/create_copy/) hvis brukeren velger en arkivert instans.
 


### PR DESCRIPTION
## Description

Documents the `copyInstanceSettings.includeAttachments` option for the **Create new copy** feature.

The existing documentation stated that attachments were never copied, while `Altinn.App.Api` supports opt-in attachment copying from version 8.7.0. The updated documentation now explains:

- that attachment copying is disabled by default
- how to enable it in `applicationmetadata.json`
- that `excludedDataTypes` applies to attachments as well as form data
- that copied data types must be associated with the first process task
- the minimum `Altinn.App.Api` version for v8 apps

The v8 Norwegian and English pages, the draft v9 reference, and both app metadata model references are updated so the setting is documented consistently wherever `CopyInstanceSettings` is described.

## Screenshots

### Attachment configuration and version requirement

![Rendered Norwegian attachment configuration](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio-docs/fdb6c2b2d73a55c10de74fd61ae6528f2bba213d/.github/pr-assets/3010/configuration-nb.png)

### Configuration example

![Rendered Norwegian attachment configuration example](https://raw.githubusercontent.com/martinothamar-agent/altinn-studio-docs/fdb6c2b2d73a55c10de74fd61ae6528f2bba213d/.github/pr-assets/3010/examples-nb.png)

## Verification

- `git diff --check`
- `hugo` (Hugo v0.164.0 extended; 2,235 Norwegian and 2,159 English pages built successfully)
- Inspected the generated Norwegian and English HTML for the setting, notice, and JSON example
- Verified behavior against the `Altinn.App.Api` implementation and copy-instance tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the new option for copying attachments when creating messagebox instances.
  * Clarified that attachment copying is disabled by default and requires the appropriate app library version.
  * Explained how excluded data types apply to both form data and attachments.
  * Added configuration examples and clarified copy settings in the API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
