### PR TITLE
docs: faktasjekk engelske sluttbrukerguider for autorisasjon

### DIFF
--- a/content/authorization/guides/end-user/system-user/_index.en.md
+++ b/content/authorization/guides/end-user/system-user/_index.en.md
@@ -1,70 +1,38 @@
 ---
-title: Enduser guide for System user
-linktitle: System user
-description: Find comprehensive information on what an end user must be aware of and the steps to follow to establish a system user integration.
+title: System access guide for end users
+linktitle: System access
+description: Step-by-step guides to setting up and using system access in Altinn.
 toc: false
 ---
 
-### Guide for End User (STADIG KONSERT, Dagligleder of TILFELDIG SUBTIL APE)
+### What is system access?
 
-1. Purchasing the Accounting System
-   - STADIG KONSERT, the Dagligleder of TILFELDIG SUBTIL APE, purchases SmartCloud to manage the company’s tax and fee claims.
-   - The software offers a feature to view the company's total tax and fee claims.
-2. Approving the System User Request
+System access allows you to use a vendor system, such as an accounting or HR system, to retrieve and submit data to public services through Altinn. The vendor system can act on behalf of your own organization or your clients.
 
-   - As part of the software setup, STADIG KONSERT can either create a system user in altinn portal via end user driven system user creation or approve a system user request sent by the SmartCloud.
-   - For example, STADIG KONSERT can create a system user for TILFELDIG SUBTIL APE from altinn portal like below
+This is done through a system user, which is a technical user connected to the vendor system. The system user has the necessary powers of attorney to perform tasks in Altinn without requiring you to log in each time.
 
-     Select the system
-     ![Select system as end user](systemtilgang-1.png)
-     Create the system user
-     ![approve creation of slected system access as end user](systemtilgang-2.png)
-     see the list of system users
-     ![list system users](systemtilgang-4.png)
+#### Two types of system access
 
-     - In this example, STADIG KONSERT is sent to the system user request and must approve in Altinn portal, where STADIG KONSERT grants the necessary access rights to SmartCloud for the "Krav og betalinger" service.
-       ![approve system user request](systemtilgang-approve-1.png)
+- **System access for your own organization:** Used when the vendor system only performs tasks for your own organization, such as submitting an A-melding or VAT return.
+- **System access for clients:** Used when your organization performs tasks on behalf of others, for example as an accounting firm. The clients must grant your organization the necessary powers of attorney in Altinn.
 
-     Once the request is approved, the user is sent to the redirecturl specified in the system user request
-     ![vendor receipt page](systemtilgang-receipt-vendor.png)
+### How do you obtain system access?
 
-     STADIG KONSERT can login to altinn again, to see that the system user that was approved is listed
-     ![system user overview](systemtilgang-overview.png)
+System access can be created in two ways:
 
-   1. Granting the Required Permissions - After STADIG KONSERT's approval, the system access includes the rights to view TILFELDIG SUBTIL APE’s tax and fee claims.
-      STADIG KONSERT has granted authorization to SmartCloud for this specific service and can revoke the access at any time via Altinn.
+- **User-driven creation:** You log in to Altinn and create the system access directly.
+- **Vendor-driven creation:** The vendor system provider sends a request that you approve in Altinn.
 
-#### Guide for End User (DRESs MINST, Client Administrator for TILBAKEHOLDEN USYMMETRISK TIGER AS )
+You must be able to grant the vendor system every power of attorney it requests. If one is missing, the system access cannot be created.
 
-1.  Purchasing the Accounting System
-    - DRESs MINST, the CEO of TILBAKEHOLDEN USYMMETRISK TIGER AS , purchases SmartCloud to manage different services for their clients .
-    - for example, The software offers a feature to view their client company's total tax and fee claims.
-2.  Approving the System User Request
+**What does this mean in practice?**
+When a vendor system requests system access through Altinn, you must approve powers of attorney for specific services, such as submitting an A-melding or retrieving tax returns.
+Each service requires a power of attorney that may follow from a role or an access package in Altinn.
+If you cannot grant all the requested powers of attorney, Altinn stops the process.
 
