### PR TITLE
docs: add topic selection to authorization quiz

### DIFF
--- a/content/authorization/getting-started/quiz/questions.en.json
+++ b/content/authorization/getting-started/quiz/questions.en.json
@@ -498,5 +498,105 @@
     "correct": 1,
     "explanation": "The service owner must express the guardianship powers in the access rules, let the guardian select the correct ward and finally check that the guardian has the right power for the action.",
     "source": {"label": "Get started with guardianship", "url": "/en/authorization/getting-started/guardianship/"}
+  },
+  {
+    "id": 51,
+    "category": "Authorizations and access management",
+    "level": "Scenario",
+    "question": "What determines which authorizations Access Management can offer when a user acts on behalf of an organisation?",
+    "options": ["The service, the resource and the authorizations held by the person managing access", "The browser and screen size selected by the user", "How long the organisation has been registered", "Whether the recipient has previously used Altinn"],
+    "correct": 0,
+    "explanation": "Access Management must take into account both the rules for the service or resource and the authorizations held by the person managing access.",
+    "source": {"label": "Access Management", "url": "/en/authorization/what-do-you-get/accessmanagement/"}
+  },
+  {
+    "id": 52,
+    "category": "Authorizations and access management",
+    "level": "Detailed",
+    "question": "What must the service owner do before a new resource can be managed in Access Management?",
+    "options": ["Add the resource manually to the user interface", "Give every user Main Administrator authorization", "Create a Maskinporten scope without registering the resource", "Describe and publish the resource with authorization rules and any access-package assignment"],
+    "correct": 3,
+    "explanation": "Once the resource is published, Altinn can use its authorization rules and access-package assignment when users manage authorizations.",
+    "source": {"label": "Access Management for service owners", "url": "/en/authorization/what-do-you-get/accessmanagement/#for-service-owners"}
+  },
+  {
+    "id": 53,
+    "category": "Authorizations and access management",
+    "level": "Overview",
+    "question": "Which phrase should normally describe the user-facing action of giving another person authority to act on behalf of an organisation?",
+    "options": ["Provision access", "Grant authorization", "Create connection", "Synchronize rights"],
+    "correct": 1,
+    "explanation": "Grant authorization clearly describes the user-facing action. Delegation and connection are useful technical terms for the corresponding API operations and domain model.",
+    "source": {"label": "Access Management", "url": "/en/authorization/what-do-you-get/accessmanagement/"}
+  },
+  {
+    "id": 54,
+    "category": "Authorizations and access management",
+    "level": "Detailed",
+    "question": "An organisation wants to see who it has granted authorizations to. Which direction should the connections lookup represent?",
+    "options": ["Authorizations the organisation has received from others", "Only authorizations granted to system users", "Authorizations granted from the organisation to others", "Only requests the organisation has received"],
+    "correct": 2,
+    "explanation": "When the organisation is the sender, the lookup must show authorizations granted from the organisation to others. In the API, this means the administered party equals from.",
+    "source": {"label": "Access Management API: Retrieve connections", "url": "/en/authorization/guides/system-vendor/access-management/#api-retrieve-connections"}
+  },
+  {
+    "id": 55,
+    "category": "Authorizations and access management",
+    "level": "Detailed",
+    "question": "How can a party selector find the organisations for which the user can actually manage authorizations?",
+    "options": ["Retrieve authorized parties filtered by the altinn_access_management resource", "Display every organisation from the Central Coordinating Register for Legal Entities", "Display only organisations where the user is registered as general manager", "Use the organisation most recently stored in the browser"],
+    "correct": 0,
+    "explanation": "Authorized Parties can be filtered with anyOfResourceIds=altinn_access_management. This returns only parties where the user has rights to manage access.",
+    "source": {"label": "Access Management API: Retrieve authorised parties", "url": "/en/authorization/guides/system-vendor/access-management/#api-retrieve-authorised-parties"}
+  },
+  {
+    "id": 56,
+    "category": "Authorizations and access management",
+    "level": "Scenario",
+    "question": "What should be checked before the user interface allows a user to grant a particular access package?",
+    "options": ["That the recipient signed in on the same day", "That the access package contains more than one service", "That the user is always registered as general manager", "That the user can delegate the access package on behalf of the selected party"],
+    "correct": 3,
+    "explanation": "The delegation check determines whether the logged-in user can delegate the specific access package on behalf of the party being managed.",
+    "source": {"label": "Access Management API: Check delegation eligibility", "url": "/en/authorization/guides/system-vendor/access-management/#api-check-delegation-eligibility-for-access-packages"}
+  },
+  {
+    "id": 57,
+    "category": "Authorizations and access management",
+    "level": "Scenario",
+    "question": "A sent authorization request has status Pending. What can the sender do?",
+    "options": ["Approve the request on behalf of the recipient", "Change the recipient without creating a new request", "Withdraw the request while it has not been processed", "Create the authorization without the recipient processing the request"],
+    "correct": 2,
+    "explanation": "The sender can withdraw a request that has not yet been approved or rejected. The recipient is responsible for approving or rejecting it.",
+    "source": {"label": "Access Management API: Requesting access", "url": "/en/authorization/guides/system-vendor/access-management/#requesting-access-from-another-party"}
+  },
+  {
+    "id": 58,
+    "category": "Authorizations and access management",
+    "level": "Overview",
+    "question": "What happens when the recipient approves an authorization request?",
+    "options": ["The request is archived without any other change", "The underlying authorization is created", "The sender must create the authorization manually afterwards", "The recipient automatically receives Main Administrator authorization"],
+    "correct": 1,
+    "explanation": "When the recipient approves the request, Altinn creates the underlying delegation that implements the authorization.",
+    "source": {"label": "Access Management API: Approve a request", "url": "/en/authorization/guides/system-vendor/access-management/#api-approve-a-received-request"}
+  },
+  {
+    "id": 59,
+    "category": "Authorizations and access management",
+    "level": "Detailed",
+    "question": "A request concerns several rights on one resource. Must the recipient approve every right?",
+    "options": ["No, the recipient can approve a selection of the rights", "Yes, a resource request can never be divided", "No, but only the service owner can select rights", "Yes, unless the recipient has Main Administrator authorization"],
+    "correct": 0,
+    "explanation": "When approving a resource request, the recipient can specify which rights to grant. An empty request body approves all the rights that were requested.",
+    "source": {"label": "Access Management API: Approve a request", "url": "/en/authorization/guides/system-vendor/access-management/#api-approve-a-received-request"}
+  },
+  {
+    "id": 60,
+    "category": "Authorizations and access management",
+    "level": "Detailed",
+    "question": "Why does Access Management UI use a backend for frontend (BFF)?",
+    "options": ["To store every authorization locally in the user interface", "To replace all underlying authorization services", "To let the browser call every underlying API directly", "To expose endpoints shaped around user tasks and hide service topology and access tokens from the browser"],
+    "correct": 3,
+    "explanation": "The BFF gathers orchestration behind endpoints suited to user tasks. This gives fewer browser calls, simpler contracts and one security boundary.",
+    "source": {"label": "Architecture patterns: Backend for frontend", "url": "/en/authorization/reference/system/application-architecture/access-management-ui/patterns/#backend-for-frontend"}
   }
 ]

