### PR TITLE
docs: introduction to v9 and whats new including migraiton guide

### DIFF
--- a/content/altinn-studio/v9/new-in-v9/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/_index.nb.md
@@ -28,7 +28,7 @@ I v9 har vi lagt til en ny prosessmotor (workflow engine). Det er en egen tjenes
 
 Når en prosess skal videre, havner den i kø hos prosessmotoren. Motoren kjører ett steg om gangen og kaller appen din for å gjøre arbeidet. En database holder på tilstanden underveis, så ingenting går tapt om et steg feiler.
 
-### Hva plattformen vinner
+### Hva som blir bedre på plattformen
 
 - Tunge eller trege operasjoner blokkerer ikke lenger brukeren.
 - Prosessmotoren prøver automatisk på nytt når feilen er midlertidig.

--- a/content/altinn-studio/v9/new-in-v9/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/_index.nb.md
@@ -54,7 +54,7 @@ Noen apper beholder `Index.cshtml`. Det gjelder apper som ikke tilbyr brukeroppl
 
 ## Én versjon for frontenden og backenden
 
-Frontenden og backenden i Altinn Studio har nå samme versjonsnummer. Altinn Studio er ett produkt og har derfor én versjon.
+Frontend og backend i Altinn Studio har nå samme versjonsnummer. Altinn Studio er ett produkt og har derfor én versjon.
 
 For deg betyr det:
 

--- a/content/altinn-studio/v9/new-in-v9/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/_index.nb.md
@@ -59,7 +59,7 @@ Frontend og backend i Altinn Studio har nå samme versjonsnummer. Altinn Studio 
 For deg betyr det:
 
 - Du trenger bare å holde styr på ett versjonsnummer.
-- Du slipper å finne ut hvilken backendversjon som passer med hvilken frontendversjon.
+- Du slipper å finne ut hvilken backend-versjon som passer med hvilken frontend-versjon.
 
 ## studioctl er kommandolinjeverktøyet
 

