### PR TITLE
docs: document the ALTINNAPP analyzer rules

### DIFF
--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0001/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0001/_index.en.md
@@ -1,0 +1,15 @@
+---
+title: "ALTINNAPP0001: Altinn-appprosjektet ble ikke funnet"
+tags: [needstranslation]
+description: "Analysen fant ikke prosjektkatalogen og ble ikke kjørt"
+weight: 1
+---
+
+Denne diagnostikken meldes når analysen starter, men ikke finner katalogen til
+appprosjektet. Analysen kjører da ikke, og de øvrige reglene sier ingenting om appen —
+fraværet av andre advarsler betyr i dette tilfellet ikke at alt er i orden.
+
+Kategori `General`, alvorlighetsgrad **advarsel**.
+
+Meldingen ber deg kontakte support. Det er riktig respons: dette er ikke noe som rettes i
+appkoden.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0001/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0001/_index.nb.md
@@ -1,0 +1,14 @@
+---
+title: "ALTINNAPP0001: Altinn-appprosjektet ble ikke funnet"
+description: "Analysen fant ikke prosjektkatalogen og ble ikke kjørt"
+weight: 1
+---
+
+Denne diagnostikken meldes når analysen starter, men ikke finner katalogen til
+appprosjektet. Analysen kjører da ikke, og de øvrige reglene sier ingenting om appen —
+fraværet av andre advarsler betyr i dette tilfellet ikke at alt er i orden.
+
+Kategori `General`, alvorlighetsgrad **advarsel**.
+
+Meldingen ber deg kontakte support. Det er riktig respons: dette er ikke noe som rettes i
+appkoden.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0002/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0002/_index.en.md
@@ -1,0 +1,22 @@
+---
+title: "ALTINNAPP0002: feil i applicationmetadata.json"
+tags: [needstranslation]
+description: "applicationmetadata.json mangler, finnes i flere eksemplarer eller kan ikke leses"
+weight: 2
+---
+
+Denne diagnostikken meldes når `applicationmetadata.json` ikke kan leses slik
+analysen trenger den. Meldingen inneholder årsaken. Tilfellene som rapporteres er:
+
+- filen finnes ikke (`No applicationmetadata.json file found`)
+- filen finnes i flere eksemplarer (`Multiple applicationmetadata.json file found`)
+- datamodellklassen som er oppgitt i filen finnes ikke i kompileringen
+  (`Could not find class ... in the compilation`)
+
+Strukturelle feil og ugyldig JSON rapporteres også her, og ikke av
+deprecation-reglene, som er tause når filen ikke lar seg tolke.
+
+Kategori `Metadata`, alvorlighetsgrad **advarsel**.
+
+Rett filen slik at det finnes nøyaktig én `applicationmetadata.json`, at den er gyldig
+JSON, og at klassen den viser til finnes i prosjektet.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0002/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0002/_index.nb.md
@@ -1,0 +1,21 @@
+---
+title: "ALTINNAPP0002: feil i applicationmetadata.json"
+description: "applicationmetadata.json mangler, finnes i flere eksemplarer eller kan ikke leses"
+weight: 2
+---
+
+Denne diagnostikken meldes når `applicationmetadata.json` ikke kan leses slik
+analysen trenger den. Meldingen inneholder årsaken. Tilfellene som rapporteres er:
+
+- filen finnes ikke (`No applicationmetadata.json file found`)
+- filen finnes i flere eksemplarer (`Multiple applicationmetadata.json file found`)
+- datamodellklassen som er oppgitt i filen finnes ikke i kompileringen
+  (`Could not find class ... in the compilation`)
+
+Strukturelle feil og ugyldig JSON rapporteres også her, og ikke av
+deprecation-reglene, som er tause når filen ikke lar seg tolke.
+
+Kategori `Metadata`, alvorlighetsgrad **advarsel**.
+
+Rett filen slik at det finnes nøyaktig én `applicationmetadata.json`, at den er gyldig
+JSON, og at klassen den viser til finnes i prosjektet.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0600/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0600/_index.en.md
@@ -12,3 +12,6 @@ av app-backend. Meldingen navngir hvilken `dataType` det gjelder.
 Kategori `Deprecation`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
 
 Generer PDF med en PDF-tjenesteoppgave i prosessen i stedet.
