### PR TITLE
remove APIM subscription key from doc

### DIFF
--- a/content/broker/getting-started/developer-guides/_index.en.md
+++ b/content/broker/getting-started/developer-guides/_index.en.md
@@ -39,5 +39,5 @@ As such, you should implement Event subscriptions to make your process optimized
 For all operations you will need to Authenticate using your [Maskinporten Client](https://docs.digdir.no/docs/Maskinporten/maskinporten_guide_apikonsument.html)
 then [acquire an Altinn Token from Altinn Authentication](https://docs.altinn.studio/authorization/getting-started/authentication/#exchange-a-jwt-token-from-an-external-token-provider).
 
-Use the Altinn Token as a Bearer token for all Broker API requests along with the APIM subscription key as a header with the key `Ocp-Apim-Subscription-Key`.
+Use the Altinn Token as a Bearer token for all Broker API requests.
 

--- a/content/broker/getting-started/developer-guides/_index.nb.md
+++ b/content/broker/getting-started/developer-guides/_index.nb.md
@@ -39,4 +39,4 @@ Som sådan bør du implementere hendelsesabonnementer for å optimalisere proses
 For alle operasjoner må du autentisere deg ved å bruke din [Maskinporten-klient](https://docs.digdir.no/docs/Maskinporten/maskinporten_guide_apikonsument.html) og 
 deretter [skaffe en Altinn-token fra Altinn-autentisering](https://docs.altinn.studio/nb/authorization/getting-started/authentication/#bytt-et-jwt-fra-en-ekstern-tokenleverandør).
 
-Bruk Altinn-tokenet som en Bearer-token for alle Formidling API-forespørsler sammen med APIM-abonnementsnøkkelen som en header med nøkkelen `Ocp-Apim-Subscription-Key`.
+Bruk Altinn-tokenet som en Bearer-token for alle Formidling API-forespørsler.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication guidance to clarify that API requests require the Altinn Token as a Bearer token.
  * Removed instructions to include an APIM subscription key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->