### PR TITLE
docs: faktasjekk sluttbrukerguider for autorisasjon

### DIFF
--- a/content/authorization/guides/end-user/instancedelegation/_index.nb.md
+++ b/content/authorization/guides/end-user/instancedelegation/_index.nb.md
@@ -14,13 +14,13 @@ Funksjonen er tilgjengelig fra meldings- eller skjemaelementet i Altinn-innbokse
 
 Hvis du har brukt tilsvarende funksjon i den gamle innboksen, vil du oppleve at kravene er strengere. Nå kan bare personer med riktig fullmakt dele elementet og gi andre fullmakt, ikke alle som har tilgang til meldinger og skjemaer i innboksen.
 
-Når du klikker på knappen **Gi tilgang**, kommer du til en ny side.
+Når du klikker på knappen **Gi tilgang**, kommer du til siden **Del og gi fullmakt**. Her kan du velge en person som allerede er registrert, eller klikke på **Ny bruker** for å gi fullmakt til en ny person.
 
-På denne siden må du
-- velge hvilke handlinger i tjenesten (lese, skrive) mottakeren skal ha rett til å utføre
+Når du gir fullmakt til en ny person, må du
 - identifisere mottakeren med fødselsnummer og etternavn, eller med Altinn-brukernavn og etternavn
+- velge hvilke handlinger i tjenesten (lese, skrive) mottakeren skal ha rett til å utføre
 
-![Skjermbilde som viser valg av tilganger før du fyller inn identifiserende informasjon](./instansdelegering3.png)
+![Skjermbilde av å gi fullmakt til en ny person](./instansdelegering3.png)
 
 Når du har gitt fullmakten, finner mottakeren meldingen eller skjemaet i Altinn-innboksen.
 

--- a/content/authorization/guides/end-user/system-user/_index.nb.md
+++ b/content/authorization/guides/end-user/system-user/_index.nb.md
@@ -1,7 +1,7 @@
 ---
 title: Systemtilgang veiledning for sluttbruker
 linktitle: Systemtilgang
-description: Her under "guider" vil du finne enkle og trinnvise veiledninger som hjelper deg som sluttbruker med å gjennomføre oppgavene du må gjøre for å sette opp å bruke systemtilgang i Altinn.
+description: Her finner du enkle og trinnvise veiledninger som hjelper deg med å sette opp og bruke systemtilgang i Altinn.
 toc: false
 ---
 
@@ -29,12 +29,8 @@ Hver av disse tjenestene krever en fullmakt som kan følge av en bestemt rolle e
 Hvis du ikke har alle fullmaktene som kreves for å gi systemet denne myndigheten, vil Altinn stoppe prosessen. Det holder ikke å ha noen av fullmaktene – du må ha alle som systemet ber om.
 
 **Eksempel:**
-La oss si at systemet ber om tilgang til:
-- **Rolle:** "Regnskapsfører"
-- **Rolle:** "Lønnsinnsender"
+Et fagsystem ber om fullmakt til både en tilgangspakke og en enkelttjeneste. Hvis du bare kan gi fullmakt til tilgangspakken, men ikke enkelttjenesten, kan du ikke godkjenne systemtilgangen. Du må enten få den manglende fullmakten eller sende forespørselen videre til en person som kan gi alle fullmaktene.
 
-Hvis du bare har "Regnskapsfører"-rollen, men ikke "Lønnsinnsender", vil du ikke kunne godkjenne systemtilgangen. Du må da få tildelt den manglende rollen av noen som har fullmakt til å administrere dette i virksomheten – for eksempel daglig leder.
-
-Guidene åpnes i nye faner, slik at du enkelt kan følge dem steg for steg uten å miste oversikten. Velg den guiden som passer for deg og kom i gang med systemtilgang.
+Velg guiden som passer for deg, og kom i gang med systemtilgang.
 
 {{<children />}}

--- a/content/authorization/guides/end-user/system-user/accept-request/_index.nb.md
+++ b/content/authorization/guides/end-user/system-user/accept-request/_index.nb.md
@@ -1,29 +1,30 @@
 ---
 title: Godkjenne systemtilgang
-description: Denne veiledningen viser deg hvordan du som sluttbruker kan godkjenne en systemtilgang du har fått fra en fagsystem-leverandør.
+description: Denne veiledningen viser hvordan du godkjenner en forespørsel om systemtilgang fra en leverandør av fagsystem.
 linktitle: Godkjenne
 weight: 1
 ---
 