--- a/content/authorization/getting-started/quiz/questions.json
+++ b/content/authorization/getting-started/quiz/questions.json
@@ -498,5 +498,105 @@
     "correct": 1,
     "explanation": "Tjenesteeieren må uttrykke vergefullmaktene i tilgangsreglene, la vergen velge riktig vergehaver og til slutt kontrollere at vergen har riktig fullmakt for handlingen.",
     "source": {"label": "Kom i gang med vergemål", "url": "/nb/authorization/getting-started/guardianship/"}
+  },
+  {
+    "id": 51,
+    "category": "Fullmakter og tilgangsstyring",
+    "level": "Scenario",
+    "question": "Hva avgjør hvilke fullmakter Tilgangsstyring kan tilby når en bruker handler på vegne av en virksomhet?",
+    "options": ["Tjenesten, ressursen og fullmaktene til den som administrerer tilgangen", "Nettleseren og skjermstørrelsen brukeren har valgt", "Hvor lenge virksomheten har vært registrert", "Om mottakeren tidligere har brukt Altinn"],
+    "correct": 0,
+    "explanation": "Tilgangsstyring må ta hensyn til både reglene for tjenesten eller ressursen og fullmaktene til personen som administrerer tilgangen.",
+    "source": {"label": "Tilgangsstyring", "url": "/nb/authorization/what-do-you-get/accessmanagement/"}
+  },
+  {
+    "id": 52,
+    "category": "Fullmakter og tilgangsstyring",
+    "level": "Detaljert",
+    "question": "Hva må tjenesteeieren gjøre før en ny ressurs kan håndteres i Tilgangsstyring?",
+    "options": ["Legge ressursen manuelt inn i brukergrensesnittet", "Gi alle brukere fullmakt som hovedadministrator", "Opprette et Maskinporten-scope uten å registrere ressursen", "Beskrive og publisere ressursen med autorisasjonsregler og eventuell tilknytning til tilgangspakke"],
+    "correct": 3,
+    "explanation": "Når ressursen er publisert, kan Altinn bruke autorisasjonsreglene og tilknytningen til tilgangspakker når brukerne administrerer fullmakter.",
+    "source": {"label": "Tilgangsstyring for tjenesteeiere", "url": "/nb/authorization/what-do-you-get/accessmanagement/#for-tjenesteeiere"}
+  },
+  {
+    "id": 53,
+    "category": "Fullmakter og tilgangsstyring",
+    "level": "Overordnet",
+    "question": "Hvilken formulering bør normalt brukes når en bruker skal gi en annen person myndighet til å handle på vegne av virksomheten?",
+    "options": ["Delegere rettigheter", "Gi fullmakt", "Opprette tilkobling", "Provisjonere tilgang"],
+    "correct": 1,
+    "explanation": "I brukerrettet tekst skal handlingen normalt beskrives som å gi fullmakt. Delegering kan beholdes i tekniske navn, API-operasjoner og teknisk dokumentasjon.",
+    "source": {"label": "Begreper: Delegere og delegering", "url": "/nb/authorization/getting-started/terms/#delegeredelegering"}
+  },
+  {
+    "id": 54,
+    "category": "Fullmakter og tilgangsstyring",
+    "level": "Detaljert",
+    "question": "En virksomhet vil se hvem den har gitt fullmakter til. Hvilken retning skal oppslaget etter tilkoblinger representere?",
+    "options": ["Fullmakter som virksomheten har mottatt fra andre", "Bare fullmakter som er gitt til systembrukere", "Fullmakter som er gitt fra virksomheten til andre", "Bare forespørsler som virksomheten har mottatt"],
+    "correct": 2,
+    "explanation": "Når virksomheten er avgiver, skal oppslaget vise fullmakter som er gitt fra virksomheten til andre. I API-et betyr dette at parten som administreres, er lik from.",
+    "source": {"label": "Tilgangsstyrings-API: Hente tilkoblinger", "url": "/nb/authorization/guides/system-vendor/access-management/#api-hente-tilkoblinger"}
+  },
+  {
+    "id": 55,
+    "category": "Fullmakter og tilgangsstyring",
+    "level": "Detaljert",
+    "question": "Hvordan kan en aktørvelger finne virksomhetene som brukeren faktisk kan administrere fullmakter for?",
+    "options": ["Hente autoriserte parter filtrert på ressursen altinn_access_management", "Vise alle virksomheter fra Enhetsregisteret", "Vise bare virksomheter der brukeren er registrert som daglig leder", "Bruke virksomheten som sist ble lagret i nettleseren"],
+    "correct": 0,
+    "explanation": "Authorized Parties kan filtreres med anyOfResourceIds=altinn_access_management. Da returneres bare parter der brukeren har rettigheter til å styre tilganger.",
+    "source": {"label": "Tilgangsstyrings-API: Hente autoriserte parter", "url": "/nb/authorization/guides/system-vendor/access-management/#api-hente-autoriserte-parter"}
+  },
+  {
+    "id": 56,
+    "category": "Fullmakter og tilgangsstyring",
+    "level": "Scenario",
+    "question": "Hva bør kontrolleres før brukergrensesnittet lar en bruker gi fullmakt til en bestemt tilgangspakke?",
+    "options": ["At mottakeren har logget inn samme dag", "At tilgangspakken inneholder mer enn én tjeneste", "At brukeren alltid er registrert som daglig leder", "At brukeren kan delegere den aktuelle tilgangspakken på vegne av valgt part"],
+    "correct": 3,
+    "explanation": "Delegeringskontrollen undersøker om den innloggede brukeren kan delegere den konkrete tilgangspakken på vegne av parten som administreres.",
+    "source": {"label": "Tilgangsstyrings-API: Kontrollere delegeringsmulighet", "url": "/nb/authorization/guides/system-vendor/access-management/#api-kontrollere-delegeringsmulighet-for-tilgangspakker"}
+  },
+  {
+    "id": 57,
+    "category": "Fullmakter og tilgangsstyring",
+    "level": "Scenario",
+    "question": "En sendt forespørsel om fullmakt har status Pending. Hva kan avsenderen gjøre?",
+    "options": ["Godkjenne forespørselen på vegne av mottakeren", "Bytte mottaker uten å opprette en ny forespørsel", "Trekke forespørselen så lenge den ikke er behandlet", "Opprette fullmakten uten at mottakeren behandler forespørselen"],
+    "correct": 2,
+    "explanation": "Avsenderen kan trekke en forespørsel som ennå ikke er godkjent eller avvist. Det er mottakeren som kan godkjenne eller avvise den.",
+    "source": {"label": "Tilgangsstyrings-API: Be om fullmakt", "url": "/nb/authorization/guides/system-vendor/access-management/#be-om-fullmakt-fra-en-annen-part"}
+  },
+  {
+    "id": 58,
+    "category": "Fullmakter og tilgangsstyring",
+    "level": "Overordnet",
+    "question": "Hva skjer når mottakeren godkjenner en forespørsel om fullmakt?",
+    "options": ["Forespørselen arkiveres uten andre endringer", "Den underliggende fullmakten blir opprettet", "Avsenderen må opprette fullmakten manuelt etterpå", "Mottakeren får automatisk hovedadministrator"],
+    "correct": 1,
+    "explanation": "Når mottakeren godkjenner forespørselen, oppretter Altinn den underliggende delegeringen som realiserer fullmakten.",
+    "source": {"label": "Tilgangsstyrings-API: Godkjenne en forespørsel", "url": "/nb/authorization/guides/system-vendor/access-management/#api-godkjenne-en-mottatt-forespørsel"}
+  },
+  {
+    "id": 59,
+    "category": "Fullmakter og tilgangsstyring",
+    "level": "Detaljert",
+    "question": "En forespørsel gjelder flere rettigheter på én ressurs. Må mottakeren godkjenne alle rettighetene?",
+    "options": ["Nei, mottakeren kan godkjenne et utvalg av rettighetene", "Ja, en forespørsel om en ressurs kan aldri deles opp", "Nei, men bare tjenesteeieren kan velge rettigheter", "Ja, med mindre mottakeren har fullmakt som hovedadministrator"],
+    "correct": 0,
+    "explanation": "Ved godkjenning av en ressursforespørsel kan mottakeren angi hvilke rettigheter som skal gis. En tom forespørselskropp godkjenner alle rettighetene som ble forespurt.",
+    "source": {"label": "Tilgangsstyrings-API: Godkjenne en forespørsel", "url": "/nb/authorization/guides/system-vendor/access-management/#api-godkjenne-en-mottatt-forespørsel"}
+  },
+  {
+    "id": 60,
+    "category": "Fullmakter og tilgangsstyring",
+    "level": "Detaljert",
+    "question": "Hvorfor bruker Access Management UI en backend for frontend (BFF)?",
+    "options": ["For å lagre alle fullmaktene lokalt i brukergrensesnittet", "For å erstatte alle underliggende autorisasjonstjenester", "For å la nettleseren kontakte alle underliggende API-er direkte", "For å tilby endepunkter tilpasset brukeroppgavene og skjule tjenestetopologi og tilgangstokener for nettleseren"],
+    "correct": 3,
+    "explanation": "BFF-en samler orkestreringen bak endepunkter som passer brukeroppgavene. Det gir færre nettleserkall, enklere kontrakter og en samlet sikkerhetsgrense.",
+    "source": {"label": "Arkitekturmønstre: Backend for frontend", "url": "/nb/authorization/reference/system/application-architecture/access-management-ui/patterns/#backend-for-frontend"}
   }
 ]