--- a/content/altinn-studio/v9/new-in-v9/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/_index.nb.md
@@ -47,7 +47,7 @@ Når du har oppgradert til v9, har de fleste apper ikke lenger filen `Index.csht
 
 Det gir to fordeler:
 
-- Appen kan forberede mer av informasjonen den trenger med en gang og laster derfor raskere i nettleseren til brukeren.
+- Appen kan forberede mer av informasjonen den trenger med en gang, og laster derfor raskere i nettleseren til brukeren.
 - Vi får større rom til å videreutvikle bibliotekene uten å be deg endre denne filen. Du kan fortsatt legge til egne JavaScript- og CSS-filer hvis du vil overstyre noe.
 
 Noen apper beholder `Index.cshtml`. Det gjelder apper som ikke tilbyr brukeropplevelsen fra app-frontenden vår, apper som har bygget sin egen versjon av den og apper med en helt egen frontend. Har appen din fortsatt filen etter oppgraderingen, går vi ut fra at du vil styre innholdet og frontenden selv.

--- a/content/altinn-studio/v9/new-in-v9/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/_index.nb.md
@@ -10,7 +10,7 @@ tags: [needsReview]
 
 Altinn har bak seg mange år med høyt utviklingstempo og mange leveranser. Nå er plattformen i full drift for alle innbyggere og bedrifter i Norge, og da endrer behovene seg. Vi må stabilisere plattformen og gjøre den klar for mer trafikk og videre utvikling.
 
-v9 gir derfor lite ny funksjonalitet for deg som er tjenesteeier, og lite som sluttbrukeren merker. Til gjengjeld gir versjonen bedre ytelse og stabilitet på områder som betyr mye når du skal forvalte og videreutvikle tjenesten din over tid.
+V9 gir derfor lite ny funksjonalitet for deg som er tjenesteeier, og lite som sluttbrukeren merker. Til gjengjeld gir versjonen bedre ytelse og stabilitet på områder som betyr mye når du skal forvalte og videreutvikle tjenesten din over tid.
 
 {{% notice info %}}
 Skal du oppgradere en app fra v8? Følg [veiledningen for å oppgradere appen fra v8 til v9]({{< relref "/altinn-studio/v9/new-in-v9/upgrade" >}}).

--- a/content/altinn-studio/v9/new-in-v9/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/_index.nb.md
@@ -1,0 +1,74 @@
+---
+draft: true
+title: Hvorfor v9?
+linktitle: Nytt i v9
+description: Bakgrunnen for v9, og hva den nye versjonen betyr for deg som eier eller utvikler en Altinn-app.
+weight: 2
+toc: true
+tags: [needsReview]
+---
+
+Altinn har bak seg mange år med høyt utviklingstempo og mange leveranser. Nå er plattformen i full drift for alle innbyggere og bedrifter i Norge, og da endrer behovene seg. Vi må stabilisere plattformen og gjøre den klar for mer trafikk og videre utvikling.
+
+v9 gir derfor lite ny funksjonalitet for deg som er tjenesteeier, og lite som sluttbrukeren merker. Til gjengjeld gir versjonen bedre ytelse og stabilitet på områder som betyr mye når du skal forvalte og videreutvikle tjenesten din over tid.
+
+{{% notice info %}}
+Skal du oppgradere en app fra v8? Følg [veiledningen for å oppgradere appen fra v8 til v9]({{< relref "/altinn-studio/v9/new-in-v9/upgrade" >}}).
+{{% /notice %}}
+
+## Dette er de største endringene
+
+- En ny prosessmotor kjører prosesser med flere steg asynkront, utenfor appen.
+- Appen bygger frontenden selv, i stedet for å bruke filen `Index.cshtml`.
+- Frontenden og backenden har fått samme versjonsnummer.
+
+## En ny prosessmotor tar seg av flyten
+
+I v9 har vi lagt til en ny prosessmotor (workflow engine). Det er en egen tjeneste som kjører prosesser med flere steg asynkront. Tidligere gjorde appen alt arbeidet synkront, mens brukeren satt og ventet.
+
+Når en prosess skal videre, havner den i kø hos prosessmotoren. Motoren kjører ett steg om gangen og kaller appen din for å gjøre arbeidet. En database holder på tilstanden underveis, så ingenting går tapt om et steg feiler.
+
+### Hva plattformen vinner
+
+- Tunge eller trege operasjoner blokkerer ikke lenger brukeren.
+- Prosessmotoren prøver automatisk på nytt når feilen er midlertidig.
+- Feil blir eksplisitte og synlige. Ingen feil forsvinner i stillhet.
+- Plattformen tåler mer trafikk, fordi flere appinstanser deler på arbeidet.
+
+### Hva det betyr for deg
+
+- Du kan sende tilstand fra ett steg til det neste og dermed bygge sammensatte flyter.
+- Feiler en flyt, kan du starte den på nytt i stedet for at den setter seg fast.
+- Du får full oversikt over flyter som kjører eller har feilet, gjennom dashbord og API.
+
+## Appen bygger frontenden selv
+
+Når du har oppgradert til v9, har de fleste apper ikke lenger filen `Index.cshtml`. I stedet bygger appen HTML-en i koden.
+
+Det gir to fordeler:
+
+- Appen kan forberede mer av informasjonen den trenger med en gang og laster derfor raskere i nettleseren til brukeren.
+- Vi får større rom til å videreutvikle bibliotekene uten å be deg endre denne filen. Du kan fortsatt legge til egne JavaScript- og CSS-filer hvis du vil overstyre noe.
+
+Noen apper beholder `Index.cshtml`. Det gjelder apper som ikke tilbyr brukeropplevelsen fra app-frontenden vår, apper som har bygget sin egen versjon av den og apper med en helt egen frontend. Har appen din fortsatt filen etter oppgraderingen, går vi ut fra at du vil styre innholdet og frontenden selv.
+
+## Én versjon for frontenden og backenden
+
+Frontenden og backenden i Altinn Studio har nå samme versjonsnummer. Altinn Studio er ett produkt og har derfor én versjon.
+
+For deg betyr det:
+
+- Du trenger bare å holde styr på ett versjonsnummer.
+- Du slipper å finne ut hvilken backendversjon som passer med hvilken frontendversjon.
+
+## studioctl er kommandolinjeverktøyet
+
+Du bruker `studioctl` til å logge inn, klone appen, starte en lokal testplattform og kjøre appen på egen maskin. Det er også `studioctl` som oppgraderer appen din fra v8 til v9.
+
+Se [veiledningen for å jobbe med tjenesten lokalt på egen maskin]({{< relref "/altinn-studio/v9/getting-started/development/localtest" >}}) for hvordan du bruker verktøyet i det daglige.
+
+## Neste steg
+
+Er appen din på v8, er dette veien videre:
+
+{{<children />}}

--- a/content/altinn-studio/v9/new-in-v9/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/_index.nb.md
@@ -33,7 +33,7 @@ Når en prosess skal videre, havner den i kø hos prosessmotoren. Motoren kjøre
 - Tunge eller trege operasjoner blokkerer ikke lenger brukeren.
 - Prosessmotoren prøver automatisk på nytt når feilen er midlertidig.
 - Feil blir eksplisitte og synlige. Ingen feil forsvinner i stillhet.
-- Plattformen tåler mer trafikk, fordi flere appinstanser deler på arbeidet.
+- Plattformen tåler mer trafikk, fordi flere app-instanser deler på arbeidet.
 
 ### Hva det betyr for deg
 

--- a/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
@@ -1,0 +1,125 @@
+---
+draft: true
+title: Slik oppgraderer du appen fra v8 til v9
+linktitle: Oppgradere fra v8
+description: Slik oppgraderer du en Altinn-app fra v8 til v9 med studioctl, og dette endrer oppgraderingen i appen din.
+weight: 10
+toc: true
+tags: [needsReview]
+---
+
+`studioctl app upgrade` gjør mesteparten av jobben for deg. Verktøyet går gjennom appen og endrer filene som trenger det.
+
+## Før du starter
+
+- Commit alt du har jobbet med. Oppgraderingen stopper hvis repositoriet har endringer du ikke har committet.
+- Lukk appen i editoren din, for eksempel Visual Studio eller Visual Studio Code.
+- Lag en egen branch, slik at du har et punkt å gå tilbake til hvis du vil forkaste oppgraderingen.
+
+## 1. Installer studioctl
+
+På Mac og Linux:
+
+```bash
+curl -sSL https://altinn.studio/designer/api/v1/studioctl/install.sh | sh
+```
+
+I PowerShell på Windows:
+
+```powershell
+iwr https://altinn.studio/designer/api/v1/studioctl/install.ps1 -useb | iex
+```
+
+Trenger du flere installasjonsvalg, finner du dem i [dokumentasjonen for studioctl](https://github.com/Altinn/altinn-studio/tree/main/src/cli#quick-start-app-developers).
+
+## 2. Kjør oppgraderingen
+
+Gå til rotmappen i prosjektet ditt og kjør:
+
+```bash
+studioctl app upgrade v9
+```
+
+v9 er standardvalget, så `studioctl app upgrade` gjør det samme.
+
+Verktøyet går gjennom appen steg for steg og skriver ut hva det endrer. Les gjennom utskriften. Der oppgraderingen ikke klarer å gjøre en endring selv, sier den fra om hva du må ordne manuelt.
+
+## 3. Kontroller at appen fungerer
+
+Start den lokale testplattformen og kjør appen:
+
+```bash
+studioctl env up
+studioctl app run
+```
+
+Fyll ut skjemaet, gå gjennom hele prosessen og se at PDF-en og kvitteringen blir slik du forventer. Se [veiledningen for å jobbe med tjenesten lokalt på egen maskin]({{< relref "/altinn-studio/v9/getting-started/development/localtest" >}}) hvis du trenger hjelp til det lokale oppsettet.
+
+## Dette endrer oppgraderingen i appen din
+
+Oppgraderingen tar seg av endringene nedenfor. Noen av dem endrer hvordan appen ser ut eller oppfører seg, så les gjennom dem før du publiserer.
+
+### UI-mappen følger nå prosessen
+
+Tidligere hadde `App/ui` én mappe per layoutsett, med sidene i undermappen `layouts`. Filen `layout-sets.json` koblet layoutsettet til steget i prosessen. Den koblingen så du ellers bare igjen i URL-en:
+
+```
+https://ttd.apps.tt02.altinn.no/ttd/rbi-demo-v9/#/instance/51757388/769c64af-0c52-4db6-839c-36f8284ea1d6/Task_1/Side1
+```
+
+Etter oppgraderingen heter hver mappe under `App/ui` det samme som oppgaven i prosessen, og sidene ligger fortsatt under `layouts`:
+
+```
+App/
+  ui/
+    Task_1/
+      layouts/
+        Side1.json
+        Side2.json
+      Settings.json
+    Task_2/
+      layouts/
+        Side1.json
+      Settings.json
+```
+
+Mappestrukturen viser dermed selv hvilket skjema som hører til hvilket steg. Da trenger ikke appen `layout-sets.json` lenger, og oppgraderingen sletter filen.
+
+### PDF-en har fått sitt eget steg i prosessen
+
+Tidligere laget appen PDF-kvitteringen idet brukeren gikk ut av et utfyllingssteg. PDF-en var altså en implisitt del av det steget. Feilet PDF-en, kunne hele innsendingen feile, og det var ikke lett å starte prosessen på nytt fra punktet som gikk galt.
+
+Etter oppgraderingen har appen din en egen PDF-oppgave i prosessen. Det gjør både feilhåndtering og ny kjøring enklere, og du får flere valg:
+
+- Du kan fjerne PDF-oppgaven hvis du ikke vil ha en PDF.
+- Du kan flytte PDF-oppgaven helt bakerst i større prosesser, når PDF-en skal inneholde data fra flere steg.
+
+Standardoppsettet lager en PDF som oppsummerer skjemautfyllingen, ut fra skjemaoppsettet ditt. Du kan overstyre dette og bestemme selv hvordan appen lager PDF-en. Se [veiledningen for å sette opp PDF-generering som systemoppgave]({{< relref "/altinn-studio/v9/develop-a-service/process/pdf" >}}).
+
+{{% notice warning %}}
+**PDF-en kan se annerledes ut etter oppgraderingen.** Tidligere kunne du sette funksjonsflagget `BetaPDFenabled` for å la `Summary2`-komponenten lage PDF-en automatisk. Dette er nå standardinnstillingen, og flagget forsvinner. Har du ikke tilpasset utseendet på PDF-en selv, kan den derfor se annerledes ut.
+
+v9 støtter i tillegg egenskapen `pageBreak` på `Summary2`-komponenter. Det gjorde ikke app-frontend v4. Se etter om PDF-en har fått flere sideskift enn du ønsker.
+{{% /notice %}}
+
+### Regelfilene forsvinner
+
+Vi har lenge anbefalt å sette opp dynamikk i skjemaer med dynamiske uttrykk i JSON-filene, men vi har fortsatt støttet de eldre reglene som er skrevet i JavaScript. Den støtten forsvinner i v9.
+
+Oppgraderingen sletter regelfilene og forsøker samtidig å skrive reglene om til dynamiske uttrykk eller C#-kode. Noen ganger klarer den ikke å konvertere en regel automatisk. Da må du bygge dynamikken selv. Se [introduksjonen til uttrykksspråket]({{< relref "/altinn-studio/v9/develop-a-service/expressions" >}}) hvis du trenger å skrive om en regel.
+
+{{% notice warning %}}
+Gå gjennom uttrykkene oppgraderingen har laget, og test at dynamikken i skjemaet virker som den skal.
+{{% /notice %}}
+
+### Mindre endringer
+
+Oppgraderingen ordner disse endringene uten at du trenger å gjøre noe, men det er greit å kjenne til dem:
+
+- Komponenten `NavigationButtons` viser nå tilbake-knappen som standard. Tidligere måtte du slå den på selv. Vil du skjule knappen, setter du `"showBackButton": false`.
+- Komponenten `OrganisationLookup` heter nå `OrganizationLookup`.
+- Komponenten `Header` heter nå `Heading`.
+
+## Neste steg
+
+Vil du vite mer om hva som ligger bak endringene, kan du lese [om bakgrunnen for v9]({{< relref "/altinn-studio/v9/new-in-v9" >}}).

--- a/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
@@ -14,7 +14,7 @@ tags: [needsReview]
 
 - Commit alt du har jobbet med. Oppgraderingen stopper hvis repositoriet har endringer du ikke har committet.
 - Lukk appen i editoren din, for eksempel Visual Studio eller Visual Studio Code.
-- Lag en egen branch, slik at du har et punkt å gå tilbake til hvis du vil forkaste oppgraderingen.
+- Lag en egen branch, slik at du har et punkt å gå tilbake til hvis du vil angre oppgraderingen.
 
 ## 1. Installer studioctl
 

--- a/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
@@ -99,7 +99,7 @@ Standardoppsettet lager en PDF som oppsummerer skjemautfyllingen, ut fra skjemao
 {{% notice warning %}}
 **PDF-en kan se annerledes ut etter oppgraderingen.** Tidligere kunne du sette funksjonsflagget `BetaPDFenabled` for å la `Summary2`-komponenten lage PDF-en automatisk. Dette er nå standardinnstillingen, og flagget forsvinner. Har du ikke tilpasset utseendet på PDF-en selv, kan den derfor se annerledes ut.
 
-v9 støtter i tillegg egenskapen `pageBreak` på `Summary2`-komponenter. Det gjorde ikke app-frontend v4. Se etter om PDF-en har fått flere sideskift enn du ønsker.
+V9 støtter i tillegg egenskapen `pageBreak` på `Summary2`-komponenter. Det gjorde ikke app-frontend v4. Se etter om PDF-en har fått flere sideskift enn du ønsker.
 {{% /notice %}}
 
 ### Regelfilene forsvinner

--- a/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
@@ -87,7 +87,7 @@ Mappestrukturen viser dermed selv hvilket skjema som hører til hvilket steg. Da
 
 ### PDF-en har fått sitt eget steg i prosessen
 
-Tidligere laget appen PDF-kvitteringen idet brukeren gikk ut av et utfyllingssteg. PDF-en var altså en implisitt del av det steget. Feilet PDF-en, kunne hele innsendingen feile, og det var ikke lett å starte prosessen på nytt fra punktet som gikk galt.
+Tidligere laget appen PDF-kvitteringen samtidig som brukeren gikk ut av et utfyllingssteg. PDF-en var altså en del av det steget. Feilet PDF-en, kunne hele innsendingen feile, og det var ikke lett å starte prosessen på nytt fra punktet som gikk galt.
 
 Etter oppgraderingen har appen din en egen PDF-oppgave i prosessen. Det gjør både feilhåndtering og ny kjøring enklere, og du får flere valg:
 

--- a/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
@@ -8,7 +8,7 @@ toc: true
 tags: [needsReview]
 ---
 
-`studioctl app upgrade` gjør mesteparten av jobben for deg. Verktøyet går gjennom appen og endrer filene som trenger det.
+`studioctl app upgrade` gjør mesteparten av jobben for deg. Verktøyet går gjennom appen og endrer de filene som trenger det.
 
 ## Før du starter
 

--- a/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
@@ -2,7 +2,7 @@
 draft: true
 title: Slik oppgraderer du appen fra v8 til v9
 linktitle: Oppgradere fra v8
-description: Slik oppgraderer du en Altinn-app fra v8 til v9 med studioctl, og dette endrer oppgraderingen i appen din.
+description: Slik oppgraderer du en Altinn-app fra v8 til v9 med studioctl.
 weight: 10
 toc: true
 tags: [needsReview]

--- a/layouts/shortcodes/studio-hub.html
+++ b/layouts/shortcodes/studio-hub.html
@@ -28,6 +28,16 @@
                 Studio →{{ else }}How Altinn Studio works →{{ end }}</a></div>
     </div>
     <section class="authz-section authz-wrap">
+        <div class="authz-banner" style="margin:0 0 44px">
+            <div>
+                <h2>{{ if $nb }}Hva er nytt i v9?{{ else }}What is new in v9?{{ end }}</h2>
+                <p>{{ if $nb }}v9 gir bedre ytelse og stabilitet, ikke ny funksjonalitet. Se hva vi har endret og
+                    hvordan du oppgraderer en app fra v8.{{ else }}v9 brings better performance and stability rather
+                    than new functionality. See what has changed and how to upgrade an app from v8.{{ end }}</p>
+            </div>
+            <a class="authz-btn authz-btn-primary" href="{{ "altinn-studio/v9/new-in-v9/" | relLangURL }}">{{ if $nb
+                }}Se hva som er nytt{{ else }}See what is new{{ end }} →</a>
+        </div>
         <div class="authz-section-head">
             <div>
                 <h2>{{ if $nb }}Start med rollen din{{ else }}Start with your role{{ end }}</h2>


### PR DESCRIPTION
 ## Hva

  Lager v9-landingsside og migrasjonsguide fra v8, og gir dem en synlig
  inngang på v9-forsiden.

  Løser Altinn/altinn-studio#20190.
  
  ## Sider

  | Side | Sti | Type |
  |---|---|---|
  | Hvorfor v9? | `v9/new-in-v9/` | Forklaring |
  | Slik oppgraderer du appen fra v8 til v9 | `v9/new-in-v9/upgrade/` | Veiledning |.


Jeg har også lagt inn en inngang til v9 direkte på forsiden. Jeg er usikker på om vi ønsker det, men for meg ga det mening at etablerte brukere får en rask vei inn.
<img width="2026" height="1139" alt="image" src="https://github.com/user-attachments/assets/266ea5a3-a043-4609-a585-58b8451541c7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localised banner to the Altinn Studio hub highlighting v9 updates and linking to the overview.

* **Documentation**
  * Added Norwegian documentation covering asynchronous workflows, frontend and backend versioning, frontend build changes and the `studioctl` command-line tool.
  * Added step-by-step guidance for upgrading apps from v8 to v9, including prerequisites, verification and key migration changes such as process-based UI organisation and updated rule handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->