-    - As part of the software setup, DRESs MINST must approve the system user request from SmartCloud.
-    - In this example, DRESs MINST is sent to the agent system user request and must approve in Altinn portal, where DRESs MINST creates a system user, adds their clients to the system user which grants access to the access package "Regnskapfører med signeringsrettighet" which gives access to one or more services.
+**Example:**
+A vendor system requests a power of attorney for both an access package and a single service. If you can grant the access package but not the single service, you cannot approve the system access. You must either obtain the missing power of attorney or forward the request to someone who can grant all of them.
 
-    Approve agent system user request
+Choose the guide that applies to you to get started with system access.
 
-    ![approve agent system request](systemtilgang-agent-approve.png)
-
-    End user sent to the vendor's receipt page after approve/reject
-    ![system vendor receipt page](systemtilgang-receipt-vendor.png)
-
-    End user logs in to the system to manage the system users
-    ![list of system users](systemtilgang-overview-clientdelegation.png)
-
-    Clicks on the particular system user for managing/viewing. clicks on add client to add clients
-    ![system user overview](systemuser-agent.png)
-
-    Adds the clients
-    ![Add clients to the system user](clientdelegation-addclient.png)
-
-    Clients are added
-    ![clients added to the system user](addclient-added.png)
-
-    Overview of the system user and clients
-    ![system user with clients overview](systemuser-withclients.png)
-
-3.  Granting the Required Permissions - After DRESs MINST's approval and client addition, the system access includes the access package that gives access to various services for clients of TILBAKEHOLDEN USYMMETRISK TIGER AS.
-    DRESs MINST has granted authorization to SmartCloud for this specific access package and can revoke the access at any time via Altinn.
+{{<children />}}

--- a/content/authorization/guides/end-user/system-user/accept-request/_index.en.md
+++ b/content/authorization/guides/end-user/system-user/accept-request/_index.en.md
@@ -1,29 +1,30 @@
 ---
 title: Approve system access
-description: This guide shows you how to approve a system access request you have received from a software vendor.
+description: This guide shows how to approve a system access request from a vendor system provider.
 linktitle: Approve
 weight: 1
 ---
 
-## Approve system access for your own system
-
-{{% notice warning%}} To approve a system access request for your own system, the logged-in user must have the role Tilgangsstyrer in the selected organisation (for example, the managing director has the role Tilgangsstyrer), and must also have the requested permissions.
+{{% notice warning %}}
+To approve a system access request, you must be able to manage powers of attorney for the selected organization. For example, you can do this as the general manager or with the administrator permission **Access Management** or **Main Administrator**. You must also be able to grant the vendor system every power of attorney included in the request.
 {{% /notice %}}
 
-1. In this example, an end user approves a request to create system access for their own system. DRESS MINST, managing director of DISKRET NÆR TIGER AS, receives a request for system access for their own system from the vendor SmartCloud. This request must be approved in the Altinn portal. ![Approval image for own system access](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/standard-request.png)
-2. After the request is approved or rejected, the end user will be logged out. If the vendor has set up a verified redirect in the request, the user will be sent to the vendor's receipt page. If not, the end user will be sent to Altinn's logged-out page. ![Receipt page for own system access](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/systemtilgang-receipt-vendor.png)
+## Approve system access for your own system
+
+1. In this example, a user approves a request to create system access for their own organization. DRESS MINST, general manager of DISKRET NÆR TIGER AS, receives a system access request from the provider SmartCloud. The request must be approved in the Altinn portal. ![Approval of system access for your own organization](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/standard-request.png)
+2. If you opened the request using the provider's link, you are logged out after approving or rejecting it. If the provider configured a verified redirect, you are sent to the provider's receipt page. Otherwise, you are sent to Altinn's logged-out page. If you opened the request under **System accesses** in Altinn, you return to the overview and remain logged in. ![Receipt page for system access](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/systemtilgang-receipt-vendor.png)
 3. After approval, the system access is created.
 
 ## Approve system access for clients
 
