### PR TITLE
Fiks v8-lenker i v9 der v9-innhold allerede finnes (lavthengende frukt)

### DIFF
--- a/content/altinn-studio/v9/develop-a-service/look-and-feel/subform/backend-manual/_index.en.md
+++ b/content/altinn-studio/v9/develop-a-service/look-and-feel/subform/backend-manual/_index.en.md
@@ -9,7 +9,7 @@ This documentation is a work in progess. Subforms are currently in preview-relea
 
 Subforms are contained in a subform table. Let us go through configuring a subform table and the subform contained within.
 
-1. [Create a data model](/nb/altinn-studio/v9/develop-a-service/reference/data/data-modeling/) for the subform.
+1. [Create a data model](/en/altinn-studio/v8/reference/data/data-modeling/) for the subform.
 2. You should now see the three files under `App/model`. The c# class, the json schema and the xsd.
 3. Set [appLogic.allowInSubform](/en/api/models/app-metadata/#applicationlogic) to **true** in **applicationMetadata.json**.
 4. Create a folder under **App/ui** with your desired subform name.

--- a/content/altinn-studio/v9/develop-a-service/look-and-feel/subform/backend-manual/_index.en.md
+++ b/content/altinn-studio/v9/develop-a-service/look-and-feel/subform/backend-manual/_index.en.md
@@ -9,7 +9,7 @@ This documentation is a work in progess. Subforms are currently in preview-relea
 
 Subforms are contained in a subform table. Let us go through configuring a subform table and the subform contained within.
 
-1. [Create a data model](/en/altinn-studio/v8/reference/data/data-modeling/) for the subform.
+1. [Create a data model](/nb/altinn-studio/v9/develop-a-service/reference/data/data-modeling/) for the subform.
 2. You should now see the three files under `App/model`. The c# class, the json schema and the xsd.
 3. Set [appLogic.allowInSubform](/en/api/models/app-metadata/#applicationlogic) to **true** in **applicationMetadata.json**.
 4. Create a folder under **App/ui** with your desired subform name.

--- a/content/altinn-studio/v9/develop-a-service/look-and-feel/subform/backend-manual/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/look-and-feel/subform/backend-manual/_index.nb.md
@@ -3,7 +3,7 @@ draft: true
 hidden: true
 ---
 
-1. [Opprett en datamodell](/nb/altinn-studio/v8/reference/data/data-modeling/) for underskjemaet.
+1. [Opprett en datamodell](/nb/altinn-studio/v9/develop-a-service/reference/data/data-modeling/) for underskjemaet.
 2. Du skal nå se tre filer under `App/model`: klassen i C#, JSON-schema og XSD.
 3. Sett [appLogic.allowInSubform](/nb/api/models/app-metadata/#applicationlogic) til **true** i **applicationMetadata.json**.
 4. Opprett en mappe under **App/ui** med det navnet du vil ha på underskjemaet.

--- a/content/altinn-studio/v9/develop-a-service/process/flowcontrol/_index.en.md
+++ b/content/altinn-studio/v9/develop-a-service/process/flowcontrol/_index.en.md
@@ -94,7 +94,7 @@ If an applications process has a confirmation step where it is possible to rejec
 <bpmn:sequenceFlow id="Flow_g1_end" sourceRef="Gateway_1" targetRef="EndEvent" />
 ```
 
-In the example above there is defined two actions in _Task_2_ confirm and reject. [Read more about actions](/en/altinn-studio/v8/reference/process/tasks/)
+In the example above there is defined two actions in _Task_2_ confirm and reject. [Read more about actions](/en/altinn-studio/v9/develop-a-service/reference/process/tasks/)
 
 What we want to accomplish is to make the process engine choose _Flow_g1_t1_ if the user performs action _reject_ and _Flow_g1_end_ if action performed was _confirm…
 

--- a/content/altinn-studio/v9/develop-a-service/process/flowcontrol/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/process/flowcontrol/_index.nb.md
@@ -93,7 +93,7 @@ Hvis en applikasjonsprosess har et bekreftelsessteg kan du avvise dataene og sen
 <bpmn:sequenceFlow id="Flow_g1_end" sourceRef="Gateway_1" targetRef="EndEvent" />
 ```
 
-I eksempelet ovenfor er det definert to handlinger i _Task_2_: `confirm` og `reject`. [Les mer om handlinger](/nb/altinn-studio/v8/reference/process/tasks/)
+I eksempelet ovenfor er det definert to handlinger i _Task_2_: `confirm` og `reject`. [Les mer om handlinger](/nb/altinn-studio/v9/develop-a-service/reference/process/tasks/)
 
 Prosessmotoren skal velge _Flow_g1_t1_ hvis brukeren utfører handlingen _reject_ og _Flow_g1_end_ hvis handlingen var _confirm_.
 

--- a/content/altinn-studio/v9/develop-a-service/reference/configuration/messagebox/create-copy/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/configuration/messagebox/create-copy/_index.nb.md
@@ -13,7 +13,7 @@ Hovedhensikten med **Lag ny kopi**-funksjonaliteten er å gjøre det enkelt for 
 
 {{%notice info%}}
 Lag ny kopi-funksjonaliteten ble introdusert i versjon 7.9.0 av nuget-pakkene.
-[Les hvordan du oppdaterer nugetreferanser for appen din](/nb/altinn-studio/v8/guides/administration/maintainance/dependencies/).
+[Les hvordan du oppdaterer nugetreferanser for appen din](/nb/altinn-studio/v9/manage-a-service/maintainance/dependencies/#nuget).
 {{% /notice%}}
 
 ## Konfigurasjon

--- a/content/altinn-studio/v9/develop-a-service/reference/configuration/stateless/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/configuration/stateless/_index.nb.md
@@ -116,7 +116,7 @@ Appens frontend leser konfigurasjonen fra `applicationmetadata.json` og forstår
 {{%notice warning%}}
 OBS! Skjemakomponenter som påvirker prosess (knapp for innsending eller instansiering) er ikke støttet for anonyme brukere!
 
-**MERK:** For å bruke denne funksjonaliteten må du bruke versjon >= 5.1.0 av [nuget-pakkene](/nb/altinn-studio/v8/guides/administration/maintainance/dependencies#nuget) `Altinn.App.PlatformServices`, `Altinn.App.Common` og `Altinn.App.Api`.
+**MERK:** For å bruke denne funksjonaliteten må du bruke versjon >= 5.1.0 av [nuget-pakkene](/nb/altinn-studio/v9/manage-a-service/maintainance/dependencies/#nuget) `Altinn.App.PlatformServices`, `Altinn.App.Common` og `Altinn.App.Api`.
 
 {{%/notice%}}
 
@@ -433,7 +433,7 @@ Videre i eksempelet vil betegnelsen *bruker* være synonymt med en virksomhet re
 
 Dette er helt ny funksjonalitet. Oppsett må gjøres manuelt inntil videre og vil ikke være støttet i Altinn Studio.
 
-**MERK:** For å bruke denne funksjonaliteten må du bruke versjon >= 4.17.2 av [nuget-pakkene](/nb/altinn-studio/v8/guides/administration/maintainance/dependencies#nuget) `Altinn.App.PlatformServices`, `Altinn.App.Common` og `Altinn.App.Api`.
+**MERK:** For å bruke denne funksjonaliteten må du bruke versjon >= 4.17.2 av [nuget-pakkene](/nb/altinn-studio/v9/manage-a-service/maintainance/dependencies/#nuget) `Altinn.App.PlatformServices`, `Altinn.App.Common` og `Altinn.App.Api`.
 
 {{%/notice%}}
 

--- a/content/altinn-studio/v9/develop-a-service/reference/process/flowcontrol/_index.en.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/process/flowcontrol/_index.en.md
@@ -94,7 +94,7 @@ If an applications process has a confirmation step where it is possible to rejec
 <bpmn:sequenceFlow id="Flow_g1_end" sourceRef="Gateway_1" targetRef="EndEvent" />
 ```
 
-In the example above there is defined two actions in _Task_2_ confirm and reject. [Read more about actions](/en/altinn-studio/v8/reference/process/tasks/)
+In the example above there is defined two actions in _Task_2_ confirm and reject. [Read more about actions](/en/altinn-studio/v9/develop-a-service/reference/process/tasks/)
 
 What we want to accomplish is to make the process engine choose _Flow_g1_t1_ if the user performs action _reject_ and _Flow_g1_end_ if action performed was _confirm…
 

--- a/content/altinn-studio/v9/develop-a-service/reference/process/flowcontrol/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/process/flowcontrol/_index.nb.md
@@ -94,7 +94,7 @@ Hvis en applikasjonsprosess har et bekreftelsessteg kan du avvise dataene og sen
 <bpmn:sequenceFlow id="Flow_g1_end" sourceRef="Gateway_1" targetRef="EndEvent" />
 ```
 
-I eksempelet ovenfor er det definert to handlinger i _Task_2_: `confirm` og `reject`. [Les mer om handlinger](/nb/altinn-studio/v8/reference/process/tasks/)
+I eksempelet ovenfor er det definert to handlinger i _Task_2_: `confirm` og `reject`. [Les mer om handlinger](/nb/altinn-studio/v9/develop-a-service/reference/process/tasks/)
 
 Prosessmotoren skal velge _Flow_g1_t1_ hvis brukeren utfører handlingen _reject_ og _Flow_g1_end_ hvis handlingen var _confirm_.
 

--- a/content/altinn-studio/v9/develop-a-service/reference/process/tasks/signing/_index.en.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/process/tasks/signing/_index.en.md
@@ -305,7 +305,7 @@ If it should be possible to decline signing and, for example send the instance b
 
 This is then added to the authorization rule, and a separate `ActionButton` is defined that is associated with the `reject` action.
 
-See [Controlling process flow](/en/altinn-studio/v8/reference/process/flowcontrol/) for more information.
+See [Controlling process flow](/en/altinn-studio/v9/develop-a-service/reference/process/flowcontrol/) for more information.
 
 
 ### Signing object stored when user signs

--- a/content/altinn-studio/v9/develop-a-service/reference/process/tasks/signing/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/process/tasks/signing/_index.nb.md
@@ -304,7 +304,7 @@ Hvis du vil at signereren skal kunne avslå å signere og for eksempel sende ins
 
 Du legger denne til i autorisasjonsregelen og setter opp en egen ActionButton som knyttes til handlingen `reject`.
 
-Se [Slik styrer du prosessflyten](/nb/altinn-studio/v8/reference/process/flowcontrol/) for mer informasjon.
+Se [Slik styrer du prosessflyten](/nb/altinn-studio/v9/develop-a-service/reference/process/flowcontrol/) for mer informasjon.
 
 ### Slik lagres signaturobjektet når brukeren signerer
 

--- a/content/altinn-studio/v9/examples-and-patterns/multi-app-solution/instructions/app-a/_index.en.md
+++ b/content/altinn-studio/v9/examples-and-patterns/multi-app-solution/instructions/app-a/_index.en.md
@@ -35,13 +35,13 @@ We recommend using the _confirm_ step type, and that is what this guide uses.
 To add steps and extend the app process, you must update `process.bpmn` and `policy.xml`.
 
 1. You will find examples of how to customise the `process.bpmn` file, where the app process is defined, in
-   the [process documentation](/nb/altinn-studio/v8/reference/configuration/process).
+   the [process documentation](/nb/altinn-studio/v9/develop-a-service/reference/configuration/process).
    <br><br>When using the _confirm_ step type, you must allow going back to a previous step type, which also means
    that you need to use _exclusive gateways_. Read more about exclusive
-   gateways [here](/nb/altinn-studio/v8/reference/configuration/process/exclusive-gateways).
+   gateways [here](/nb/altinn-studio/v9/develop-a-service/reference/configuration/process/exclusive-gateways).
 2. The `policy.xml` file, where the authorisation rules are defined, needs updates so that you can perform read and write operations
    on the new step. <br><br>See [XACML policy](/nb/authorization/reference/xacml),
-   [policy editor](/nb/altinn-studio/v8/reference/configuration/authorization)
+   [policy editor](/nb/altinn-studio/v9/develop-a-service/reference/configuration/authorization)
    and [Guidelines for authorisation rules](/nb/altinn-studio/v8/reference/configuration/authorization/guidelines_authorization)
    for details. Most apps allow this by default with the current template.
 
@@ -58,7 +58,7 @@ There is no built-in way in Altinn to trigger this behaviour, which means you mu
 
 The general approach for an Altinn app to perform custom operations is to implement code on
 certain hooks, which are predefined functions in the app backend.
-Read about how to add this custom code [here](/nb/altinn-studio/v8/reference/configuration/process/pre-post-hooks).
+Read about how to add this custom code [here](/nb/altinn-studio/v9/develop-a-service/reference/configuration/process/pre-post-hooks).
 
 1. If the file does not already exist, create a file to implement the custom code that runs at the end
    of a step: `ProcessTaskEnd.cs`. In the file, implement the code that creates the instance object that will be used as
@@ -88,7 +88,7 @@ Read about how to add this custom code [here](/nb/altinn-studio/v8/reference/con
    ```
 
 2. To actually perform the request to create the instance, you must add a client. See
-   the [consume documentation](/nb/altinn-studio/v8/reference/api/consume#implementere-klient) for an example of how
+   the [consume documentation](/nb/altinn-studio/v9/develop-a-service/reference/api/consume#implementere-klienten) for an example of how
    you can add such a client to the app. A suitable name for the client used in this context could be,
    for example, `AppInstantiationClient`. In addition to the instructions in the referenced documentation, the
    constructor needs additional configuration for the HttpClient. Add the following code to the constructor to add
@@ -135,7 +135,7 @@ Read about how to add this custom code [here](/nb/altinn-studio/v8/reference/con
 
 3. In the `ProcessTaskEnd.cs` file, add the new _AppInstantiationClient_ to the `ProcessTaskEnd` class in the same way
    as the _CountryClient_ is added to the `DataProcessingHandler` class
-   in the [consume documentation](/nb/altinn-studio/v8/reference/api/consume#benytte-klient-i-applogikk).
+   in the [consume documentation](/nb/altinn-studio/v9/develop-a-service/reference/api/consume#bruke-klient-i-app-logikk).
    Then call the method that triggers the request in the appInstantiationClient like this:
 
    ```csharp
@@ -189,7 +189,7 @@ You can control certain data in app B in several ways, where you can utilise one
   the corresponding value in the `prefill` field of the instance template that you created in
   the [Trigger creation of app B](#triggering-creation-of-app-b) section above.
 - **Alt 2:** If the intention is to manipulate the texts in the Altinn inbox for instances of app B,
-  use [_presentation fields_](/nb/altinn-studio/v8/reference/configuration/messagebox/presentationfields).
+  use [_presentation fields_](/nb/altinn-studio/v9/develop-a-service/reference/configuration/messagebox/presentationfields/).
 
 - **Alt 3:** Add data as binary data by sending a POST request to the instance of app B.
 

--- a/content/altinn-studio/v9/examples-and-patterns/multi-app-solution/instructions/app-a/_index.nb.md
+++ b/content/altinn-studio/v9/examples-and-patterns/multi-app-solution/instructions/app-a/_index.nb.md
@@ -35,13 +35,13 @@ Vi anbefaler å bruke stegtypen _confirm_, og det er det denne veilederen bruker
 For å legge til steg og utvide appprosessen, må du oppdatere `process.bpmn` og `policy.xml`.
 
 1. Du finner eksempler på hvordan du tilpasser filen `process.bpmn`, der appprosessen er definert, i
-   [prosessdokumentasjonen](/nb/altinn-studio/v8/reference/configuration/process).
+   [prosessdokumentasjonen](/nb/altinn-studio/v9/develop-a-service/reference/configuration/process).
    <br><br>Når du bruker stegtypen _confirm_, må du tillate å gå tilbake til en tidligere stegtype, noe som også betyr
    at du må bruke _exclusive gateways_. Les mer om exclusive
-   gateways [her](/nb/altinn-studio/v8/reference/configuration/process/exclusive-gateways).
+   gateways [her](/nb/altinn-studio/v9/develop-a-service/reference/configuration/process/exclusive-gateways).
 2. Filen `policy.xml`, der autorisasjonsreglene er definert, trenger oppdateringer slik at du kan utføre lese- og skriveoperasjoner
    på det nye steget. <br><br>Se [XACML-policy](/nb/authorization/reference/xacml),
-   [policyredigerer](/nb/altinn-studio/v8/reference/configuration/authorization)
+   [policyredigerer](/nb/altinn-studio/v9/develop-a-service/reference/configuration/authorization)
    og [Retningslinjer for autorisasjonsregler](/nb/altinn-studio/v8/reference/configuration/authorization/guidelines_authorization)
    for detaljer. De fleste apper tillater dette som standard med gjeldende mal.
 
@@ -58,7 +58,7 @@ Det er ingen innebygd måte i Altinn for å utløse denne atferden, noe som bety
 
 Den generelle tilnærmingen for at en Altinn-app skal utføre egendefinerte operasjoner, er å implementere kode på
 visse hooks, som er forhåndsdefinerte funksjoner i app-backend.
-Les om hvordan du legger til denne egendefinerte koden [her](/nb/altinn-studio/v8/reference/configuration/process/pre-post-hooks).
+Les om hvordan du legger til denne egendefinerte koden [her](/nb/altinn-studio/v9/develop-a-service/reference/configuration/process/pre-post-hooks).
 
 1. Hvis filen ikke allerede finnes, opprett en fil for å implementere den egendefinerte koden som kjører på slutten
    av et steg: `ProcessTaskEnd.cs`. I filen implementerer du koden som oppretter instansobjektet som blir brukt som
@@ -88,7 +88,7 @@ Les om hvordan du legger til denne egendefinerte koden [her](/nb/altinn-studio/v
    ```
 
 2. For å faktisk utføre forespørselen for å opprette instansen, må du legge til en klient. Se
-   [konsumer dokumentasjonen](/nb/altinn-studio/v8/reference/api/consume#implementere-klient) for et eksempel på hvordan
+   [konsumer dokumentasjonen](/nb/altinn-studio/v9/develop-a-service/reference/api/consume#implementere-klienten) for et eksempel på hvordan
    du kan legge til en slik klient i appen. Et passende navn for klienten som brukes i denne konteksten kan for
    eksempel være `AppInstantiationClient`. I tillegg til instruksjonene i den refererte dokumentasjonen, trenger
    konstruktøren ytterligere konfigurasjon for HttpClient. Legg til følgende kode i konstruktøren for å legge til
@@ -135,7 +135,7 @@ Les om hvordan du legger til denne egendefinerte koden [her](/nb/altinn-studio/v
 
 3. I filen `ProcessTaskEnd.cs` legger du til den nye _AppInstantiationClient_ i klassen `ProcessTaskEnd` på samme måte
    som _CountryClient_ legges til i klassen `DataProcessingHandler`
-   i [konsumer dokumentasjonen](/nb/altinn-studio/v8/reference/api/consume#benytte-klient-i-applogikk).
+   i [konsumer dokumentasjonen](/nb/altinn-studio/v9/develop-a-service/reference/api/consume#bruke-klient-i-app-logikk).
    Kall deretter metoden som utløser forespørselen i appInstantiationClient slik:
 
    ```csharp
@@ -189,7 +189,7 @@ Du kan kontrollere visse data i app B på flere måter, der du kan utnytte en el
   den tilsvarende verdien i `prefill`-feltet til instansmalen som du opprettet i
   [Utløs opprettelsen av app B](#utløse-opprettelse-av-app-b)-delen over.
 - **Alt 2:** Hvis intensjonen er å manipulere tekstene i Altinn-innboksen for instanser av app B,
-  bruk [_presentasjonsfelt_](/nb/altinn-studio/v8/reference/configuration/messagebox/presentationfields).
+  bruk [_presentasjonsfelt_](/nb/altinn-studio/v9/develop-a-service/reference/configuration/messagebox/presentationfields/).
 
 - **Alt 3:** Legg til data som binære data ved å sende en POST-forespørsel til instansen av app B.
 

--- a/content/altinn-studio/v9/manage-a-service/monitor-and-instrument/_index.en.md
+++ b/content/altinn-studio/v9/manage-a-service/monitor-and-instrument/_index.en.md
@@ -109,7 +109,7 @@ Here is a brief overview of visualising the telemetry instrumented above.
 
 ###  Running locally 
 
-When running locally using [localtest](/en/altinn-studio/v8/guides/development/local-dev/), a monitoring stack consisting of Grafana and OpenTelemetry Collector 
+When running locally using [localtest](/en/altinn-studio/v9/getting-started/development/localtest/local-dev/), a monitoring stack consisting of Grafana and OpenTelemetry Collector 
 can be provisioned along side localtest and Platform APIs. [See the localtest README for more info](https://github.com/Altinn/app-localtest/blob/main/README.md).
 
 Localtest monitoring setup currently contains a Grafana instance with ASP.NET Core dashboards and a preview Altinn app dashboard.

--- a/content/altinn-studio/v9/manage-a-service/monitoring/_index.en.md
+++ b/content/altinn-studio/v9/manage-a-service/monitoring/_index.en.md
@@ -20,7 +20,7 @@ Configuration of custom rules and alerts is not currently available for service 
 but we aim to support this during autumn 2024.
 {{% /notice %}}
 
-See [user guide for instrumentation and monitoring](/nb/altinn-studio/v8/guides/administration/monitor-and-instrument/) to get started in your app.
+See [user guide for instrumentation and monitoring](/en/altinn-studio/v9/manage-a-service/monitor-and-instrument/) to get started in your app.
 
 This documentation contains the necessary information to support app developers and service owners in
 operating, monitoring, and instrumenting applications on the Altinn 3 platform.

--- a/content/altinn-studio/v9/manage-a-service/monitoring/_index.nb.md
+++ b/content/altinn-studio/v9/manage-a-service/monitoring/_index.nb.md
@@ -20,7 +20,7 @@ Konfigurasjon av egendefinerte regler og varsler er for øyeblikket ikke tilgjen
 men vi jobber med å støtte dette.
 {{% /notice %}}
 
-Se [brukerveiledning for instrumentering og overvåking](/nb/altinn-studio/v8/guides/administration/monitor-and-instrument/) for å komme i gang i din app.
+Se [brukerveiledning for instrumentering og overvåking](/nb/altinn-studio/v9/manage-a-service/monitor-and-instrument/) for å komme i gang i din app.
 
 Denne dokumentasjonen inneholder nødvendig informasjon for å støtte apputviklere og tjenesteeiere i å
 drifte, overvåke og instrumentere applikasjoner på Altinn 3-plattformen.

--- a/content/altinn-studio/v9/manage-a-service/monitoring/visualisation/_index.en.md
+++ b/content/altinn-studio/v9/manage-a-service/monitoring/visualisation/_index.en.md
@@ -36,7 +36,7 @@ an end user's experience. Debugging and alerting make Application Insights a val
     The Test Developer role grants access to Application Insights for apps in TT02, and the Production Developer role grants access
     to apps in production.
 
-    [See here how to request the role](/nb/altinn-studio/v8/guides/administration/access-management/apps/)
+    [See here how to request the role](/en/altinn-studio/v9/manage-a-service/access-management/apps/)
 
 - **General overview of Application Insights features**
     Application Insights has several features available.

--- a/content/altinn-studio/v9/manage-a-service/monitoring/visualisation/_index.nb.md
+++ b/content/altinn-studio/v9/manage-a-service/monitoring/visualisation/_index.nb.md
@@ -36,7 +36,7 @@ brukeropplevelsen til en sluttbruker. Feilsøking og varsling gjør Application 
     Test Developer-rollen gir tilgang til Application Insights for apper i TT02, og Production Developer-rollen gir tilgang
     til apper i produksjon.
 
-    [Her kan du se hvordan du ber om rollen](/nb/altinn-studio/v8/guides/administration/access-management/apps/)
+    [Her kan du se hvordan du ber om rollen](/nb/altinn-studio/v9/manage-a-service/access-management/apps/)
 
 - **Generell oversikt over Application Insights-funksjoner**
     Application Insights har flere funksjoner tilgjengelig.


### PR DESCRIPTION
## Hva er gjort

Bytter ut lenker til v8 med v9-ekvivalenter i de tilfellene der innholdet allerede er migrert til v9 (bekreftet via `aliases`-oppføringer og/eller innholdssammenligning). Ingen tekstlig omskriving her — kun lenkemål.

### Endrede lenker
- `access-management/apps/` og `.../studio/` (Studio-tilganger)
- `monitor-and-instrument/` og `local-dev/`
- `maintainance/dependencies/` (nuget-oppdatering), 3 forekomster
- `reference/configuration/process/`, `/exclusive-gateways/`, `/pre-post-hooks/`, `/authorization/`
- `reference/api/consume/` (ankernavn oppdatert til nye overskrifter etter språkvask: `#implementere-klienten`, `#bruke-klient-i-app-logikk`)
- `reference/configuration/messagebox/presentationfields/`
- `reference/process/tasks/` og `reference/process/flowcontrol/` — sistnevnte var en **selv-referanse-bug** i `reference/process/tasks/signing/` (lenket til v8-utgaven av sin egen nabofil)
- `reference/data/data-modeling/`

### Ikke endret (bevisst)
- `reference/configuration/authorization/guidelines_authorization` peker fortsatt til v8 — v9-ekvivalenten finnes kun i `new-from-v8/`-parkeringsområdet, ikke i endelig IA-plassering ennå.
- Store seksjoner (`reference/logic/*`, `reference/ux/*`, referanse-versjonen av access-management) er ikke migrert til v9 ennå, så v8-lenkene der er fortsatt riktige.

Verifisert med fullt `hugo --buildDrafts`-bygg uten lenkefeil.

Del av en større opprydding før v9-lansering (kartlegging: 206 v8-lenker i 86 v9-filer). Se separat issue for resten av arbeidet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated v9 documentation links across English and Norwegian guides.
  - Replaced outdated v8 references for data modelling, actions, process flow, signing, dependencies, monitoring, local development and access management.
  - Corrected links and anchors in the multi-app solution instructions.
  - Improved navigation between related v9 guidance pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->