-## Godkjenne systemtilgang for eget system
-
-{{% notice warning%}} For å godkjenne en systemtilgang-forespørsel for eget system må innlogget bruker ha rollen Tilgangsstyrer i valgt organisasjon (f.eks har Daglig leder rollen Tilgangsstyrer), samt ha de forespurte fullmaktene.
+{{% notice warning %}}
+For å godkjenne en forespørsel om systemtilgang må du kunne administrere fullmakter for den valgte virksomheten. Det kan du for eksempel gjøre som daglig leder eller med administratorfullmakten **Tilgangsstyring** eller **Hovedadministrator**. Du må også kunne gi fagsystemet alle fullmaktene i forespørselen.
 {{% /notice %}}
 
-1. Her godkjenner en sluttbruker en forespørsel om å opprette en Systemtilgang for eget system. I dette eksemplet mottar DRESS MINST, daglig leder i DISKRET NÆR TIGER AS, en forespørsel om systemtilgang for eget system fra leverandøren SmartCloud. Denne forespørselen må godkjennes i Altinn-portalen. ![Godkjenningsbilde egen systemtilgang](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/standard-request.png)
-2. Etter at forespørselen er godkjent eller avvist, vil sluttbrukeren bli logget ut. Hvis leverandøren har satt opp en verifisert videresending i forespørselen, vil brukeren sendes til leverandørens kvitteringsside. Hvis ikke, blir sluttbrukeren sendt til Altinn sin utloggede side. ![Kvitteringsside egen systemtilgang](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/systemtilgang-receipt-vendor.png)
+## Godkjenne systemtilgang for eget system
+
+1. Her godkjenner en bruker en forespørsel om å opprette en systemtilgang for eget system. I dette eksemplet mottar DRESS MINST, daglig leder i DISKRET NÆR TIGER AS, en forespørsel om systemtilgang for eget system fra leverandøren SmartCloud. Denne forespørselen må godkjennes i Altinn-portalen. ![Godkjenningsbilde egen systemtilgang](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/standard-request.png)
+2. Når forespørselen er åpnet fra leverandørens lenke, blir du logget ut etter at den er godkjent eller avvist. Hvis leverandøren har satt opp en verifisert videresending, blir du sendt til leverandørens kvitteringsside. Hvis ikke, blir du sendt til Altinns utloggede side. Hvis du åpnet forespørselen under **Systemtilganger** i Altinn, går du i stedet tilbake til oversikten og forblir innlogget. ![Kvitteringsside egen systemtilgang](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/systemtilgang-receipt-vendor.png)
 3. Etter godkjenning er systemtilgangen opprettet.
 
 ## Godkjenne systemtilgang for klienter
 
-1. Her godkjenner en sluttbruker en forespørsel om å opprette en Systemtilgang for klienter. For å godkjenne en systemtilgang-forespørsel må innlogget bruker ha rollen Tilgangsstyrer i valgt organisasjon (f.eks har Daglig leder rollen Tilgangsstyrer). I dette eksemplet mottar DRESS MINST, daglig leder i DISKRET NÆR TIGER AS, en forespørsel om systemtilgang for klienter fra leverandøren SmartCloud. Denne forespørselen må godkjennes i Altinn-portalen. ![Godkjenningsbilde systemtilgang for klienter](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/agent-request.png)
-2. Etter at forespørselen er godkjent eller avvist, vil sluttbrukeren bli logget ut. Hvis leverandøren har satt opp en verifisert videresending i forespørselen, vil brukeren sendes til leverandørens kvitteringsside. Hvis ikke, blir sluttbrukeren sendt til Altinn sin utloggede side. ![Kvitteringsside systemtilgang for klienter](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/systemtilgang-receipt-vendor.png)
+1. Her godkjenner en bruker en forespørsel om å opprette en systemtilgang for klienter. I dette eksemplet mottar DRESS MINST, daglig leder i DISKRET NÆR TIGER AS, en forespørsel om systemtilgang for klienter fra leverandøren SmartCloud. Denne forespørselen må godkjennes i Altinn-portalen. ![Godkjenningsbilde systemtilgang for klienter](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/agent-request.png)
+2. Når forespørselen er åpnet fra leverandørens lenke, blir du logget ut etter at den er godkjent eller avvist. Hvis leverandøren har satt opp en verifisert videresending, blir du sendt til leverandørens kvitteringsside. Hvis ikke, blir du sendt til Altinns utloggede side. Hvis du åpnet forespørselen under **Systemtilganger** i Altinn, går du i stedet tilbake til oversikten og forblir innlogget. ![Kvitteringsside systemtilgang for klienter](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/systemtilgang-receipt-vendor.png)
 3. Etter godkjenning er systemtilgangen opprettet. Nå kan [klienter legges til systemtilgangen](/nb/authorization/guides/end-user/system-user/delegate-clients/).
 
 ## Eskalere forespørsel
 