-1. In this example, an end user approves a request to create system access for clients. To approve a system access request, the logged-in user must have the role Tilgangsstyrer in the selected organisation (for example, the managing director has the role Tilgangsstyrer). DRESS MINST, managing director of DISKRET NÆR TIGER AS, receives a request for system access for clients from the vendor SmartCloud. This request must be approved in the Altinn portal. ![Approval image for system access for clients](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/agent-request.png)
-2. After the request is approved or rejected, the end user will be logged out. If the vendor has set up a verified redirect in the request, the user will be sent to the vendor's receipt page. If not, the end user will be sent to Altinn's logged-out page. ![Receipt page for system access for clients](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/systemtilgang-receipt-vendor.png)
+1. In this example, a user approves a request to create system access for clients. DRESS MINST, general manager of DISKRET NÆR TIGER AS, receives the request from the provider SmartCloud. The request must be approved in the Altinn portal. ![Approval of system access for clients](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/agent-request.png)
+2. If you opened the request using the provider's link, you are logged out after approving or rejecting it. If the provider configured a verified redirect, you are sent to the provider's receipt page. Otherwise, you are sent to Altinn's logged-out page. If you opened the request under **System accesses** in Altinn, you return to the overview and remain logged in. ![Receipt page for system access for clients](https://docs.altinn.studio/nb/authorization/guides/end-user/system-user/systemtilgang-receipt-vendor.png)
 3. After approval, the system access is created. You can now [add clients to the system access](/en/authorization/guides/end-user/system-user/delegate-clients/).
 
 ## Escalate request
 
-If the user who opens the approval link does not have the necessary permissions to approve the creation, they can forward the request to a user with the necessary permissions.
+If the user who opens the approval link does not have the necessary powers of attorney, they can forward the request to someone who has them.
 
-1. Click **Ja, send videre** to forward the request to a user with the necessary permissions. ![Escalate request by clicking the send forward button](eskaler_1.png "Escalate request by clicking the send forward button")
-2. After forwarding the request, you can close and optionally notify the access manager that the request has been forwarded. ![Close after forwarding the request](eskaler_2.png "Close after forwarding the request")
-3. The access manager finds the escalated request under **Systemtilganger** in the access management interface in Altinn. ![Access manager finds escalated request and approves](eskaler_3.png "Access manager finds escalated request and approves")
+1. Click **Yes, forward request** to forward the request to someone with the necessary powers of attorney. ![Forward the request](eskaler_1.png "Forward the request")
+2. After forwarding the request, you can close the page and optionally notify the recipient. ![Close after forwarding the request](eskaler_2.png "Close after forwarding the request")
+3. The recipient finds the request under **System accesses** in Altinn's access management interface. ![The recipient finds and approves the request](eskaler_3.png "The recipient finds and approves the request")

--- a/content/authorization/guides/end-user/system-user/delegate-clients/_index.en.md
+++ b/content/authorization/guides/end-user/system-user/delegate-clients/_index.en.md
@@ -1,21 +1,19 @@
 ---
-title: Client Delegation
-description:
-linktitle: Client Delegation
+title: Client Administration
+description: This guide shows how to add clients to a system access for clients.
+linktitle: Client Administration
 weight: 2
 ---
 
-## Assigning Clients to a System User
+## Add clients to a system access
 
-If you are creating a system user for client relationships, clients can be assigned either in the Altinn portal or via API. This step does not apply if you are creating a system user for your own system.
+If you use a system access for clients, you can add clients in the Altinn portal. This does not apply to system access for your own organization. To perform services on behalf of another organization through the system access, the client must grant your organization the necessary powers of attorney.
 
-Part of this process can be done using our API. See the [Client Delegation API documentation](/en/api/authentication/systemuserapi/clientdelegation/).
+### Automatic client relationships
 
-## Automatic Client Relationships
+Some client relationships are created automatically based on roles registered in the Central Coordinating Register for Legal Entities (Enhetsregisteret). These relationships may give your organization powers of attorney for certain access packages when you use a system access for clients.
 
