### PR TITLE
docs: legg til manglende engelske autorisasjonsguider

### DIFF
--- a/content/authorization/guides/end-user/instancedelegation/_index.en.md
+++ b/content/authorization/guides/end-user/instancedelegation/_index.en.md
@@ -1,0 +1,41 @@
+---
+title: Share and give power of attorney for individual messages, forms and dialogs
+linktitle: Share and give power of attorney
+description: Learn how to share individual messages, forms and dialogs from the Altinn inbox and give others power of attorney for them.
+toc: false
+hidden: true
+---
+
+The feature is available from a message or form in the Altinn inbox. To share the item and give the recipient power of attorney, you must:
+
+- have access to the item through an access package, a role or a power of attorney for the single service
+- have received a power of attorney for the access package **Access manager for single messages, forms and dialogs**
+
+![The required access package](./instansdelegering2.png)
+
+If you used the equivalent feature in the old inbox, you will find that the requirements are stricter. Only people with the necessary power of attorney can now share the item and give others power of attorney. Previously, anyone with access to messages and forms in the inbox could do this.
+
+When you click **Give access**, you are taken to the **Share and give power of attorney** page. Here, you can select a person who is already registered or click **New user** to give power of attorney to a new person.
+
+When you give power of attorney to a new person, you must:
+
+- identify the recipient using their national identity number and surname, or their Altinn username and surname
+- select which actions in the service, such as reading or writing, the recipient may perform
+
+![Give power of attorney to a new person](./instansdelegering3.png)
+
+Once you have given the power of attorney, the recipient will find the message or form in the Altinn inbox.
+
+If the recipient has not previously had access to items for the person or organization on whose behalf you are acting, that person or organization will also appear in the party list for the first time.
+
+## Give power of attorney for the access package for individual messages, forms and dialogs
+
+You give power of attorney for the access package **Access manager for single messages, forms and dialogs** in the same way as for other access packages in Altinn.
+
+![Give power of attorney for an access package](./instansdelegering.png)
+
+## Users without the required access package
+
+Users without the required power of attorney see the message **You do not have the authority to share this with others.** They need the access package **Access manager for single messages, forms and dialogs** to share and give power of attorney from the inbox.
+
+![Message shown when the user lacks the required power of attorney](./instansdelegering4.png)

--- a/content/authorization/guides/end-user/system-user/create-systemuser/_index.en.md
+++ b/content/authorization/guides/end-user/system-user/create-systemuser/_index.en.md
@@ -1,0 +1,25 @@
+---
+title: Create system access
+description: This guide shows how an end user can create a system access.
+linktitle: Create system access
+weight: 3
+---
+
+## Create a system access
+
+You can create a system access in the Altinn portal when it is not possible to create it from the vendor system. To create the system access, you must be able to manage powers of attorney for the organization. For example, you can do this as the general manager or with the administrator permission **Access Management** or **Main Administrator**. You cannot create a system access for clients in the Altinn portal.
+
+## Create a system access in the Altinn portal
+
+1. Log in to the Altinn portal and open the [system access overview](https://am.ui.altinn.no/accessmanagement/ui/systemuser/overview).
+   ![Open the system access overview](create-systemuser1.png)
+2. Click **Create new system access**.
+   ![Create a new system access](create-systemuser2.png)
+3. Select the vendor system for which you want to create a system access.
+   ![Select a vendor system](create-systemuser3.png)
+4. Click **Proceed**. You will now see an overview of the powers of attorney the vendor system will receive.
+   ![Review the powers of attorney](create-systemuser4.png)
+5. Click **Create system access**. The new system access will appear in the overview.
+   ![The new system access in the overview](create-systemuser5.png)
+
+Once the system access has been created, the vendor system provider can start using it.


### PR DESCRIPTION
## Hva er endret

- legger til engelsk versjon av guiden for å opprette systemtilgang i Altinn-portalen
- legger til engelsk versjon av guiden for å dele enkeltmeldinger, skjemaer og dialoger og gi fullmakt
- bruker engelske knappetekster og produktnavn fra frontendens språkressurser
- gjør at «Create system access» vises automatisk i guideoversikten via children-kortkoden

## Avgrensning

PR-en legger bare til to engelske Markdown-filer under `content/authorization/guides/end-user`. De eksisterende skjermbildene gjenbrukes uten endringer. Tilgangspakkebeskrivelser og andre dokumentasjonsområder er ikke berørt.

## Verifisering

- full Hugo-bygg
- kontroll av generert engelsk HTML for begge sider
- kontrollert at «Create system access» rendres i children-listen med lenke og beskrivelse
- `git diff --check`

Følger opp #3038.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on sharing individual inbox messages, forms and dialogs, including granting others power of attorney.
  * Documented access requirements and the steps for granting access to existing or new users.
  * Added instructions for creating system access in the Altinn portal, including required permissions and confirmation steps.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->