### PR TITLE
fix: Legg til manglende headless: true i api-signing intro (v9)

### DIFF
--- a/content/altinn-studio/v9/develop-a-service/process/signing/how-to/api-signing/intro.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/process/signing/how-to/api-signing/intro.nb.md
@@ -1,6 +1,7 @@
 ---
 draft: true
 hidden: true
+headless: true
 tags: [needsReview, translate]
 ---
 


### PR DESCRIPTION
## Hva endrer denne PR-en?

Legger til `headless: true` i frontmatter for `develop-a-service/process/signing/how-to/api-signing/intro.nb.md`.

### Bakgrunn
Under gjennomgang av det utdaterte emnet **api-signing** fant jeg at v8-filen fikk lagt til `headless: true` 18. juni 2026 (commit `d64272989`), men denne attributten manglet i v9-versjonen.

Filen brukes med `{{% insert %}}`-shortcode tre steder i v9 (`_setup.nb.md` og `api-signing/index.nb.md`/`.en.md`), så attributten bør være med for konsistent oppførsel.

### Status:
- Ingen v8-filer endret
- Kun frontmatter-endring, ingen tekstlig innhold endret