--- a/layouts/shortcodes/authorization-quiz.html
+++ b/layouts/shortcodes/authorization-quiz.html
@@ -10,7 +10,7 @@
       <a class="authorization-quiz__back" href="{{ "authorization/getting-started/" | relLangURL }}">{{ if $en }}← Back to Get started{{ else }}← Tilbake til Kom i gang{{ end }}</a>
       <p class="authorization-quiz__eyebrow">Onboarding · {{ if $en }}Altinn Authorization{{ else }}Altinn Autorisasjon{{ end }}</p>
       <h1>{{ if $en }}Test your knowledge{{ else }}Test kunnskapen din{{ end }}</h1>
-      <p class="authorization-quiz__lead">{{ if $en }}Choose a short or full quiz. After each question, you get the correct answer, a detailed explanation and a link to the documentation.{{ else }}Velg en kort eller full test. Du får riktig svar, en faglig forklaring og en lenke til dokumentasjonen etter hvert spørsmål.{{ end }}</p>
+      <p class="authorization-quiz__lead">{{ if $en }}Choose a short, full or topic-based quiz. After each question, you get the correct answer, a detailed explanation and a link to the documentation.{{ else }}Velg en kort, full eller temabasert test. Du får riktig svar, en faglig forklaring og en lenke til dokumentasjonen etter hvert spørsmål.{{ end }}</p>
     </div>
   </header>
 