+
+Se veiledningen for PDF i appen her: 
+https://docs.altinn.studio/en/altinn-studio/v8/guides/development/pdf/

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0600/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0600/_index.en.md
@@ -1,0 +1,14 @@
+---
+title: "ALTINNAPP0600: enablePdfCreation støttes ikke"
+tags: [needstranslation]
+description: "enablePdfCreation på en dataType er ikke lenger støttet"
+weight: 60
+---
+
+Denne diagnostikken meldes når en `dataType` i `applicationmetadata.json` har
+`enablePdfCreation` satt til `true`. Egenskapen er ikke lenger støttet av denne versjonen
+av app-backend. Meldingen navngir hvilken `dataType` det gjelder.
+
+Kategori `Deprecation`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
+
+Generer PDF med en PDF-tjenesteoppgave i prosessen i stedet.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0600/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0600/_index.nb.md
@@ -11,3 +11,6 @@ av app-backend. Meldingen navngir hvilken `dataType` det gjelder.
 Kategori `Deprecation`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
 
 Generer PDF med en PDF-tjenesteoppgave i prosessen i stedet.
+
+Se veiledningen for PDF i appen her: 
+https://docs.altinn.studio/nb/altinn-studio/v8/guides/development/pdf/

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0600/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0600/_index.nb.md
@@ -1,0 +1,13 @@
+---
+title: "ALTINNAPP0600: enablePdfCreation støttes ikke"
+description: "enablePdfCreation på en dataType er ikke lenger støttet"
+weight: 60
+---
+
+Denne diagnostikken meldes når en `dataType` i `applicationmetadata.json` har
+`enablePdfCreation` satt til `true`. Egenskapen er ikke lenger støttet av denne versjonen
+av app-backend. Meldingen navngir hvilken `dataType` det gjelder.
+
+Kategori `Deprecation`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
+
+Generer PDF med en PDF-tjenesteoppgave i prosessen i stedet.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0601/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0601/_index.en.md
@@ -12,5 +12,8 @@ Kategori `Deprecation`, alvorlighetsgrad **feil**. Regelen stopper altså bygget
 
 Konfigurer eFormidling på en BPMN eFormidling-tjenesteoppgave i stedet.
 
+Apper satt opp før versjon 8.9 må i tillegg fjerne den gamle konfigurasjonen fra
+`appsettings.json`, ikke bare fra `applicationmetadata.json`.
+
 Se veiledningen for eFormidling-tjenesteoppgaven her: 
 https://docs.altinn.studio/en/altinn-studio/v8/guides/development/eformidling/service-task/

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0601/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0601/_index.en.md
@@ -1,0 +1,13 @@
+---
+title: "ALTINNAPP0601: gammel eFormidling-konfigurasjon støttes ikke"
+tags: [needstranslation]
+description: "eFormidling-blokken i applicationmetadata.json er ikke lenger støttet"
+weight: 61
+---
+
+Denne diagnostikken meldes når `applicationmetadata.json` inneholder en
+`eFormidling`-blokk. Blokken er ikke lenger støttet av denne versjonen av app-backend.
+
+Kategori `Deprecation`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
+
+Konfigurer eFormidling på en BPMN eFormidling-tjenesteoppgave i stedet.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0601/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0601/_index.en.md
@@ -11,3 +11,6 @@ Denne diagnostikken meldes når `applicationmetadata.json` inneholder en
 Kategori `Deprecation`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
 
 Konfigurer eFormidling på en BPMN eFormidling-tjenesteoppgave i stedet.
+
+Se veiledningen for eFormidling-tjenesteoppgaven her: 
+https://docs.altinn.studio/en/altinn-studio/v8/guides/development/eformidling/service-task/

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0601/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0601/_index.nb.md
@@ -10,3 +10,6 @@ Denne diagnostikken meldes når `applicationmetadata.json` inneholder en
 Kategori `Deprecation`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
 
 Konfigurer eFormidling på en BPMN eFormidling-tjenesteoppgave i stedet.
+
+Se veiledningen for eFormidling-tjenesteoppgaven her: 
+https://docs.altinn.studio/nb/altinn-studio/v8/guides/development/eformidling/service-task/

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0601/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0601/_index.nb.md
@@ -1,0 +1,12 @@
+---
+title: "ALTINNAPP0601: gammel eFormidling-konfigurasjon støttes ikke"
+description: "eFormidling-blokken i applicationmetadata.json er ikke lenger støttet"
+weight: 61
+---
+
+Denne diagnostikken meldes når `applicationmetadata.json` inneholder en
+`eFormidling`-blokk. Blokken er ikke lenger støttet av denne versjonen av app-backend.
+
+Kategori `Deprecation`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
+
+Konfigurer eFormidling på en BPMN eFormidling-tjenesteoppgave i stedet.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0601/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0601/_index.nb.md
@@ -11,5 +11,8 @@ Kategori `Deprecation`, alvorlighetsgrad **feil**. Regelen stopper altså bygget
 
 Konfigurer eFormidling på en BPMN eFormidling-tjenesteoppgave i stedet.
 
