### PR TITLE
docs: foreslå begrepsregler for autorisasjon

### DIFF
--- a/content/authorization/getting-started/terms/_index.nb.md
+++ b/content/authorization/getting-started/terms/_index.nb.md
@@ -7,6 +7,22 @@ toc: false
 weight: 1
 ---
 
+Denne ordlisten forklarer hvordan sentrale begreper innen Altinn Autorisasjon skal brukes. I brukerrettet tekst skal vi beskrive personen, virksomheten eller handlingen så konkret som mulig. Tekniske begreper kan brukes når teksten beskriver API-er, domenemodeller eller etablerte systemnavn, men bør forklares første gang de brukes.
+
+## Slik velger du riktig begrep
+
+| Når vi mener … | Bruk | Unngå i brukerrettet tekst | Unntak |
+| --- | --- | --- | --- |
+| En organisasjon generelt | **virksomhet** | aktør, bedrift, selskap, hovedenhet | Bruk den offisielle betegnelsen når virksomhetsformen er relevant. |
+| En person eller virksomhet i en teknisk modell | **part** | – | Brukes hovedsakelig i API- og domenedokumentasjon. |
+| En intern fellesbetegnelse for personer og virksomheter | **aktør** | aktør i brukerrettede instrukser | Kan brukes i kode, API-navn og forklaringer av eldre løsninger. |
+| At noen handler for en annen | **gjøre eller handle på vegne av** | representere | *Representasjon* kan beholdes som teknisk domenebegrep når det forklares. |
+| Myndigheten til å handle på vegne av noen | **fullmakt** | tilgang, rettighet, tillatelse | Begrepet må brukes i samsvar med den juridiske og faglige betydningen. |
+| Den tekniske muligheten til å bruke en funksjon eller ressurs | **tilgang** | fullmakt | For eksempel: «Systemet har tilgang til API-et.» |
+| En bestemt tillatt handling på en ressurs | **rettighet** | fullmakt, tilgang | For eksempel retten til å lese en melding. |
+| Å gi noen en fullmakt | **gi fullmakt** | delegere | *Delegere* kan beholdes i tekniske navn og API-operasjoner. |
+| Enheter registrert som hoved- eller underenhet | **hovedenhet** og **underenhet** | – | Brukes bare når Enhetsregisterets struktur er relevant. |
+
 ## Administratortilgang
 
 Tilgangspakkene som gir fullmakt til å administrere fullmakter, men de gir ikke tilgang til tjenester.
@@ -20,19 +36,31 @@ Fire tilgangspakker er administratorfullmakter:
 
 Disse er skilt ut i en egen tab i GUI i dag. Det går an å skjule dem i ressursregisteret.
 
-## Avgiver/aktør
+## Aktør
 
-Avgiver/aktør er den innbyggeren eller virksomheten som den man opptrer på vegne av i Altinn.
+En teknisk eller intern fellesbetegnelse for en person eller virksomhet.
 
-- Rapporterer inn data for
-- Leser meldinger for
-- Administrerer rettigheter for
+Bruk som hovedregel ikke *aktør* i tekst rettet mot sluttbrukere. Skriv heller hvem teksten gjelder, for eksempel *personen*, *virksomheten* eller *den du handler på vegne av*.
 
-Se også part.
+Begrepet kan beholdes i API-navn, tekniske modeller og omtale av eksisterende funksjoner. Forklar begrepet første gang det brukes.
+
+## Autorisasjon
+
+Reglene og kontrollene som avgjør om en person, virksomhet eller et system får utføre en handling på en ressurs.
+
+Brukes hovedsakelig i teknisk dokumentasjon.
+
+## Avgiver
+
+Et historisk begrep fra Altinn 2 for personen eller virksomheten noen handler på vegne av.
+
+Bruk ikke *avgiver* i ny brukerrettet dokumentasjon. Begrepet kan brukes når Altinn 2, avgiverlisten eller eksisterende tekniske navn omtales.
 
 ## Delegere/delegering
 
-Å gi fullmakt. Man kan delegere til innbygger, virksomhet, systembruker og selvidentifiserte brukere i Altinn.
+Den tekniske handlingen der en fullmakt eller rettighet gis videre til noen andre.
+
+Skriv normalt *gi fullmakt* i brukerrettet tekst. Behold *delegere* og *delegering* når teksten beskriver en API-operasjon, systemfunksjon eller et etablert teknisk navn.
 
 ## Enkelttjeneste
 