@@ -24,7 +24,7 @@
         </div>
         <ul class="authorization-quiz__facts" aria-label="{{ if $en }}What the quiz includes{{ else }}Dette får du i testen{{ end }}">
           <li><strong>4</strong><span>{{ if $en }}answer options{{ else }}svaralternativer{{ end }}</span></li>
-          <li><strong data-question-bank-count>50</strong><span>{{ if $en }}questions in the bank{{ else }}spørsmål i banken{{ end }}</span></li>
+          <li><strong data-question-bank-count>60</strong><span>{{ if $en }}questions in the bank{{ else }}spørsmål i banken{{ end }}</span></li>
           <li><strong>7</strong><span>{{ if $en }}subject areas{{ else }}fagområder{{ end }}</span></li>
         </ul>
       </div>
@@ -38,9 +38,35 @@
         <button class="authorization-quiz__mode authorization-quiz__mode--full" type="button" data-start-quiz="all">
           <span class="authorization-quiz__mode-label">{{ if $en }}Complete curriculum{{ else }}Hele pensumet{{ end }}</span>
           <strong>{{ if $en }}Full quiz{{ else }}Full test{{ end }}</strong>
-          <span><span data-full-test-count>50</span> {{ if $en }}questions · about 30 minutes{{ else }}spørsmål · omtrent 30 minutter{{ end }}</span>
+          <span><span data-full-test-count>60</span> {{ if $en }}questions · about 40 minutes{{ else }}spørsmål · omtrent 40 minutter{{ end }}</span>
+        </button>
+        <button class="authorization-quiz__mode authorization-quiz__mode--topic" type="button" data-show-topic-picker aria-expanded="false" aria-controls="authorization-quiz-topic-picker">
+          <span class="authorization-quiz__mode-label">{{ if $en }}Choose subjects{{ else }}Velg fagområder{{ end }}</span>
+          <strong>{{ if $en }}Topic quiz{{ else }}Tematest{{ end }}</strong>
+          <span>{{ if $en }}Focus on one or more of the 7 subject areas{{ else }}Fordyp deg i ett eller flere av de 7 fagområdene{{ end }}</span>
         </button>
       </div>