+Apper satt opp før versjon 8.9 må i tillegg fjerne den gamle konfigurasjonen fra
+`appsettings.json`, ikke bare fra `applicationmetadata.json`.
+
 Se veiledningen for eFormidling-tjenesteoppgaven her: 
 https://docs.altinn.studio/nb/altinn-studio/v8/guides/development/eformidling/service-task/

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0700/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0700/_index.en.md
@@ -1,0 +1,21 @@
+---
+title: "ALTINNAPP0700: forseglet standardimplementasjon er erstattet"
+tags: [needstranslation]
+description: "En klasse erstatter et grensesnittmedlem hvis standardimplementasjon er forseglet"
+weight: 70
+---
+
+Denne diagnostikken meldes når en klasse implementerer et grensesnittmedlem som
+allerede har en standardimplementasjon merket som forseglet, og klassens egen
+implementasjon dermed erstatter den.
+
+Et konkret tilfelle: `IServiceTask` har en standardimplementasjon av
+`IPipelineServiceTask.Define` som videresender til `Execute`. En klasse som implementerer
+`IServiceTask` og selv definerer `Define`, erstatter den videresendingen — og da kjører
+`Execute` aldri.
+
+Kategori `Contracts`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
+
+Meldingen navngir klassen, medlemmet som erstattes og typen standardimplementasjonen
+ligger på, og avsluttes med veiledningsteksten som er knyttet til det aktuelle medlemmet.
+For tilfellet over er løsningen å implementere `IPipelineServiceTask` direkte.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0700/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0700/_index.nb.md
@@ -1,0 +1,20 @@
+---
+title: "ALTINNAPP0700: forseglet standardimplementasjon er erstattet"
+description: "En klasse erstatter et grensesnittmedlem hvis standardimplementasjon er forseglet"
+weight: 70
+---
+
+Denne diagnostikken meldes når en klasse implementerer et grensesnittmedlem som
+allerede har en standardimplementasjon merket som forseglet, og klassens egen
+implementasjon dermed erstatter den.
+
+Et konkret tilfelle: `IServiceTask` har en standardimplementasjon av
+`IPipelineServiceTask.Define` som videresender til `Execute`. En klasse som implementerer
+`IServiceTask` og selv definerer `Define`, erstatter den videresendingen — og da kjører
+`Execute` aldri.
+
+Kategori `Contracts`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
+
+Meldingen navngir klassen, medlemmet som erstattes og typen standardimplementasjonen
+ligger på, og avsluttes med veiledningsteksten som er knyttet til det aktuelle medlemmet.
+For tilfellet over er løsningen å implementere `IPipelineServiceTask` direkte.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0701/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0701/_index.en.md
@@ -18,3 +18,6 @@ Kategori `Contracts`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
 Fullfør registreringen, for eksempel med `.WithMetadata<T>()`. Ønsker du bevisst kun det
 inngangspunktet registrerer, skriv en eksplisitt forkastning — `_ = services.AddEFormidling();`
 — som ikke rapporteres.
+
+Se veiledningen for eFormidling-tjenesteoppgaven her: 
+https://docs.altinn.studio/en/altinn-studio/v8/guides/development/eformidling/service-task/

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0701/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0701/_index.en.md
@@ -1,0 +1,20 @@
+---
+title: "ALTINNAPP0701: ufullstendig registrering forkastes"
+tags: [needstranslation]
+description: "Resultatet av et builder-kall forkastes, men er ikke en brukbar registrering alene"
+weight: 71
+---
+
+Denne diagnostikken meldes når resultatet av et kall forkastes, og returtypen er et
+builder-trinn som ikke er en fullstendig registrering i seg selv. Et eksempel er
+`services.AddEFormidling();`, som registrerer alt bortsett fra den ene implementasjonen
+appen selv må levere.
+
+Regelen ser kun på kall der resultatet forkastes helt — der kallet utgjør hele setningen.
+Et builder-objekt som lagres i en variabel eller sendes videre, rapporteres ikke.
+
+Kategori `Contracts`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
+
+Fullfør registreringen, for eksempel med `.WithMetadata<T>()`. Ønsker du bevisst kun det
+inngangspunktet registrerer, skriv en eksplisitt forkastning — `_ = services.AddEFormidling();`
+— som ikke rapporteres.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0701/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0701/_index.nb.md
@@ -17,3 +17,6 @@ Kategori `Contracts`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
 Fullfør registreringen, for eksempel med `.WithMetadata<T>()`. Ønsker du bevisst kun det
 inngangspunktet registrerer, skriv en eksplisitt forkastning — `_ = services.AddEFormidling();`
 — som ikke rapporteres.