-Hvis brukeren som åpner godkjenningslenken ikke har de nødvendige fullmaktene til å godkjenne opprettelsen, kan vedkommende videresende forespørselen til en bruker med nødvendige fullmakter.
+Hvis brukeren som åpner godkjenningslenken, ikke har de nødvendige fullmaktene, kan vedkommende sende forespørselen videre til en person som har dem.
 
 1. Trykk **Ja, send videre** for å videresende forespørselen til en bruker med nødvendige fullmakter. ![Eskalere forespørsel ved å trykke på send videre-knappen](eskaler_1.png "Eskalere forespørsel ved å trykke på send videre-knappen")
-2. Etter at forespørselen er videresendt, kan du avslutte og eventuelt varsle tilgangsstyreren om at forespørselen er videresendt. ![Avslutte etter å ha sendt forespørselen videre](eskaler_2.png "Avslutte etter å ha sendt forespørselen videre")
-3. Tilgangsstyreren finner den eskalerte forespørselen under **Systemtilganger** i brukerflaten for tilgangsstyring i Altinn. ![Tilgangsstyrer finner eskalert forespørsel og godkjenner](eskaler_3.png "Tilgangsstyrer finner eskalert forespørsel og godkjenner")
+2. Etter at forespørselen er sendt videre, kan du avslutte og eventuelt varsle mottakeren. ![Avslutte etter å ha sendt forespørselen videre](eskaler_2.png "Avslutte etter å ha sendt forespørselen videre")
+3. Mottakeren finner forespørselen under **Systemtilganger** i brukerflaten for tilgangsstyring i Altinn. ![Mottakeren finner forespørselen og godkjenner](eskaler_3.png "Mottakeren finner forespørselen og godkjenner")

--- a/content/authorization/guides/end-user/system-user/create-systemuser/_index.nb.md
+++ b/content/authorization/guides/end-user/system-user/create-systemuser/_index.nb.md
@@ -7,11 +7,11 @@ weight: 3
 
 ## Oppretting av systemtilgang
 
-Oppretting i Altinn-portalen gjøres kun i de tilfellene det ikke er mulig å opprette systemtilgang fra fagsystemet. Det er sluttbrukeren selv (med rollen tilgangsstyrer) som kan opprette systemtilganger i Altinn-portalen. Systemtilgang for kunder kan ikke opprettes via Altinn-portalen. 
+Du kan opprette systemtilgang i Altinn-portalen når det ikke er mulig å gjøre det fra fagsystemet. For å opprette systemtilgangen må du kunne administrere fullmakter for virksomheten. Det kan du for eksempel gjøre som daglig leder eller med administratorfullmakten **Tilgangsstyring** eller **Hovedadministrator**. Systemtilgang for klienter kan ikke opprettes via Altinn-portalen.
 
 ## Slik oppretter du systemtilgang i Altinn-portalen
 