+
+      <section class="authorization-quiz__topic-picker" id="authorization-quiz-topic-picker" data-topic-picker hidden tabindex="-1" aria-labelledby="authorization-quiz-topic-title">
+        <span class="authorization-quiz__kicker">{{ if $en }}Tailor the quiz{{ else }}Tilpass testen{{ end }}</span>
+        <h3 id="authorization-quiz-topic-title">{{ if $en }}Which subjects do you want to be tested on?{{ else }}Hvilke fagområder vil du testes i?{{ end }}</h3>
+        <p>{{ if $en }}Select one or more subjects. The quiz includes every question in your selection.{{ else }}Velg ett eller flere fagområder. Testen tar med alle spørsmålene i utvalget ditt.{{ end }}</p>
+        <fieldset>
+          <legend class="authorization-quiz__topic-legend">{{ if $en }}Available subjects{{ else }}Tilgjengelige fagområder{{ end }}</legend>
+          <div class="authorization-quiz__topic-options" data-topic-options></div>
+        </fieldset>
+        <div class="authorization-quiz__topic-footer">
+          <p data-topic-summary aria-live="polite">{{ if $en }}Select at least one subject.{{ else }}Velg minst ett fagområde.{{ end }}</p>
+          <div class="authorization-quiz__topic-actions">
+            <button class="authorization-quiz__button authorization-quiz__button--primary" type="button" data-start-topic disabled>
+              {{ if $en }}Start topic quiz{{ else }}Start tematest{{ end }}
+            </button>
+            <button class="authorization-quiz__button authorization-quiz__button--secondary" type="button" data-close-topic>
+              {{ if $en }}Cancel{{ else }}Avbryt{{ end }}
+            </button>
+          </div>
+        </div>
+      </section>
 
       <p class="authorization-quiz__privacy">{{ if $en }}No sign-in. No results are sent or stored.{{ else }}Ingen innlogging. Ingen resultater sendes eller lagres.{{ end }}</p>
     </section>