+
+Se veiledningen for eFormidling-tjenesteoppgaven her: 
+https://docs.altinn.studio/nb/altinn-studio/v8/guides/development/eformidling/service-task/

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0701/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0701/_index.nb.md
@@ -1,0 +1,19 @@
+---
+title: "ALTINNAPP0701: ufullstendig registrering forkastes"
+description: "Resultatet av et builder-kall forkastes, men er ikke en brukbar registrering alene"
+weight: 71
+---
+
+Denne diagnostikken meldes når resultatet av et kall forkastes, og returtypen er et
+builder-trinn som ikke er en fullstendig registrering i seg selv. Et eksempel er
+`services.AddEFormidling();`, som registrerer alt bortsett fra den ene implementasjonen
+appen selv må levere.
+
+Regelen ser kun på kall der resultatet forkastes helt — der kallet utgjør hele setningen.
+Et builder-objekt som lagres i en variabel eller sendes videre, rapporteres ikke.
+
+Kategori `Contracts`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
+
+Fullfør registreringen, for eksempel med `.WithMetadata<T>()`. Ønsker du bevisst kun det
+inngangspunktet registrerer, skriv en eksplisitt forkastning — `_ = services.AddEFormidling();`
+— som ikke rapporteres.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0800/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0800/_index.en.md
@@ -23,3 +23,6 @@ Kategori `Authorization`, alvorlighetsgrad **feil**. Regelen stopper altså bygg
 
 Gi handlingene til org-subjektet i `config/authorization/policy.xml`, eller kjør
 oppgraderingen fra v8 til v9, som setter inn regelen.
+
+Se regelbiblioteket for hvordan en regel for org-subjektet skrives her: 
+https://docs.altinn.studio/en/altinn-studio/v8/reference/configuration/authorization/rules/

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0800/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0800/_index.en.md
@@ -1,0 +1,25 @@
+---
+title: "ALTINNAPP0800: tjenesteeier mangler nødvendig autorisasjon"
+tags: [needstranslation]
+description: "policy.xml gir ikke apporganisasjonen rettighetene appen bruker på egne vegne"
+weight: 80
+---
+
+Denne diagnostikken meldes når `config/authorization/policy.xml` ikke gir
+apporganisasjonen (org) de handlingene appen utfører mot Storage som tjenesteeier.
+
+Appen lagrer instansdata og prosessoverganger som tjenesteeier, ikke som sluttbruker.
+Storage autoriserer de kallene mot appens egen policy, med `urn:altinn:org` som subjekt.
+En policy som bare gir sluttbrukeren rettigheter — den vanlige formen i v8 — gjør at appen
+ikke får flyttet sin egen prosess videre. Feilen viser seg ellers først når en innbygger
+sender inn.
+
+Hvilke handlinger som kreves følger av oppgavetypene i prosessen: `write` for data,
+`pay` eller `write` for betaling, `confirm` for bekreftelse, `sign` eller `write` for
+signering, `complete` der en tjenesteoppgave markerer instansen som fullført, og `delete`
+der instansen slettes ved prosessens slutt.
+
+Kategori `Authorization`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
+
+Gi handlingene til org-subjektet i `config/authorization/policy.xml`, eller kjør
+oppgraderingen fra v8 til v9, som setter inn regelen.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0800/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0800/_index.nb.md
@@ -22,3 +22,6 @@ Kategori `Authorization`, alvorlighetsgrad **feil**. Regelen stopper altså bygg
 
 Gi handlingene til org-subjektet i `config/authorization/policy.xml`, eller kjør
 oppgraderingen fra v8 til v9, som setter inn regelen.
