### PR TITLE
fix: Rett produktnavn og norsk uttrykk i v9-varselboksen

### DIFF
--- a/themes/hugo-theme-altinn/layouts/partials/header.html
+++ b/themes/hugo-theme-altinn/layouts/partials/header.html
@@ -88,7 +88,7 @@
         {{- end -}}
         {{- if and $currentVersion (eq $currentVersion "v9") (eq $currentProduct "altinn-studio") -}}
           <div  id="version-alert-container" class="ds-alert" data-color="info" icon>
-             Dette er dokumentasjonen for versjon {{ $currentVersion }} av {{ $currentProduct }}, som er i pre-release. Gjeldende versjon er v8. 
+             Dette er dokumentasjonen for versjon {{ $currentVersion }} av Altinn Studio, som er under utvikling. Gjeldende versjon er v8. 
              For å se dokumentasjonen for gjeldende versjon, velg v8 i versjonsvelgeren i menyen til venstre.
           </div>
         {{- end -}}


### PR DESCRIPTION
## Hva endrer denne PR-en?

Retter varselboksen som vises øverst på alle v9-sider (`themes/hugo-theme-altinn/layouts/partials/header.html`). Denne teksten ligger kun ett sted og styrer alle v9-sider samtidig.

### Endringer:
- `{{ $currentProduct }}` (rå slug, vises som «altinn-studio») → «Altinn Studio» (korrekt produktnavn)
- «pre-release» → «under utvikling» (norsk, ikke anglisisme)

Før: *"Dette er dokumentasjonen for versjon v9 av altinn-studio, som er i pre-release."*
Etter: *"Dette er dokumentasjonen for versjon v9 av Altinn Studio, som er under utvikling."*