@@ -48,13 +76,31 @@ Sluttbrukersystem brukes der målgruppen er tjenesteeiere og systemleverandører
 
 ## Fullmakt
 
-Betyr å "få tilgang/tillatelse til noe". Erstatter “tilgang” som hovedbegrep for handlingen. “Fullmakt” er begrepet vi bruker for handlingen brukerne skal gjøre når de gir tilgang. “Fullmakt” skal stå på navigasjonselementer, for eksempel på knapper.
+Myndigheten en person, virksomhet eller et system har til å handle på vegne av en annen person eller virksomhet.
+
+En fullmakt kan omfatte én eller flere rettigheter. Bruk *fullmakt* når teksten handler om hva noen får myndighet til å gjøre, ikke om den tekniske gjennomføringen.
 
 ## Fullmakt til en enkelttjeneste
 
 Erstatter enkeltrettighetsdelegering.
 
+## Gjøre eller handle på vegne av
+
+Brukes når en person, virksomhet eller et system utfører en oppgave for en annen person eller virksomhet.
+
+Foretrekk denne formuleringen fremfor *representere* i brukerrettet tekst.
+
+Eksempel: «Velg virksomheten du skal handle på vegne av.»
+
+## Hovedenhet og underenhet
+
+Offisielle begreper som beskriver enhetsstrukturen i Enhetsregisteret.
+
+Bruk begrepene når registerstrukturen har betydning for det som forklares. Bruk ellers *virksomhet*.
+
 ## Klientadministrasjon
+
+
 
 Erstatter klientdelegering.
 
@@ -82,7 +128,15 @@ Den som bruker en tjeneste, for eksempel den som skal fylle ut et skjema.
 
 Brukes i Ressursregisteret, Altinn Studio, i dokumentasjon og mot tjenesteeiere.
 
+## Part
+
+Et teknisk domenebegrep for personen eller virksomheten som en ressurs, dialog eller forespørsel gjelder.
+
+Bruk *part* i API- og domenedokumentasjon når den tekniske modellen krever det. Forklar begrepet første gang det brukes. I brukerrettet tekst bør man vanligvis skrive *person* eller *virksomhet*.
+
 ## Policy
+
+
 
 En policy er en samling av en eller flere regler. Hver tjeneste eller ressurs i Altinn har en policy med minst én regel.
 
@@ -99,11 +153,11 @@ F.eks
 
 ## Rettighet
 
-Hva noen har rett til å gjøre, for eksempel rett til å lese en melding eller rett til å signere.
+En bestemt handling noen har lov til å utføre på en ressurs.
 
-En rettighet beskrives med handling + ressurs.
+En rettighet beskrives vanligvis som en kombinasjon av handling og ressurs, for eksempel retten til å lese en melding eller signere et skjema.
 
-Se regel.
+En fullmakt kan inneholde flere rettigheter. Se også regel.
 
 ## Sluttbruker
 
@@ -125,17 +179,15 @@ Med en systemtilgang kan sluttbruker gi et fagsystem fullmakt til å løse oppga
 
 ## Tilgang
 
-I Altinn: Handlingen “gi fullmakt”. Kan brukes i løpende tekst for å forklare denne handlingen.
+Den tekniske muligheten til å bruke en funksjon, tjeneste eller ressurs.
 
-Kan også brukes hvis det er nødvendig for å beskrive de ulike tingene en fullmakt kan gi rett til å gjøre med en tjeneste, for eksempel “lesetilgang”.
+Tilgang er den tekniske gjennomføringen av en fullmakt eller rettighet. Bruk ikke *tilgang* når teksten egentlig handler om myndigheten noen har fått til å handle på vegne av andre.
 
 ## Tilgangspakke
 
-Fullmakter til enkelttjenester er samlet i tilgangspakker.
+En definert samling rettigheter innenfor et område.
 
-En tilgangspakke er en fullmakt til flere tjenester innenfor samme område.
-
-Tjenesteeier definerer hvilke rettigheter som skal knyttes til en fullmaktspakke.
+En tilgangspakke kan inngå i en fullmakt. Selve pakken er ikke nødvendigvis det samme som fullmakten som gis til en person, virksomhet eller et system.
 
 ## Tilgangsstyrer
 
