### PR TITLE
docs: correct spelling in handbook, changelog and events reference

### DIFF
--- a/content/altinn-studio/v8/reference/logic/events/_index.nb.md
+++ b/content/altinn-studio/v8/reference/logic/events/_index.nb.md
@@ -23,7 +23,7 @@ The functionality provided within the template is:
 [Subscring to events is descibed here](subscribing) 
 
 ### Validate subscriptions
-Once the application succesfully have created a subscription, the Event Service will sende a ping event. It's a regular event with a specific type `platform.events.validatesubscription`. There is already a handler for this type registered and the validation should be done without further action required.
+Once the application successfully have created a subscription, the Event Service will sende a ping event. It's a regular event with a specific type `platform.events.validatesubscription`. There is already a handler for this type registered and the validation should be done without further action required.
 
 ### Run custom code when receiving events
 All inbound events are received through the EventsReceiverController on the route `/{org}/{app}/api/v1/eventsreceiver`. The controller uses `IEventHandlerResolver` interface to resolve the the class that should handle the event based on mapping the incoming event type to the EventType property on registered implementations of `IEventHandler`.

--- a/content/community/changelog/app-frontend/v3/whats-new/_index.en.md
+++ b/content/community/changelog/app-frontend/v3/whats-new/_index.en.md
@@ -269,7 +269,7 @@ Patching of external dependencies for week  4 av 2022.
 Issue [#7842](https://github.com/Altinn/altinn-studio/issues/7842).
 
 ## 3.25.0 (2022-01-24) - Added more data sources for dynamic texts
-The feature that adds support for variables in texts have recieved two new data sources. The new sources are the current Instance and ApplicationSettings. ApplicationSettings requires version 4.25.0 or newer of the backend NuGet packages.
+The feature that adds support for variables in texts have received two new data sources. The new sources are the current Instance and ApplicationSettings. ApplicationSettings requires version 4.25.0 or newer of the backend NuGet packages.
 
 Related to issue [#7520](https://github.com/Altinn/altinn-studio/issues/7520).
 

--- a/content/community/changelog/app-nuget/v7/breaking-changes/_index.nb.md
+++ b/content/community/changelog/app-nuget/v7/breaking-changes/_index.nb.md
@@ -667,7 +667,7 @@ The following list is some of the namespaces that have changed that we think wil
 * `Altinn.App.Common.Models` namespace is moved to `Altinn.App.Core.Models`
 * `Altinn.App.PlatformServices.Interface.ICustomPdfHandler` interface is moved and renamed to: `Altinn.App.Core.Features.Pdf.IPdfFormatter`
 
-## Recomended plugin for Visual Studio Code
+## Recommended plugin for Visual Studio Code
 There are a lot of changes to namespaces so we strongly recommend using Visual Studio Code with the C# plugin installed. This will give you code help for importing and locating new or changed interfaces.
 
 Plugin information:<br/>

--- a/content/community/contributing/handbook/azure-storage/queues/_index.en.md
+++ b/content/community/contributing/handbook/azure-storage/queues/_index.en.md
@@ -30,7 +30,7 @@ queue after too many failed attempts.
 4. Click the arrow next to _Move messages_ to specify if all or just a single message should be moved
 5. In the dialogue, select the destination queue and click `Move`
     ![Select destination queue dialogue](select-destination-queue.png)
-6. The messages will be moved immediatly. Check the destination queue to confirm.
+6. The messages will be moved immediately. Check the destination queue to confirm.
 
 
 ## Manually adding messages in queue

--- a/content/community/contributing/handbook/azure-storage/queues/_index.nb.md
+++ b/content/community/contributing/handbook/azure-storage/queues/_index.nb.md
@@ -30,7 +30,7 @@ queue after too many failed attempts.
 4. Click the arrow next to _Move messages_ to specify if all or just a single message should be moved
 5. In the dialogue, select the destination queue and click `Move`
     ![Select destination queue dialogue](select-destination-queue.png)
-6. The messages will be moved immediatly. Check the destination queue to confirm.
+6. The messages will be moved immediately. Check the destination queue to confirm.
 
 
 ## Manually adding messages in queue

--- a/content/community/contributing/handbook/back-end/app-template-and-deps/_index.en.md
+++ b/content/community/contributing/handbook/back-end/app-template-and-deps/_index.en.md
@@ -21,7 +21,7 @@ Duplicate changes in Altinn Studio template
 
 ### Updating Altinn Platform and app template  
 
-1. Code that requires changes in platform are merged in a seperate PR
+1. Code that requires changes in platform are merged in a separate PR
 2. The platform code must be rolled out to all environments.
 3. Then, follow [Updating app template](#updating-app-template-template-files--depentent-supporting-projects) for remaning changes.
 

--- a/content/community/contributing/handbook/back-end/app-template-and-deps/_index.nb.md
+++ b/content/community/contributing/handbook/back-end/app-template-and-deps/_index.nb.md
@@ -21,7 +21,7 @@ Duplicate changes in Altinn Studio template
 
 ### Updating Altinn Platform and app template  
 
-1. Code that requires changes in platform are merged in a seperate PR
+1. Code that requires changes in platform are merged in a separate PR
 2. The platform code must be rolled out to all environments.
 3. Then, follow [Updating app template](#updating-app-template-template-files--depentent-supporting-projects) for remaning changes.
 

--- a/content/community/contributing/handbook/theming/_index.en.md
+++ b/content/community/contributing/handbook/theming/_index.en.md
@@ -19,4 +19,4 @@ to the theme.
 
 ## How to change theme
 
-Changing the theme without having to do alot of changes to the code is post-MVP.
+Changing the theme without having to do a lot of changes to the code is post-MVP.

--- a/content/community/contributing/handbook/theming/_index.nb.md
+++ b/content/community/contributing/handbook/theming/_index.nb.md
@@ -20,4 +20,4 @@ to the theme.
 
 ## How to change theme
 
-Changing the theme without having to do alot of changes to the code is post-MVP.
+Changing the theme without having to do a lot of changes to the code is post-MVP.


### PR DESCRIPTION
Spelling corrections in prose. No front matter, code sample, field name or link target is
changed.

| File | Line | Was | Now |
| --- | --- | --- | --- |
| `content/community/contributing/handbook/back-end/app-template-and-deps/_index.en.md` | 24 | `seperate` | `separate` |
| `content/community/contributing/handbook/back-end/app-template-and-deps/_index.nb.md` | 24 | `seperate` | `separate` |
| `content/community/contributing/handbook/azure-storage/queues/_index.en.md` | 33 | `immediatly` | `immediately` |
| `content/community/contributing/handbook/azure-storage/queues/_index.nb.md` | 33 | `immediatly` | `immediately` |
| `content/community/contributing/handbook/theming/_index.en.md` | 22 | `alot` | `a lot` |
| `content/community/contributing/handbook/theming/_index.nb.md` | 23 | `alot` | `a lot` |
| `content/community/changelog/app-nuget/v7/breaking-changes/_index.nb.md` | 670 | `Recomended` | `Recommended` |
| `content/community/changelog/app-frontend/v3/whats-new/_index.en.md` | 272 | `recieved` | `received` |
| `content/altinn-studio/v8/reference/logic/events/_index.nb.md` | 26 | `succesfully` | `successfully` |

The `.nb.md` files carry English text at these points, so the pairs are corrected together.

Deliberately left alone:

- `streetAdress` in the repeating-group JSON examples under `ux/fields/grouping` — that is a
  field name in a sample data model, not prose.
- `Altinn.App.PlatformServices.Extentions` in the older breaking-changes log — that is the
  historical namespace the entry is telling readers to migrate away from.
- Norwegian `adresse` and its compounds throughout, which are correct.
- `an error is occured` in `handbook/back-end/error-flow` — the sentence needs a grammar
  change, not just a spelling one, so it seemed better left to someone who owns the text.

Front matter still parses as YAML in all nine files.