+
+Se regelbiblioteket for hvordan en regel for org-subjektet skrives her: 
+https://docs.altinn.studio/nb/altinn-studio/v8/reference/configuration/authorization/rules/

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0800/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0800/_index.nb.md
@@ -1,0 +1,24 @@
+---
+title: "ALTINNAPP0800: tjenesteeier mangler nødvendig autorisasjon"
+description: "policy.xml gir ikke apporganisasjonen rettighetene appen bruker på egne vegne"
+weight: 80
+---
+
+Denne diagnostikken meldes når `config/authorization/policy.xml` ikke gir
+apporganisasjonen (org) de handlingene appen utfører mot Storage som tjenesteeier.
+
+Appen lagrer instansdata og prosessoverganger som tjenesteeier, ikke som sluttbruker.
+Storage autoriserer de kallene mot appens egen policy, med `urn:altinn:org` som subjekt.
+En policy som bare gir sluttbrukeren rettigheter — den vanlige formen i v8 — gjør at appen
+ikke får flyttet sin egen prosess videre. Feilen viser seg ellers først når en innbygger
+sender inn.
+
+Hvilke handlinger som kreves følger av oppgavetypene i prosessen: `write` for data,
+`pay` eller `write` for betaling, `confirm` for bekreftelse, `sign` eller `write` for
+signering, `complete` der en tjenesteoppgave markerer instansen som fullført, og `delete`
+der instansen slettes ved prosessens slutt.
+
+Kategori `Authorization`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
+
+Gi handlingene til org-subjektet i `config/authorization/policy.xml`, eller kjør
+oppgraderingen fra v8 til v9, som setter inn regelen.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0801/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0801/_index.en.md
@@ -1,0 +1,23 @@
+---
+title: "ALTINNAPP0801: tjenesteeiers autorisasjon kunne ikke verifiseres"
+tags: [needstranslation]
+description: "Analysen kunne ikke avgjøre statisk om apporganisasjonen har de nødvendige rettighetene"
+weight: 81
+---
+
+Denne diagnostikken meldes der analysen ikke kan avgjøre om apporganisasjonen har
+handlingene den trenger. Den sier ikke at rettighetene mangler — bare at spørsmålet ikke
+lot seg avgjøre ved bygging. Meldingen oppgir årsaken:
+
+- `policy.xml` kunne ikke leses som et XACML-policydokument
+- `policy.xml` inneholder `Deny`-regler, hvis virkning på apporganisasjonen analysen ikke
+  kan evaluere
+- `process.bpmn` kunne ikke tolkes, slik at handlingene prosessen trenger ikke lot seg
+  bestemme
+- rettigheten gis kun gjennom en regel analysen ikke kan avgjøre statisk: en betingelse,
+  en tildeling avgrenset til én enkelt oppgave, eller et attributt eller en match-funksjon
+  den ikke modellerer
+
+Kategori `Authorization`, alvorlighetsgrad **advarsel**.
+
+Kontroller manuelt at apporganisasjonen har de oppgitte handlingene. Se ALTINNAPP0800 for hvilke handlinger appen utfører som tjenesteeier.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0801/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0801/_index.nb.md
@@ -1,0 +1,22 @@
+---
+title: "ALTINNAPP0801: tjenesteeiers autorisasjon kunne ikke verifiseres"
+description: "Analysen kunne ikke avgjøre statisk om apporganisasjonen har de nødvendige rettighetene"
+weight: 81
+---
+
+Denne diagnostikken meldes der analysen ikke kan avgjøre om apporganisasjonen har
+handlingene den trenger. Den sier ikke at rettighetene mangler — bare at spørsmålet ikke
+lot seg avgjøre ved bygging. Meldingen oppgir årsaken:
+
+- `policy.xml` kunne ikke leses som et XACML-policydokument
+- `policy.xml` inneholder `Deny`-regler, hvis virkning på apporganisasjonen analysen ikke
+  kan evaluere
+- `process.bpmn` kunne ikke tolkes, slik at handlingene prosessen trenger ikke lot seg
+  bestemme
+- rettigheten gis kun gjennom en regel analysen ikke kan avgjøre statisk: en betingelse,
+  en tildeling avgrenset til én enkelt oppgave, eller et attributt eller en match-funksjon
+  den ikke modellerer
+
+Kategori `Authorization`, alvorlighetsgrad **advarsel**.
+
+Kontroller manuelt at apporganisasjonen har de oppgitte handlingene. Se ALTINNAPP0800 for hvilke handlinger appen utfører som tjenesteeier.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP9999/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP9999/_index.en.md
@@ -1,0 +1,14 @@
+---
+title: "ALTINNAPP9999: ukjent analysefeil"
+tags: [needstranslation]
+description: "Analysen feilet med en uventet feil"
+weight: 99
+---
+
+Denne diagnostikken meldes når analysen selv feiler med en uventet feil. Meldingen
+inneholder feiltypen og detaljene fra unntaket.
+
+Kategori `General`, alvorlighetsgrad **advarsel**.
+
+Som for ALTINNAPP0001 sier meldingen at du skal kontakte support.
+Regelen peker på analysen, ikke på appkoden.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP9999/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP9999/_index.nb.md
@@ -1,0 +1,13 @@
+---
+title: "ALTINNAPP9999: ukjent analysefeil"
+description: "Analysen feilet med en uventet feil"
+weight: 99
+---
+
+Denne diagnostikken meldes når analysen selv feiler med en uventet feil. Meldingen
+inneholder feiltypen og detaljene fra unntaket.
+
+Kategori `General`, alvorlighetsgrad **advarsel**.
+
+Som for ALTINNAPP0001 sier meldingen at du skal kontakte support.
+Regelen peker på analysen, ikke på appkoden.