-Some client relationships are created automatically based on roles registered in the Central Coordinating Register for Legal Entities (Enhetsregisteret). These relationships give you access to use certain access packages when creating a system user for client relationships.
-
-The table below shows which access packages are available based on your role in the Central Coordinating Register:
+The table below shows which access packages are available based on your role in the Central Coordinating Register for Legal Entities:
 
 | ER Role                                 | Available Access Packages                                                                                                                                                                 | Organization type |
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
@@ -23,17 +21,22 @@ The table below shows which access packages are available based on your role in 
 | **Regnskapsfører** (Accountant)         | `urn:altinn:accesspackage:regnskapsforer-med-signeringsrettighet`<br>`urn:altinn:accesspackage:regnskapsforer-uten-signeringsrettighet`<br>`urn:altinn:accesspackage:regnskapsforer-lonn` | All               |
 | **Forretningsfører** (Business Manager) | `urn:altinn:accesspackage:forretningsforer-eiendom`                                                                                                                                       | ESEK, BRL         |
 
-When creating a system user for client relationships, you must specify which access packages the system user should have access to. These packages must align with the roles you have in the Central Coordinating Register.
+When a system access for clients is created, the access packages it needs are specified. Your organization's powers of attorney for the client must cover these packages.
 
-> **Note:** Access packages with client relationships only work for "AND" cases. This means that if a system user for client relationships has multiple access packages, the client must have **either directly delegated or received delegation through the ER role** for **all** packages for the system user to function. For example: If the system user for client relationships has both the agriculture package and the accountant package, the client must have explicitly delegated the agriculture package (directly delegated) in addition to having received delegation for the accountant package through the ER role (which comes automatically).
+> **Note:** Access packages for client relationships are evaluated as an "AND" condition. If the system access includes several access packages, your organization must have received a power of attorney for **all** of them from the client, either directly or through a role in the Central Coordinating Register for Legal Entities. For example, if the system access includes both the agriculture package and the accountant package, the client must grant the agriculture package directly, while the accountant package may follow automatically from the registered role.
 
-## In the Altinn Portal
+### Prerequisites
 