--- a/static/css/authorization-quiz.css
+++ b/static/css/authorization-quiz.css
@@ -147,7 +147,7 @@
 .authorization-quiz__modes {
   display: grid;
   gap: 18px;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   margin-top: 38px;
 }
 
@@ -188,6 +188,106 @@
 .authorization-quiz__mode > span:last-child {
   color: var(--quiz-muted);
   line-height: 1.4;
+}
+
+.authorization-quiz__mode--topic {
+  background: linear-gradient(145deg, #f5f2ff, #fff);
+}
+
+.authorization-quiz__topic-picker {
+  background: #f7fbfe;
+  border: 1px solid var(--quiz-line);
+  border-radius: 13px;
+  margin-top: 26px;
+  padding: clamp(20px, 4vw, 32px);
+}
+
+.authorization-quiz__topic-picker h3 {
+  color: var(--quiz-ink);
+  font: 26px/1.2 DIN-bold, Arial, sans-serif;
+  margin: 0 0 8px;
+}
+
+.authorization-quiz__topic-picker > p {
+  margin: 0 0 24px;
+}
+
+.authorization-quiz .authorization-quiz__topic-legend {
+  color: var(--quiz-ink);
+  font: 16px/1.3 DIN-bold, Arial, sans-serif;
+  margin-bottom: 12px;
+}
+
+.authorization-quiz__topic-options {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.authorization-quiz__topic-option {
+  align-items: center;
+  background: #fff;
+  border: 2px solid var(--quiz-line);
+  border-radius: 10px;
+  cursor: pointer;
+  display: flex;
+  gap: 12px;
+  min-height: 72px;
+  padding: 13px 15px;
+}
+
+.authorization-quiz__topic-option:hover {
+  border-color: #669dc2;
+}
+
+.authorization-quiz__topic-option:has(input:checked) {
+  background: #eaf4ff;
+  border-color: var(--quiz-action);
+}
+
+.authorization-quiz__topic-option input {
+  flex: 0 0 auto;
+  height: 20px;
+  margin: 0;
+  width: 20px;
+}
+
+.authorization-quiz__topic-text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.authorization-quiz__topic-text strong {
+  font: 16px/1.3 DIN-bold, Arial, sans-serif;
+}
+
+.authorization-quiz__topic-text span {
+  color: var(--quiz-muted);
+  font-size: 14px;
+}
+
+.authorization-quiz__topic-footer {
+  align-items: flex-end;
+  display: flex;
+  gap: 20px;
+  justify-content: space-between;
+  margin-top: 22px;
+}
+
+.authorization-quiz__topic-footer > p {
+  margin: 0;
+}
+
+.authorization-quiz__topic-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.authorization-quiz__topic-actions .authorization-quiz__button {
+  margin-top: 0;
 }
 
 .authorization-quiz__privacy {
@@ -500,8 +600,22 @@
 
   .authorization-quiz__intro-grid,
   .authorization-quiz__modes,
+  .authorization-quiz__topic-options,
   .authorization-quiz__result-hero {
     grid-template-columns: 1fr;
+  }
+
+  .authorization-quiz__topic-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .authorization-quiz__topic-actions {
+    flex-direction: column;
+  }
+
+  .authorization-quiz__topic-actions .authorization-quiz__button {
+    width: 100%;
   }
 
   .authorization-quiz__score {

--- a/static/js/authorization-quiz.js
+++ b/static/js/authorization-quiz.js
@@ -23,6 +23,11 @@
       categoryResult: (category, value, total) => `${category}: ${value} av ${total} riktige`,
       yourAnswer: (answer) => `Ditt svar: ${answer}`,
       rightAnswer: (answer) => `Riktig svar: ${answer}`,
+      topicCount: (count) => `${count} spørsmål`,
+      topicSelection: (subjectCount, questionCount) => `${subjectCount} ${subjectCount === 1 ? 'fagområde' : 'fagområder'} valgt · ${questionCount} spørsmål`,
+      topicEmpty: 'Velg minst ett fagområde.',
+      startTopic: (count) => `Start ${count} spørsmål`,
+      startTopicDefault: 'Start tematest',
       resultBands: {
         low: ['Bygg videre på grunnlaget', 'Bruk temaoversikten og forklaringene under til å velge hva du bør lese først.'],
         foundation: ['Du har grunnlaget', 'Du kjenner de viktigste prinsippene. En målrettet gjennomgang av temaene under vil gi deg et tryggere helhetsbilde.'],
@@ -44,6 +49,11 @@
       categoryResult: (category, value, total) => `${category}: ${value} of ${total} correct`,
       yourAnswer: (answer) => `Your answer: ${answer}`,
       rightAnswer: (answer) => `Correct answer: ${answer}`,
+      topicCount: (count) => `${count} questions`,
+      topicSelection: (subjectCount, questionCount) => `${subjectCount} subject ${subjectCount === 1 ? 'area' : 'areas'} selected · ${questionCount} questions`,
+      topicEmpty: 'Select at least one subject.',
+      startTopic: (count) => `Start ${count} questions`,
+      startTopicDefault: 'Start topic quiz',
       resultBands: {
         low: ['Build on the basics', 'Use the subject overview and explanations below to decide what to read first.'],
         foundation: ['You have the foundation', 'You know the most important principles. A focused review of the subjects below will give you a more confident overall understanding.'],
@@ -159,6 +169,12 @@
     const questionText = root.querySelector('[data-question-text]');
     const questionCategory = root.querySelector('[data-question-category]');
     const questionLevel = root.querySelector('[data-question-level]');
+    const topicPicker = root.querySelector('[data-topic-picker]');
+    const topicModeButton = root.querySelector('[data-show-topic-picker]');
+    const topicOptions = root.querySelector('[data-topic-options]');
+    const topicStartButton = root.querySelector('[data-start-topic]');
+    const topicSummary = root.querySelector('[data-topic-summary]');
+    const topicCloseButton = root.querySelector('[data-close-topic]');
     let activeQuestions = [];
     let answers = [];
     let currentIndex = 0;
@@ -167,6 +183,51 @@
     root.querySelectorAll('[data-question-bank-count], [data-full-test-count]').forEach((element) => {
       element.textContent = questionBank.length;
     });
+    const categoryCounts = new Map();
+    questionBank.forEach((question) => {
+      categoryCounts.set(question.category, (categoryCounts.get(question.category) || 0) + 1);
+    });
+
+    [...categoryCounts.entries()]
+      .sort(([first], [second]) => first.localeCompare(second, language))
+      .forEach(([category, count]) => {
+        const label = createElement('label', 'authorization-quiz__topic-option');
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.value = category;
+        const text = createElement('span', 'authorization-quiz__topic-text');
+        text.append(
+          createElement('strong', '', category),
+          createElement('span', '', labels.topicCount(count)),
+        );
+        label.append(input, text);
+        topicOptions.append(label);
+      });
+
+    const selectedTopics = () => [...topicOptions.querySelectorAll('input:checked')].map((input) => input.value);
+
+    const updateTopicSelection = () => {
+      const topics = selectedTopics();
+      const questionTotal = questionBank.filter((question) => topics.includes(question.category)).length;
+      topicStartButton.disabled = topics.length === 0;
+      topicSummary.textContent = topics.length
+        ? labels.topicSelection(topics.length, questionTotal)
+        : labels.topicEmpty;
+      topicStartButton.textContent = topics.length ? labels.startTopic(questionTotal) : labels.startTopicDefault;
+    };
+
+    const setTopicPicker = (open, returnFocus = false) => {
+      topicPicker.hidden = !open;
+      topicModeButton.setAttribute('aria-expanded', String(open));
+      if (open) {
+        topicPicker.focus({ preventScroll: true });
+        topicPicker.scrollIntoView({ behavior: scrollBehavior, block: 'nearest' });
+      } else if (returnFocus) {
+        topicModeButton.focus();
+      }
+    };
+
+    updateTopicSelection();
 
     const showScreen = (name) => {
       Object.entries(screens).forEach(([screenName, element]) => {
@@ -174,10 +235,13 @@
       });
     };
 
-    const startQuiz = (requestedCount, reuseQuestions = false) => {
+    const startQuiz = (requestedCount, reuseQuestions = false, topics = []) => {
       if (!reuseQuestions) {
-        const count = requestedCount === 'all' ? questionBank.length : Math.min(Number(requestedCount), questionBank.length);
-        activeQuestions = count === questionBank.length ? shuffle(questionBank) : balancedSample(questionBank, count);
+        const availableQuestions = topics.length
+          ? questionBank.filter((question) => topics.includes(question.category))
+          : questionBank;
+        const count = requestedCount === 'all' ? availableQuestions.length : Math.min(Number(requestedCount), availableQuestions.length);
+        activeQuestions = count === availableQuestions.length ? shuffle(availableQuestions) : balancedSample(availableQuestions, count);
       } else {
         activeQuestions = shuffle(activeQuestions);
       }
@@ -327,6 +391,15 @@
     root.querySelectorAll('[data-start-quiz]').forEach((button) => {
       button.addEventListener('click', () => startQuiz(button.dataset.startQuiz));
     });
+    topicModeButton.addEventListener('click', () => setTopicPicker(true));
+    topicOptions.addEventListener('change', updateTopicSelection);
+    topicStartButton.addEventListener('click', () => {
+      const topics = selectedTopics();
+      if (!topics.length) return;
+      setTopicPicker(false);
+      startQuiz('all', false, topics);
+    });
+    topicCloseButton.addEventListener('click', () => setTopicPicker(false, true));
     form.addEventListener('submit', (event) => {
       event.preventDefault();
       submitAnswer();
@@ -343,6 +416,7 @@
     });
     root.querySelector('[data-retry-button]').addEventListener('click', () => startQuiz(activeQuestions.length, true));
     root.querySelector('[data-reset-button]').addEventListener('click', () => {
+      setTopicPicker(false);
       showScreen('start');
       screens.start.focus({ preventScroll: true });
       window.scrollTo({ top: root.offsetTop, behavior: scrollBehavior });


### PR DESCRIPTION
## Summary

- add 10 detailed questions about Access Management UI and delegation in Norwegian and English
- expand the full quiz from 50 to 60 questions
- add a topic quiz where users can select one or more subject areas before starting
- show dynamic question counts and keep the existing short and full quiz modes

The Access Management category now contains 17 questions. Correct answer positions remain evenly distributed across A, B, C and D.

## Validation

- parsed and validated both 60-question JSON banks
- generated 1,000 balanced short quizzes
- verified all 20 new localized source links and anchors
- checked JavaScript syntax
- built the complete Hugo site for Norwegian and English
- ran git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a topic-based quiz mode, allowing learners to select one or more subjects before starting.
  - Added selection summaries, start/cancel controls, and responsive layouts for topic selection.
  - Expanded the quiz bank from 50 to 60 questions and increased the estimated full-quiz duration to around 40 minutes.
  - Added 10 new questions covering authorisations, access management, delegation, requests, and related concepts.
- **Improvements**
  - Updated English and Norwegian labels and improved quiz reset behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->