### PR TITLE
feat: Migrate development/assistant guide from v8 to v9 with klarspråk

### DIFF
--- a/content/altinn-studio/v9/new-from-v8/development/assistant/_index.nb.md
+++ b/content/altinn-studio/v9/new-from-v8/development/assistant/_index.nb.md
@@ -1,4 +1,5 @@
 ---
+draft: true
 title: Assistent
 description: Slik bruker du KI-assistenten i Studio
 hidden: true

--- a/content/altinn-studio/v9/new-from-v8/development/assistant/_index.nb.md
+++ b/content/altinn-studio/v9/new-from-v8/development/assistant/_index.nb.md
@@ -1,0 +1,61 @@
+---
+title: Assistent
+description: Slik bruker du KI-assistenten i Studio
+hidden: true
+tags: [needsReview]
+---
+
+{{% notice info %}}
+Assistenten er i lukket beta og bare tilgjengelig for noen få tjenesteeiere. Vil organisasjonen din også bli med i betaen? [Kontakt oss](https://altinn.studio/info/contact).
+{{% /notice %}}
+
+Assistenten er en KI-agent som kan hjelpe deg med å bygge apper i Altinn Studio. Den kan blant annet hjelpe deg med å
+
+- generere en app ut fra et eksisterende PDF-skjema
+- oversette appen til andre språk
+- sette opp dynamisk visning av elementer
+- finne og rette opp feil i appen
+
+Assistenten har tilgang til Studio-dokumentasjonen og kan også svare på spørsmål om skjemaoppsett, tilgangsstyring og andre funksjoner i verktøyet.
+
+{{% notice warning %}}
+Assistenten er spesielt tilpasset Altinn og apputvikling, og egner seg ikke for andre bruksområder. Den kan gi svar som ikke alltid er helt presise, så kontroller alltid endringene før du publiserer appen.
+{{% /notice %}}
+
+## Slå på assistenten
+
+Assistenten er skjult bak et funksjonsflagg mens den er i lukket beta. Slik slår du den på:
+
+1. Gå til [altinn.studio/info/flags](https://altinn.studio/info/flags).
+2. Slå på bryteren for **ai-assistant**.
+3. Åpne en app i Studio. Da ser du **Assistent** i menylinjen øverst.
+
+## Stille spørsmål
+
+Når **Tillat endringer i appen** er av, fungerer assistenten som en chatbot og svarer ut fra Altinn-dokumentasjonen.
+
+## Endre appen
+
+Når **Tillat endringer i appen** er på, gjør assistenten endringer i appen ut fra instruksjonene dine. Jo tydeligere instruksjonene er, desto bedre blir resultatet.
+
+Assistenten lagrer alle endringene i en egen gren. Du må flette grenen inn i `master`-grenen før du kan publisere endringene. Les mer om [hvordan du jobber med grener i Altinn Studio](/nb/altinn-studio/v8/guides/development/branching/).
+
+## Tråder
+
+Tråder lar deg opprette nye samtaler uten kontekst fra gamle meldinger. Vi anbefaler at du bruker én tråd per tema og lager nye tråder ofte. Inaktive tråder slettes automatisk etter 90 dager.
+
+## Personvern
+
+Ikke send personopplysninger eller sensitiv informasjon til assistenten. Vi lagrer meldingene dine i 90 dager. Vi bruker dataene til å feilsøke og forbedre assistenten, og også til fakturering. Vi bruker dem ikke til å trene KI-modeller.
+
+## Data og KI-modeller
+
+Assistenten bruker språkmodeller gjennom Microsoft Azure. I betaen kan vi behandle dataene dine utenfor EU. Vi skal gå over til å behandle alt kun i EU før betaperioden slutter.
+
+## Kostnad
+
+Assistenten er gratis å bruke i den lukkede betaen. Etter betaperioden kan bruk påløpe kostnader for tjenesteeiere.
+
+## Gi tilbakemelding
+
+Vi vil gjerne høre hva du synes. Bruk tilbakemeldingsfunksjonen under hver assistent-melding for å fortelle oss hvordan den fungerer for deg. Har du et forslag til forbedring? Opprett en sak i [Altinn Studio-repoet på GitHub](https://github.com/Altinn/altinn-studio/issues).

--- a/themes/hugo-theme-altinn/layouts/partials/header.html
+++ b/themes/hugo-theme-altinn/layouts/partials/header.html
@@ -88,7 +88,7 @@
         {{- end -}}
         {{- if and $currentVersion (eq $currentVersion "v9") (eq $currentProduct "altinn-studio") -}}
           <div  id="version-alert-container" class="ds-alert" data-color="info" icon>
-             Dette er dokumentasjonen for versjon {{ $currentVersion }} av {{ $currentProduct }}, som er i pre-release. Gjeldende versjon er v8. 
+             Dette er dokumentasjonen for versjon {{ $currentVersion }} av Altinn Studio, som er under utvikling. Gjeldende versjon er v8. 
              For å se dokumentasjonen for gjeldende versjon, velg v8 i versjonsvelgeren i menyen til venstre.
           </div>
         {{- end -}}


### PR DESCRIPTION
## Innhold

Migrerer development/assistant-veiledningen fra v8 til v9 med fullstendig klarspråk-vask.

### Filer lagt til
- `content/altinn-studio/v9/new-from-v8/development/assistant/_index.nb.md`
  - Migrated from v8 guides/development/assistant
  - Full klarspråk revision:
    - ✅ Eliminert s-passiv: "ville bli behandlet" → "kan vi behandle"
    - ✅ Endret til du-perspektiv: "Vi anbefaler å" → "Vi anbefaler at du bruker"
    - ✅ Fjernet substantiveringer: "går over til behandling" → "skal gå over til å behandle"
    - ✅ Forbedret naturlig språk: "samt" → "og også", "Etterpå" → "Etter betaperioden"
    - ✅ Produktnavn rettelse: "altinn-studio-repoet" → "Altinn Studio-repoet"
  - Lenke til v8 branching-guide (v9 versjon ikke migrert ennå)

### Filer endret
- `themes/hugo-theme-altinn/layouts/partials/header.html`
  - Produktnavn: 'altinn-studio' → 'Altinn Studio'
  - Version alert: 'pre-release' → 'under utvikling' (mer naturlig norsk)

### Testing
- [x] Lenke til localhost: http://localhost:1313/nb/altinn-studio/v9/new-from-v8/development/assistant/
- [x] Alle lenker fungerer (branching-link peker til v8)
- [x] Infoboks viser rett tekst

Tags: development, assistant, klarspråk, v8-to-v9-migration