### PR DESCRIPTION
Adds reference pages for the nine ALTINNAPP analyzer rules that had no page, so the
`helpLinkUri` on each diagnostic resolves.

## Pages added

| Rule | Category | Severity |
| --- | --- | --- |
| ALTINNAPP0001 | General | Warning |
| ALTINNAPP0002 | Metadata | Warning |
| ALTINNAPP0600 | Deprecation | Error |
| ALTINNAPP0601 | Deprecation | Error |
| ALTINNAPP0700 | Contracts | Error |
| ALTINNAPP0701 | Contracts | Error |
| ALTINNAPP0800 | Authorization | Error |
| ALTINNAPP0801 | Authorization | Warning |
| ALTINNAPP9999 | General | Warning |

`ALTINNAPP0500` is unchanged; it is the template the new pages follow (front matter,
prose style, `_index.nb.md` plus `_index.en.md` with `tags: [needstranslation]`).

## Source of the content

Every rule's category, severity and behaviour is taken from the analyzer source in
`Altinn/altinn-studio`, not from the issue table:

- `src/App/backend/src/Altinn.App.Analyzers/Diagnostics.cs` — ids, categories, severities
  and message formats for all ten rules
- `src/App/backend/src/Altinn.App.Analyzers/AnalyzerReleases.Unshipped.md` — the rule list
- `Deprecations/MetadataDeprecationUtils.cs` — what 0600 and 0601 inspect in
  `applicationmetadata.json`
- `SealedImplementationAnalyzer.cs` — the sealed-default replacement 0700 reports
- `IncompleteBuilderAnalyzer.cs` — the discarded-builder case 0701 reports, and the
  explicit-discard escape hatch
- `Authorization/ServiceOwnerPolicyUtils.cs` and `Authorization/ServiceOwnerActions.cs` —
  the actions 0800 requires per task type, and the four reasons 0801 reports
- `FormDataWrapper/FormDataWrapperAnalyzer.cs` — the three cases 0002 reports

Nothing is asserted that is not in that source.

## The two open questions in the issue

**Which version tree.** v8, as the issue suggested. `DocsRoot` in `Diagnostics.cs` is
`https://docs.altinn.studio/nb/altinn-studio/v8/reference/analysis/`, and the v9 analysis
tree is still `draft: true` and has no `_index.en.md`, so v8 is where the links resolve
today. If the v9 tree is published and `DocsRoot` repointed, the pages should move or be
duplicated there.

**Version availability.** Omitted. `AnalyzerReleases.Shipped.md` is empty and every rule
sits in `Unshipped.md`, so a per-rule "available from" cannot be read off the source. The
existing `ALTINNAPP0500` page states v8.6; the new pages state nothing rather than guess.
Happy to add the values if you can supply them.

## Notes

- `weight` follows the existing page: `ALTINNAPP0500` is `50`, so the new pages use the
  rule number divided by ten (`0600` → `60`, `0800` → `80`, `9999` → `99`), keeping the
  listing in rule order. `0001` and `0002` use `1` and `2`.
- No internal cross-links: neither `relref` nor relative links are used anywhere in
  `content/`, so rules are referenced by id in plain text.
- The parent `analysis/_index` uses `{{<children />}}`, so no index needed updating.
- Only new files; no existing file is touched.

Refs #3026


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added English and Norwegian reference pages for application analysis diagnostics covering missing project or metadata files, invalid configuration, unsupported settings, contract violations, authorisation issues and unexpected analysis failures.
  * Documented diagnostic categories, severity levels, build impact, affected scenarios and recommended remediation steps.
  * Added guidance for resolving PDF, eFormidling, builder registration and Storage authorisation findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->