-1. Go to the overview of system accesses
-2. Select system access
+- You must be able to administer clients in Altinn, for example as **Client Administrator** or **General Manager**.
+- An [approved system access for clients](/en/authorization/guides/end-user/system-user/accept-request/#approve-system-access-for-clients) must exist.
+
+### Process in the Altinn portal
+
+1. Open the [system access overview](https://am.ui.altinn.no/accessmanagement/ui/systemuser/overview). In this example, a general manager is logged in on behalf of DISKRET NÆR TIGER AS.
+2. Select an existing system access for clients.
    ![client delegation step 1](delegate_clients_1.png)
-3. Click "Add clients"
+3. Click **Add clients**.
    ![client delegation step 2](delegate_clients_2.png)
-4. Select clients (one, several, or all)
-5. Click confirm and close
+4. Add clients individually by clicking **Add to system access**, or click **Add all clients**. If a client is not shown, check that the client relationship exists and that your organization has a power of attorney for every access package in the system access, either directly or through a role in the Central Coordinating Register for Legal Entities. If the client relationship is missing, see the [guide to setting up a client relationship](/en/authorization/guides/end-user/system-user/setup-client-relationship/).
+5. Click **Confirm and close**.
    ![client delegation step 3](delegate_clients_3.png)

--- a/content/authorization/guides/end-user/system-user/setup-client-relationship/_index.en.md
+++ b/content/authorization/guides/end-user/system-user/setup-client-relationship/_index.en.md
@@ -1,33 +1,33 @@
 ---
 title: Set up client relationship
-description: This guide shows how an end user can grant authorizations to a system provider. This must be done where a client relationship does not already exist in order to add the client to a system access for clients.
+description: This guide shows how a client grants a service provider power of attorney when no client relationship exists.
 linktitle: Set up client relationship
 weight: 2
 ---
 
-## Client delegation where a client relationship does not already exist
+## Create a client relationship that does not already exist
 
-If you need to delegate clients, but there is no existing client relationship, this relationship must be established before the client can be added to a system access for clients.
-This applies to cases where there is no established client relationship in the Brønnøysund Registers. It is the clients themselves who grant this authorization to the organization that owns the system access.
+If you need to administer clients but no client relationship exists, you must create the relationship before the client can be added to a system access for clients.
+This applies when no client relationship is registered in the Brønnøysund Registers. The client grants the necessary power of attorney to the organization that owns the system access.
 
 ### Prerequisites
 
-- You must have access to Altinn as **Client Administrator** or **Managing Director**.
+- You must be able to manage powers of attorney for the organization granting the power of attorney. For example, you can do this as the general manager or with the administrator permission **Access Management** or **Main Administrator**.
 
 ### Process in the Altinn portal
 
-1. Log in as the Managing Director of the organization that is to be added as a client in a system access for clients. In this example, we use "Klientkunde AS" as the client.
+1. Log in on behalf of the organization that will be added as a client to the system access. In this example, a general manager is logged in on behalf of Klientkunde AS.
 2. Go to **Users** in the menu, if you are not already on this page.
    ![organization delegation 1](virksomhetsdelegering1.png)
-3. Click **+ New user** to establish a client relationship.
+3. Click **New user** to establish a client relationship.
    ![organization delegation 2](virksomhetsdelegering2.png)
-4. Enter the organization number of the organization you want to grant authorization to. In this example, we enter the organization number of "DISKRET NÆR TIGER AS", which we used in the example above.
+4. Enter the organization number of the organization you want to grant power of attorney to. In this example, enter the organization number of DISKRET NÆR TIGER AS.
    ![organization delegation 3](virksomhetsdelegering3.png)
-5. Click **Add organization**. You have now created a relationship between "Klientkunde AS" and "DISKRET NÆR TIGER AS", but without having granted any authorizations to "DISKRET NÆR TIGER AS" yet.
+5. Click **Add organization**. You have now created a relationship between Klientkunde AS and DISKRET NÆR TIGER AS, but DISKRET NÆR TIGER AS has not yet received any powers of attorney.
    ![organization delegation 5](virksomhetsdelegering5.png)
-6. Click **Grant authorization +**. In this example, we want to grant authorization to the access package "Skattegrunnlag" to "DISKRET NÆR TIGER AS", so we search for "Skattegrunnlag".
+6. Click **Give power of attorney**. In this example, grant DISKRET NÆR TIGER AS a power of attorney for the access package "Skattegrunnlag", so search for "Skattegrunnlag".
    ![organization delegation 4](virksomhetsdelegering4.png)
-7. Click **Grant authorization** on the access package "Skattegrunnlag". "DISKRET NÆR TIGER AS" has now been granted authorization to the access package "Skattegrunnlag". You have now established a client relationship that can be used for the system access.
+7. Click **Give power of attorney** for the access package "Skattegrunnlag". DISKRET NÆR TIGER AS now has a power of attorney for this access package, and the client relationship can be used for the system access.
    ![organization delegation 6](virksomhetsdelegering6.png)
 8. After you have established the client relationship through these steps, "Klientkunde AS" can [be added to a system access for clients](/en/authorization/guides/end-user/system-user/delegate-clients/) that is configured with the access package "Skattegrunnlag".
 


### PR DESCRIPTION
## Hva er endret

- erstatter den utdaterte engelske oversiktssiden med den vedtatte strukturen for systemtilgang
- korrigerer krav til administrasjon og fullmakter ved godkjenning, samt utlogging og videresending
- oppdaterer klientadministrasjon med faktiske knapper, mulighet for å legge til alle klienter og vilkårene for at en klient vises
- korrigerer forutsetninger og knappetekster for å etablere et kundeforhold

## Grunnlag

Innholdet er faktasjekket mot implementasjonen i altinn-access-management-frontend og de godkjente norske endringene som ble merget i #3037.

## Avgrensning

Endringen gjelder bare eksisterende engelske sider under content/authorization/guides/end-user/system-user. Den oppretter ikke engelske versjoner av guider som mangler oversettelse, og endrer ikke API-sider, skjermbilder eller andre dokumentasjonsområder.

## Verifisering

- full Hugo-bygg
- kontroll av generert engelsk innhold
- git diff --check

Refs #2836