-1. Logg inn til Altinn portalen og åpne [oversikten over systemtilganger](https://am.ui.altinn.no/accessmanagement/ui/systemuser/overview).
+1. Logg inn i Altinn-portalen og åpne [oversikten over systemtilganger](https://am.ui.altinn.no/accessmanagement/ui/systemuser/overview).
 ![Opprett systemtilgang 1](create-systemuser1.png)
 2. Trykk på knappen **Lag ny systemtilgang**.
 ![Opprett systemtilgang 2](create-systemuser2.png)

--- a/content/authorization/guides/end-user/system-user/delegate-clients/_index.nb.md
+++ b/content/authorization/guides/end-user/system-user/delegate-clients/_index.nb.md
@@ -38,6 +38,6 @@ Når du oppretter en systembruker for klientforhold, må du angi hvilke tilgangs
    ![Klientadministrasjon steg 2](klientdelegering2.png)
 3. Trykk **Legg til klienter**.
    ![Klientadministrasjon steg 3](klientdelegering3.png)
-4. Legg til klienter til systemtilgangen, en av gangen, ved å trykke **Legg til i systemtilgang**. I dette eksempelet legger vi til "Revisorkunde AS". Hvis du ikke ser noen klienter i denne modalen, er ikke klientforholdet satt opp. Se [egen guide for å sette opp dette](/nb/authorization/guides/end-user/system-user/setup-client-relationship/).
+4. Legg til klienter i systemtilgangen, én av gangen, ved å trykke **Legg til i systemtilgang**. I dette eksempelet legger vi til "Revisorkunde AS". Hvis en klient ikke vises i modalen, kontroller at klientforholdet finnes, og at virksomheten din har fått fullmakt til alle tilgangspakkene i systemtilgangen, enten direkte eller gjennom en rolle i Enhetsregisteret. Hvis klientforholdet mangler, se [guiden for å sette opp et klientforhold](/nb/authorization/guides/end-user/system-user/setup-client-relationship/).
 5. Trykk **Bekreft og lukk** etter at klientene er lagt til.
    ![Klientadministrasjon steg 4](klientdelegering4.png)

--- a/content/authorization/guides/end-user/system-user/delegate-clients/_index.nb.md
+++ b/content/authorization/guides/end-user/system-user/delegate-clients/_index.nb.md
@@ -36,8 +36,8 @@ Når du oppretter en systembruker for klientforhold, må du angi hvilke tilgangs
    ![Klientadministrasjon steg 1](klientdelegering1.png)
 2. Velg en eksisterende systemtilgang for kunder. I dette eksempelet velger vi systemtilgangen "Revisor klientdelegering".
    ![Klientadministrasjon steg 2](klientdelegering2.png)
-3. Trykk **+ Legg til kunder**  
+3. Trykk **Legg til klienter**.
    ![Klientadministrasjon steg 3](klientdelegering3.png)
 4. Legg til klienter til systemtilgangen, en av gangen, ved å trykke **Legg til i systemtilgang**. I dette eksempelet legger vi til "Revisorkunde AS". Hvis du ikke ser noen klienter i denne modalen, er ikke klientforholdet satt opp. Se [egen guide for å sette opp dette](/nb/authorization/guides/end-user/system-user/setup-client-relationship/).
-5. Trykk **Bekreft og lukk** etter klienter er lagt til.
+5. Trykk **Bekreft og lukk** etter at klientene er lagt til.
    ![Klientadministrasjon steg 4](klientdelegering4.png)

--- a/content/authorization/guides/end-user/system-user/delete-system-user/_index.en.md
+++ b/content/authorization/guides/end-user/system-user/delete-system-user/_index.en.md
@@ -1,23 +1,23 @@
 ---
-title: Delete System User
-description: This guide shows you, as an end-user, how to delete the system user.
-linktitle: Delete System User
+title: Delete System Access
+description: This guide shows how to delete a system access.
+linktitle: Delete System Access
 weight: 3
 ---
 
-# Deleting a System User
+## Deleting a System Access
 
-Only the end-user themselves (with the role 'Access Manager') can delete the system user. When deleted, all associated delegations are automatically removed. As of today, deleting a system user is only possible via the Altinn portal. The user with the role of access manager in the end-user organization must log in to the Altinn portal to perform the deletion. 
+To delete a system access, you must be able to manage authorizations for the organization. For example, you can do this as the general manager or with the administrator permission **Access Management** or **Main Administrator**. All authorizations linked to the system access are removed automatically. Deletion is currently only possible in the Altinn portal.
 
-## How to Delete a System User
+## How to Delete a System Access
 
-1. Log in to the Altinn portal and open the overview of system accesses: https://am.ui.altinn.no/accessmanagement/ui/systemuser/overview
-2. Find and click on the system access to be deleted
+1. Log in to the Altinn portal and open the [overview of system accesses](https://am.ui.altinn.no/accessmanagement/ui/systemuser/overview).
+2. Find and click on the system access to be deleted.
    ![Deletion step 1](delete_1.png)
 
    ![Deletion step 2](delete_2.png)
 
-3. Click delete system access
+3. Click **Delete system access**.
    ![Deletion step 3](delete_3.png)
 
-**Note:** If the system access contains clients, they must be deleted first.
+**Note:** Clients assigned to the system access are also removed when the system access is deleted.

--- a/content/authorization/guides/end-user/system-user/delete-system-user/_index.nb.md
+++ b/content/authorization/guides/end-user/system-user/delete-system-user/_index.nb.md
@@ -1,23 +1,23 @@
 ---
-title: Slett systembruker
-description: Denne veiledningen viser deg hvordan du som sluttbruker kan slette systembruker.
-linktitle: Slett systembruker
+title: Slett systemtilgang
+description: Denne veiledningen viser hvordan du sletter en systemtilgang.
+linktitle: Slett systemtilgang
 weight: 3
 ---
 
-## Sletting av systembruker
+## Sletting av systemtilgang
 
-Det er bare en bruker med fullmakt til tilgangspakken Tilgangsstyring som kan slette systembrukeren. Ved sletting fjernes alle fullmaktene som er knyttet til systembrukeren, automatisk. Per i dag er sletting av systembruker bare mulig via Altinn-portalen.
+For å slette en systemtilgang må du kunne administrere fullmakter for virksomheten. Det kan du for eksempel gjøre som daglig leder eller med administratorfullmakten **Tilgangsstyring** eller **Hovedadministrator**. Ved sletting fjernes alle fullmaktene som er knyttet til systemtilgangen, automatisk. Sletting er foreløpig bare mulig i Altinn-portalen.
 
-## Slik sletter du systembruker
+## Slik sletter du en systemtilgang
 
-1. Logg inn til Altinn portalen og åpne oversikten over systemtilganger: https://am.ui.altinn.no/accessmanagement/ui/systemuser/overview
-2. Finn og klikk på systemtilgangen som skal slettes
+1. Logg inn i Altinn-portalen og åpne [oversikten over systemtilganger](https://am.ui.altinn.no/accessmanagement/ui/systemuser/overview).
+2. Finn og klikk på systemtilgangen som skal slettes.
    ![Sletting steg 1](delete_1.png)
 
    ![Sletting steg 2](delete_2.png)
 
-3. Klikk slett systemtilgang
+3. Klikk **Slett systemtilgang**.
    ![Sletting steg 3](delete_3.png)
 
-**Merk:** Dersom systemtilgangen inneholder kunder, må disse slettes først.
+**Merk:** Klienter som er tilordnet systemtilgangen, fjernes også når systemtilgangen slettes.

--- a/content/authorization/guides/end-user/system-user/setup-client-relationship/_index.nb.md
+++ b/content/authorization/guides/end-user/system-user/setup-client-relationship/_index.nb.md
@@ -12,11 +12,11 @@ Dette gjelder tilfeller der det ikke finnes et etablert klientforhold i Brønnø
 
 ### Forutsetninger
 
-- Du må ha tilgang til Altinn som **Klientadministrator** eller **Daglig leder**.
+- Du må kunne administrere fullmakter for virksomheten som skal gi fullmakten. Det kan du for eksempel gjøre som daglig leder eller med administratorfullmakten **Tilgangsstyring** eller **Hovedadministrator**.
 
 ### Prosess i Altinn-portalen
 
-1. Logg på som daglig leder i virksomheten som skal legges til som kunde i systemtilgang for kunder. I dette eksempelet bruker vi Klientkunde AS som klient.
+1. Logg inn på vegne av virksomheten som skal legges til som klient i systemtilgangen. I dette eksempelet er en daglig leder logget inn på vegne av Klientkunde AS.
 2. Gå til **Brukere** i menyen, hvis du ikke allerede er på denne siden.
    ![Opprett klientforhold steg 1](virksomhetsdelegering1.png)
 3. Trykk på **+ Ny bruker** for å etablere et klientforhold.


### PR DESCRIPTION
## Hva er endret

- korrigerer hvem som kan opprette, godkjenne og slette systemtilgang
- presiserer at alle forespurte fullmakter er nødvendige ved godkjenning
- beskriver korrekt at tilordnede klienter fjernes automatisk når systemtilgangen slettes
- erstatter rolleeksemplet med tilgangspakke og enkelttjeneste, i tråd med forespørselsmodellen
- skiller mellom klientadministrasjon og administrasjon av fullmakter ved etablering av klientforhold
- forklarer at en klient kan mangle fra listen både på grunn av klientforholdet og manglende fullmakt til tilgangspakkene
- oppdaterer knappeteksten til «Legg til klienter» og tar med steget «Ny bruker» i Del og gi fullmakt
- presiserer forskjellen mellom leverandørlenke og behandling fra oversikten over Systemtilganger
- oppdaterer den engelske sletteguiden med samme tilgangskrav og sletteoppførsel

## Grunnlag

Endringene er faktasjekket mot gjeldende implementasjon og grensesnittstekster i altinn-access-management-frontend. Den vedtatte ordlisten for Altinn autorisasjon er brukt ved formulering av rolle-, fullmakt- og tilgangsbegrepene.

## Avgrensning

PR-en endrer sluttbrukerguider under content/authorization/guides/end-user. Hoveddelen gjelder norske guider; den engelske parallellsiden for sletting er også rettet fordi den inneholdt den samme faktafeilen. API-sidene med TBA og eksisterende skjermbilder er ikke endret. PR-en har ingen filoverlapp med #3036.

## Verifisering

- Hugo-bygg fullført med exitkode 0 etter reviewrettingene
- rendret HTML kontrollert for de endrede formuleringene
- git diff --check

Refs #2836