@@ -154,6 +206,12 @@ En tjeneste kan realiseres som en App i Altinn Studio og publiseres på Altinn p
 ## Tjenesteutviklingsløsning
 
 Løsning der tjenester blir konfigurert, for eksempel Altinn Studio og Ressursregisteret.
+
+## Virksomhet
+
+Standardbegrepet for en organisasjon i brukerrettet tekst.
+
+Bruk *virksomhet* når den konkrete organisasjonsformen eller registerstrukturen ikke er relevant.
 
 ## XACML
 

--- a/content/authorization/getting-started/terms/_index.nb.md
+++ b/content/authorization/getting-started/terms/_index.nb.md
@@ -7,7 +7,9 @@ toc: false
 weight: 1
 ---
 
-Denne ordlisten forklarer hvordan sentrale begreper innen Altinn Autorisasjon skal brukes. I brukerrettet tekst skal vi beskrive personen, virksomheten eller handlingen så konkret som mulig. Tekniske begreper kan brukes når teksten beskriver API-er, domenemodeller eller etablerte systemnavn, men bør forklares første gang de brukes.
+Denne ordlisten forklarer hvordan sentrale begreper innen Altinn Autorisasjon skal brukes. I brukerrettet tekst skal vi beskrive personen, virksomheten eller handlingen så konkret som mulig. Tekniske begreper kan brukes når teksten beskriver API-er, domenemodeller eller etablerte systemnavn, men bør forklares første gang de brukes. Når vi omtaler eksisterende funksjoner eller elementer i brukergrensesnittet, bruker vi navnet som vises i løsningen.
+
+Se også [Designsystemets retningslinjer for språk om representasjon](https://designsystemet.no/no/patterns/representation).
 
 ## Slik velger du riktig begrep
 
@@ -15,11 +17,11 @@ Denne ordlisten forklarer hvordan sentrale begreper innen Altinn Autorisasjon sk
 | --- | --- | --- | --- |
 | En organisasjon generelt | **virksomhet** | aktør, bedrift, selskap, hovedenhet | Bruk den offisielle betegnelsen når virksomhetsformen er relevant. |
 | En person eller virksomhet i en teknisk modell | **part** | – | Brukes hovedsakelig i API- og domenedokumentasjon. |
-| En intern fellesbetegnelse for personer og virksomheter | **aktør** | aktør i brukerrettede instrukser | Kan brukes i kode, API-navn og forklaringer av eldre løsninger. |
+| Personen eller virksomheten noen handler på vegne av | **personen** eller **virksomheten** | aktør, avgiver | *Aktør* og *aktørvalg* kan beholdes i etablerte produktnavn, kode og API-navn. |
 | At noen handler for en annen | **gjøre eller handle på vegne av** | representere | *Representasjon* kan beholdes som teknisk domenebegrep når det forklares. |
 | Myndigheten til å handle på vegne av noen | **fullmakt** | tilgang, rettighet, tillatelse | Begrepet må brukes i samsvar med den juridiske og faglige betydningen. |
-| Den tekniske muligheten til å bruke en funksjon eller ressurs | **tilgang** | fullmakt | For eksempel: «Systemet har tilgang til API-et.» |
-| En bestemt tillatt handling på en ressurs | **rettighet** | fullmakt, tilgang | For eksempel retten til å lese en melding. |
+| Den tekniske muligheten til å bruke en funksjon eller ressurs | **tilgang** | fullmakt | Kan brukes i sammensatte ord, for eksempel *lesetilgang*. |
+| En bestemt tillatt handling på en ressurs | **rettighet** | rettighet som synonym for fullmakt | Brukes hovedsakelig i teknisk dokumentasjon. |
 | Å gi noen en fullmakt | **gi fullmakt** | delegere | *Delegere* kan beholdes i tekniske navn og API-operasjoner. |
 | Enheter registrert som hoved- eller underenhet | **hovedenhet** og **underenhet** | – | Brukes bare når Enhetsregisterets struktur er relevant. |
 
@@ -36,13 +38,13 @@ Fire tilgangspakker er administratorfullmakter:
 
 Disse er skilt ut i en egen tab i GUI i dag. Det går an å skjule dem i ressursregisteret.
 
-## Aktør
+## Aktør og aktørvalg
 
-En teknisk eller intern fellesbetegnelse for en person eller virksomhet.
+Et etablert Altinn-begrep for en person eller virksomhet noen handler på vegne av. *Aktørvalg* er funksjonen for å velge denne personen eller virksomheten.
 
-Bruk som hovedregel ikke *aktør* i tekst rettet mot sluttbrukere. Skriv heller hvem teksten gjelder, for eksempel *personen*, *virksomheten* eller *den du handler på vegne av*.
+I ny brukerrettet tekst bør vi skrive hvem teksten gjelder, for eksempel *personen*, *virksomheten* eller *den du handler på vegne av*.
 
-Begrepet kan beholdes i API-navn, tekniske modeller og omtale av eksisterende funksjoner. Forklar begrepet første gang det brukes.
+Begrepene kan beholdes når vi omtaler et eksisterende element i brukergrensesnittet, eller når de inngår i kode, API-navn eller tekniske modeller. Forklar begrepet første gang det brukes i teknisk dokumentasjon.
 
 ## Autorisasjon
 
@@ -50,17 +52,23 @@ Reglene og kontrollene som avgjør om en person, virksomhet eller et system får
 
 Brukes hovedsakelig i teknisk dokumentasjon.
 
-## Avgiver
+## Avgiver og avgiverliste
 
 Et historisk begrep fra Altinn 2 for personen eller virksomheten noen handler på vegne av.
 
-Bruk ikke *avgiver* i ny brukerrettet dokumentasjon. Begrepet kan brukes når Altinn 2, avgiverlisten eller eksisterende tekniske navn omtales.
+Bruk ikke *avgiver* eller *avgiverliste* som nye begreper. De kan bare brukes når vi beskriver eller siterer historisk terminologi fra Altinn 2. Forklar da at begrepene er erstattet.
 
 ## Delegere/delegering
 
-Den tekniske handlingen der en fullmakt eller rettighet gis videre til noen andre.
+En teknisk operasjon der noen gir en fullmakt eller rettighet til andre.
 
 Skriv normalt *gi fullmakt* i brukerrettet tekst. Behold *delegere* og *delegering* når teksten beskriver en API-operasjon, systemfunksjon eller et etablert teknisk navn.
+
+## Del og gi fullmakt
+
+Den brukerrettede formuleringen for å dele et bestemt element og gi fullmakt til det.
+
+Bruk denne formuleringen i stedet for *instansdelegering* i brukergrensesnitt og brukerrettet dokumentasjon.
 
 ## Enkelttjeneste
 
@@ -72,7 +80,7 @@ Et system som løser noe for bruker/sluttbruker, for eksempel regnskapssystem el
 
 Fagsystem brukes eksternt i Altinn GUI med målgruppe Altinn-brukere.
 
-Sluttbrukersystem brukes der målgruppen er tjenesteeiere og systemleverandører.
+Sluttbrukersystem brukes der målgruppen er tjenesteeiere og systemleverandører, for eksempel i Ressursregisteret og Altinn Studio.
 
 ## Fullmakt
 
@@ -80,9 +88,11 @@ Myndigheten en person, virksomhet eller et system har til å handle på vegne av
 
 En fullmakt kan omfatte én eller flere rettigheter. Bruk *fullmakt* når teksten handler om hva noen får myndighet til å gjøre, ikke om den tekniske gjennomføringen.
 
+I brukergrensesnitt bruker vi *fullmakt* som produktbegrep. Skriv *gi fullmakt* i instrukser, og bruk *Fullmakt* i relevante navigasjonselementer og knapper.
+
 ## Fullmakt til en enkelttjeneste
 
-Erstatter enkeltrettighetsdelegering.
+En fullmakt som gjelder én bestemt tjeneste. Formuleringen erstatter *enkeltrettighetsdelegering*.
 
 ## Gjøre eller handle på vegne av
 
@@ -98,9 +108,13 @@ Offisielle begreper som beskriver enhetsstrukturen i Enhetsregisteret.
 
 Bruk begrepene når registerstrukturen har betydning for det som forklares. Bruk ellers *virksomhet*.
 
+## Instansdelegering
+
+Et teknisk begrep for å delegere rettigheter til ett bestemt element eller én bestemt instans.
+
+Bruk *Del og gi fullmakt* i brukergrensesnitt og brukerrettet dokumentasjon. Behold *instansdelegering* bare når den tekniske funksjonen må beskrives.
+
 ## Klientadministrasjon
-
-
 
 Erstatter klientdelegering.
 
@@ -110,21 +124,17 @@ Noen som leverer et fagsystem som blir brukt av bruker/sluttbruker, for eksempel
 
 Leverandør av fagsystem brukes eksternt i Altinn GUI med målgruppe Altinn-brukere.
 
-Sluttbrukersystemleverandør brukes der målgruppen er tjenesteeiere og systemleverandører.
+Sluttbrukersystemleverandør brukes der målgruppen er tjenesteeiere og systemleverandører, for eksempel i Ressursregisteret og Altinn Studio.
 
 ## Område
 
-Tilgangspakkene er kategorisert i områder.
+En samling tilgangspakker innenfor samme tema, basert på SSBs kategorisering av virksomhetsområder og enkelte tilleggskategorier i Altinn.
 
-Basert på SSB sin kategorisering av virksomhetsområde, men vi har laget noen i tillegg.
-
-Man kan ikke gi fullmakt til et område, men gir tilgang til pakkene under området. Dette for å understøtte fremtidige endringer.
+Områder brukes bare til å kategorisere tilgangspakker. Man kan ikke gi fullmakt til et område.
 
 ## Oppgave
 
 De ulike stegene i en tjeneste, for eksempel utfylling og signering.
-
-Den som bruker en tjeneste, for eksempel den som skal fylle ut et skjema.
 
 Brukes i Ressursregisteret, Altinn Studio, i dokumentasjon og mot tjenesteeiere.
 
@@ -135,8 +145,6 @@ Et teknisk domenebegrep for personen eller virksomheten som en ressurs, dialog e
 Bruk *part* i API- og domenedokumentasjon når den tekniske modellen krever det. Forklar begrepet første gang det brukes. I brukerrettet tekst bør man vanligvis skrive *person* eller *virksomhet*.
 
 ## Policy
-
-
 
 En policy er en samling av en eller flere regler. Hver tjeneste eller ressurs i Altinn har en policy med minst én regel.
 
@@ -159,17 +167,21 @@ En rettighet beskrives vanligvis som en kombinasjon av handling og ressurs, for 
 
 En fullmakt kan inneholde flere rettigheter. Se også regel.
 
+Bruk *rettighet* hovedsakelig i teknisk dokumentasjon. Hvis teksten egentlig handler om myndigheten noen har fått til å handle på vegne av andre, bruk *fullmakt*.
+
 ## Sluttbruker
 
 Den som bruker en tjeneste, for eksempel den som skal fylle ut et skjema.
 
 Brukes i Ressursregisteret, Altinn Studio, i dokumentasjon og mot tjenesteeiere.
 
+Bruk ikke *sluttbruker* i Altinns brukergrensesnitt. Beskriv personen mer konkret ut fra sammenhengen.
+
 ## Sluttbrukerløsning
 
 Sluttbrukerløsning har tradisjonelt vært brukt om altinn.no.
 
-## Systemtilgang /Systembruker
+## Systemtilgang/systembruker
 
 Med en systemtilgang kan sluttbruker gi et fagsystem fullmakt til å løse oppgaver i Altinn. For eksempel automatisk oppslag i skatteopplysninger. Maskin-til-maskin.
 
@@ -183,11 +195,19 @@ Den tekniske muligheten til å bruke en funksjon, tjeneste eller ressurs.
 
 Tilgang er den tekniske gjennomføringen av en fullmakt eller rettighet. Bruk ikke *tilgang* når teksten egentlig handler om myndigheten noen har fått til å handle på vegne av andre.
 
+Begrepet kan brukes når typen teknisk tilgang er relevant, for eksempel *lesetilgang*.
+
+## Tilgangskontroll
+
+Kontroller som sikrer at riktig person eller system får riktig tilgang til riktig ressurs på riktig tidspunkt, basert på registrerte fullmakter, rettigheter og andre autorisasjonsdata.
+
+Brukes hovedsakelig i teknisk dokumentasjon.
+
 ## Tilgangspakke
 
-En definert samling rettigheter innenfor et område.
+En definert samling rettigheter til tjenester innenfor et område. Tilgangspakken beskriver omfanget av en fullmakt som kan gjelde flere tjenester.
 
-En tilgangspakke kan inngå i en fullmakt. Selve pakken er ikke nødvendigvis det samme som fullmakten som gis til en person, virksomhet eller et system.
+I brukerrettet tekst bruker vi formuleringen *gi fullmakt til en tilgangspakke*. Teknisk er tilgangspakken samlingen av rettigheter, mens fullmakten er myndigheten som gis til en person, virksomhet eller et system.
 
 ## Tilgangsstyrer
 


### PR DESCRIPTION
## Bakgrunn

Dette er et diskusjonsgrunnlag for første steg i #2836. Forslaget samler språkreglene i den eksisterende norske ordlisten for Altinn Autorisasjon før vi gjør en bred språkvask av dokumentasjonen.

Forslaget er kvalitetssjekket mot:

- Designsystemets retningslinjer for språk om representasjon
- den interne Confluence-ordlisten for begrepsbruk i autorisasjonsteamene

Confluence-ordlisten inneholder også uferdige felter og enkelte motstridende føringer. Den er derfor brukt som faglig grunnlag, men ikke kopiert direkte.

## Endringer

- legger inn en beslutningstabell for brukerrettede og tekniske begreper
- skiller mellom aktør, avgiver, part og virksomhet
- anbefaler «gjøre eller handle på vegne av» fremfor «representere» i brukerrettet tekst
- tydeliggjør forholdet mellom fullmakt, tilgang, rettighet og tilgangspakke
- beholder etablerte navn i brukergrensesnitt, kode og API-er som dokumenterte unntak
- tar inn GUI-reglene for «Fullmakt» og «Del og gi fullmakt»
- skiller mellom brukerrettet språk og de tekniske begrepene delegering og instansdelegering
- tar inn begrepet tilgangskontroll
- avgrenser hovedenhet og underenhet til relevant registerkontekst
- presiserer bruken av sluttbruker og område
- retter en duplisert definisjon under «Oppgave» og formatteringsfeil i ordlisten

## Foreslåtte avklaringer

| Begrep | Forslag i denne PR-en |
| --- | --- |
| Aktør/aktørvalg | Skriv person eller virksomhet i ny brukerrettet tekst. Behold etablerte produktnavn, kode og API-navn. |
| Fullmakt | Myndigheten til å handle på vegne av noen. Brukes samtidig som etablert produktbegrep i GUI. |
| Tilgang | Den tekniske gjennomføringen. Kan brukes når typen tilgang er relevant, for eksempel lesetilgang. |
| Rettighet | En bestemt handling på en ressurs. Brukes hovedsakelig teknisk og ikke som synonym for fullmakt. |
| Tilgangspakke | En teknisk samling rettigheter som beskriver omfanget av en fullmakt. Brukerrettet formulering er «gi fullmakt til en tilgangspakke». |
| Delegering | Teknisk operasjon. Bruk «gi fullmakt» i brukerrettet tekst. |

## Punkter til diskusjon

1. Er unntaket for etablerte produktnavn som «aktørvalg» riktig avgrenset?
2. Dekker definisjonen av fullmakt både den faglige betydningen og bruken i GUI?
3. Er skillet mellom fullmakt, tilgang og rettighet riktig?
4. Beskriver forslaget forholdet mellom tilgangspakke og fullmakt korrekt?
5. Er skillet mellom «Del og gi fullmakt» og instansdelegering presist?

## Avgrensning

- Endringen gjelder bare den norske ordlisten.
- Den utfører ingen generell språkvask i andre dokumentasjonsfiler.
- Samtykke, klientbegrepet og uferdige nynorsk-/engelskoversettelser fra Confluence tas ikke inn i denne PR-en.
- Engelsk ordliste kan harmoniseres etter at begrepene er faglig forankret.

## Verifisering

- hugo --minify --renderToMemory
- git diff --check

Relatert til #2836.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reworked the Norwegian authorisation glossary with clearer introductions and guidance on choosing appropriate terminology.
  * Expanded and clarified definitions for existing authorisation concepts.
  * Added new entries covering delegation, mandates, acting on behalf of others, organisational units, instance delegation, parties, access control and businesses.
  * Added guidance distinguishing user-facing and technical terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->