### PR TITLE
Document automatic payment advancement from Nets callbacks

### DIFF
--- a/content/altinn-studio/v8/guides/development/payment/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/payment/_index.en.md
@@ -25,8 +25,8 @@ Create Nets Easy agreement here: [payments.nets.eu](https://payments.nets.eu/nb-
 {{</content-version-selector>}}
 
 
-<!-- Gi tilganger til den som skal betale-->
-## 3. Ensure correct authorization for payment task
+<!-- Gi tilganger til den som skal betale og tjenesteeieren -->
+## 3. Authorise the payer and the service owner
 {{<content-version-selector classes="border-box">}}
 {{<content-version-container version-label="Altinn Studio Designer">}}
 {{% insert "content/altinn-studio/v8/guides/development/payment/studio/access-rules.en.md" %}}
@@ -36,6 +36,10 @@ Create Nets Easy agreement here: [payments.nets.eu](https://payments.nets.eu/nb-
 {{% insert "content/altinn-studio/v8/guides/development/payment/backend-manual/access-rules.en.md" %}}
 {{</content-version-container>}}
 {{</content-version-selector>}}
+
+When Nets notifies the app that the payment is complete, the app updates the payment information and advances the process on behalf of the service owner. In `App/config/authorization/policy.xml`, `[org]` must therefore have the `read` and `write` actions for the app and the `confirm` action for the payment task.
+
+The app must also have the standard Maskinporten scopes for service owners. See [how to add Maskinporten scopes](/en/altinn-studio/v8/guides/integration/maskinporten/add-scopes/). Build and deploy the app again after changing the scopes or the authorisation policy.
 
 
 <!--Konfigurer visning av betalingsinformasjon-->
@@ -75,3 +79,19 @@ Create Nets Easy agreement here: [payments.nets.eu](https://payments.nets.eu/nb-
 {{% insert "content/altinn-studio/v8/guides/development/payment/backend-manual/configure-secrets.en.md" %}}
 {{</content-version-container>}}
 {{</content-version-selector>}}
+
+
+## 7. Automatically advance the process after payment
+
+Starting with Altinn.App 8.12.0, the built-in Nets Easy integration registers a webhook when it creates a payment. When Nets reports a completed payment, the app verifies the payment status with Nets, updates the payment information, and advances the payment task if the status is `Paid`. This happens on the server and does not depend on the user returning to the app after payment.
+
+Only the payment task is completed automatically. If the next process element is an end event, the instance is also completed. Otherwise, the instance advances to the next process task.
+
+For automatic advancement to work:
+
+- Use Altinn.App 8.12.0 or later. We recommend using the latest available patch version.
+- Configure Maskinporten and the service owner permissions described in [step 3](#3-authorise-the-payer-and-the-service-owner).
+- Build and deploy the app again after changing the configuration.
+- Start a new payment after deployment. The webhook is registered when the payment is created, so payments created before the upgrade do not receive the new callback.
+
+The webhook is not registered during local development. Test this flow in a deployed test environment.

--- a/content/altinn-studio/v8/guides/development/payment/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/payment/_index.nb.md
@@ -87,9 +87,9 @@ Appen må også ha standardscopene for tjenesteeier i Maskinporten. Se [hvordan 
 
 ## 7. Automatisk videreføring etter fullført betaling
 
-Fra og med Altinn.App 8.12.0 registrerer den innebygde Nets Easy-integrasjonen en webhook når den oppretter en betaling. Når Nets varsler om en fullført betaling, kontrollerer appen betalingsstatusen hos Nets, oppdaterer betalingsinformasjonen og fører betalingssteget videre hvis statusen er `Paid`. Dette skjer på serveren og er ikke avhengig av at brukeren returnerer til appen etter betalingen.
+Fra og med Altinn.App 8.12.0 registrerer den innebygde Nets Easy-integrasjonen en webhook når den oppretter en betaling. Når Nets varsler om en fullført betaling, kontrollerer appen betalingsstatusen hos Nets, oppdaterer betalingsinformasjonen og fører betalingsoppgaven videre hvis statusen er `Paid`. Dette skjer på serveren og er ikke avhengig av at brukeren returnerer til appen etter betalingen.
 
-Det er betalingssteget som fullføres automatisk. Hvis neste steg i prosessen er en slutthendelse, blir også instansen fullført. Ellers går instansen videre til neste prosessteg.
+Det er betalingsoppgaven som fullføres automatisk. Hvis neste steg i prosessen er en slutthendelse, blir også instansen fullført. Ellers går instansen videre til neste prosessteg.
 
 For at automatisk videreføring skal fungere:
 

--- a/content/altinn-studio/v8/guides/development/payment/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/payment/_index.nb.md
@@ -29,8 +29,8 @@ Du finner informasjon om hvordan du oppretter avtalen her:
 {{</content-version-selector>}}
 
 
-<!-- Gi tilganger til den som skal betale-->
-## 3. Gi tilganger til den som skal betale
+<!-- Gi tilganger til den som skal betale og tjenesteeieren -->
+## 3. Gi tilganger til den som skal betale og tjenesteeieren
 {{<content-version-selector classes="border-box">}}
 {{<content-version-container version-label="Altinn Studio Designer">}}
 {{% insert "content/altinn-studio/v8/guides/development/payment/studio/access-rules.nb.md" %}}
@@ -40,6 +40,10 @@ Du finner informasjon om hvordan du oppretter avtalen her:
 {{% insert "content/altinn-studio/v8/guides/development/payment/backend-manual/access-rules.nb.md" %}}
 {{</content-version-container>}}
 {{</content-version-selector>}}
+
+Når Nets varsler appen om at betalingen er fullført, oppdaterer appen betalingsinformasjonen og fører prosessen videre på vegne av tjenesteeieren. I `App/config/authorization/policy.xml` må `[org]` derfor ha handlingene `read` og `write` for appen og `confirm` for betalingsoppgaven.
+
+Appen må også ha standardscopene for tjenesteeier i Maskinporten. Se [hvordan du legger til Maskinporten-scopes](/nb/altinn-studio/v8/guides/integration/maskinporten/add-scopes/). Bygg og publiser appen på nytt etter at du har endret scopene eller autorisasjonspolicyen.
 
 
 <!--Konfigurer visning av betalingsinformasjon-->
@@ -79,3 +83,19 @@ Du finner informasjon om hvordan du oppretter avtalen her:
 {{% insert "content/altinn-studio/v8/guides/development/payment/backend-manual/configure-secrets.nb.md" %}}
 {{</content-version-container>}}
 {{</content-version-selector>}}
+
+
+## 7. Automatisk videreføring etter fullført betaling
+
+Fra og med Altinn.App 8.12.0 registrerer den innebygde Nets Easy-integrasjonen en webhook når den oppretter en betaling. Når Nets varsler om en fullført betaling, kontrollerer appen betalingsstatusen hos Nets, oppdaterer betalingsinformasjonen og fører betalingssteget videre hvis statusen er `Paid`. Dette skjer på serveren og er ikke avhengig av at brukeren returnerer til appen etter betalingen.
+
+Det er betalingssteget som fullføres automatisk. Hvis neste steg i prosessen er en slutthendelse, blir også instansen fullført. Ellers går instansen videre til neste prosessteg.
+
+For at automatisk videreføring skal fungere:
+
+- Bruk Altinn.App 8.12.0 eller nyere. Vi anbefaler den nyeste tilgjengelige patch-versjonen.
+- Sett opp Maskinporten og tilgangene for tjenesteeieren som beskrevet i [steg 3](#3-gi-tilganger-til-den-som-skal-betale-og-tjenesteeieren).
+- Bygg og publiser appen på nytt etter konfigurasjonsendringer.
+- Start en ny betaling etter publisering. Webhooken registreres når betalingen opprettes, så betalinger som ble opprettet før oppgraderingen, får ikke den nye callbacken.
+
+Webhooken registreres ikke ved lokal utvikling. Test derfor denne flyten i et publisert testmiljø.

--- a/content/altinn-studio/v9/develop-a-service/process/payment/_index.en.md
+++ b/content/altinn-studio/v9/develop-a-service/process/payment/_index.en.md
@@ -26,8 +26,8 @@ Create Nets Easy agreement here: [payments.nets.eu](https://payments.nets.eu/nb-
 {{</content-version-selector>}}
 
 
-<!-- Gi tilganger til den som skal betale-->
-## 3. Ensure correct authorization for payment task
+<!-- Gi tilganger til den som skal betale og tjenesteeieren -->
+## 3. Authorise the payer and the service owner
 {{<content-version-selector classes="border-box">}}
 {{<content-version-container version-label="Altinn Studio Designer">}}
 {{% insert "content/altinn-studio/v9/develop-a-service/process/payment/studio/access-rules.en.md" %}}
@@ -37,6 +37,10 @@ Create Nets Easy agreement here: [payments.nets.eu](https://payments.nets.eu/nb-
 {{% insert "content/altinn-studio/v9/develop-a-service/process/payment/backend-manual/access-rules.en.md" %}}
 {{</content-version-container>}}
 {{</content-version-selector>}}
+
+When Nets notifies the app that the payment is complete, the app updates the payment information and advances the process on behalf of the service owner. In `App/config/authorization/policy.xml`, `[org]` must therefore have the `read` and `write` actions for the app and the `confirm` action for the payment task.
+
+Altinn Studio automatically adds the standard Maskinporten scopes for service owners to apps that use Altinn App v9. However, you must still verify that the authorisation policy grants the required actions to the service owner. See [integrating with Maskinporten](/en/altinn-studio/v9/develop-a-service/integration/maskinporten/). Build and deploy the app again after changing the scopes or the authorisation policy.
 
 
 <!--Konfigurer visning av betalingsinformasjon-->
@@ -76,3 +80,18 @@ Create Nets Easy agreement here: [payments.nets.eu](https://payments.nets.eu/nb-
 {{% insert "content/altinn-studio/v9/develop-a-service/process/payment/backend-manual/configure-secrets.en.md" %}}
 {{</content-version-container>}}
 {{</content-version-selector>}}
+
+
+## 7. Automatically advance the process after payment
+
+The built-in Nets Easy integration registers a webhook when it creates a payment. When Nets reports a completed payment, the app verifies the payment status with Nets, updates the payment information, and advances the payment task if the status is `Paid`. This happens on the server and does not depend on the user returning to the app after payment.
+
+Only the payment task is completed automatically. If the next process element is an end event, the instance is also completed. Otherwise, the instance advances to the next process task.
+
+For automatic advancement to work:
+
+- Configure the service owner permissions described in [step 3](#3-authorise-the-payer-and-the-service-owner).
+- Build and deploy the app again after changing the configuration.
+- Start a new payment after deployment. The webhook is registered when the payment is created, so payments created before the change do not receive the new callback.
+
+The webhook is not registered during local development. Test this flow in a deployed test environment.

--- a/content/altinn-studio/v9/develop-a-service/process/payment/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/process/payment/_index.nb.md
@@ -30,8 +30,8 @@ Du finner informasjon om hvordan du oppretter avtalen her:
 {{</content-version-selector>}}
 
 
-<!-- Gi tilganger til den som skal betale-->
-## 3. Gi tilgang til den som skal betale
+<!-- Gi tilganger til den som skal betale og tjenesteeieren -->
+## 3. Gi tilgang til den som skal betale og tjenesteeieren
 {{<content-version-selector classes="border-box">}}
 {{<content-version-container version-label="Altinn Studio Designer">}}
 {{% insert "content/altinn-studio/v9/develop-a-service/process/payment/studio/access-rules.nb.md" %}}
@@ -41,6 +41,10 @@ Du finner informasjon om hvordan du oppretter avtalen her:
 {{% insert "content/altinn-studio/v9/develop-a-service/process/payment/backend-manual/access-rules.nb.md" %}}
 {{</content-version-container>}}
 {{</content-version-selector>}}
+
+Når Nets varsler appen om at betalingen er fullført, oppdaterer appen betalingsinformasjonen og fører prosessen videre på vegne av tjenesteeieren. I `App/config/authorization/policy.xml` må `[org]` derfor ha handlingene `read` og `write` for appen og `confirm` for betalingsoppgaven.
+
+Altinn Studio legger automatisk til standardscopene for tjenesteeier i Maskinporten for apper som bruker Altinn App v9. Kontroller likevel at autorisasjonspolicyen gir tjenesteeieren de nødvendige handlingene. Se [integrasjon med Maskinporten](/nb/altinn-studio/v9/develop-a-service/integration/maskinporten/). Bygg og publiser appen på nytt etter at du har endret scopene eller autorisasjonspolicyen.
 
 
 <!--Konfigurer visning av betalingsinformasjon-->
@@ -80,3 +84,18 @@ Du finner informasjon om hvordan du oppretter avtalen her:
 {{% insert "content/altinn-studio/v9/develop-a-service/process/payment/backend-manual/configure-secrets.nb.md" %}}
 {{</content-version-container>}}
 {{</content-version-selector>}}
+
+
+## 7. Automatisk videreføring etter fullført betaling
+
+Den innebygde Nets Easy-integrasjonen registrerer en webhook når den oppretter en betaling. Når Nets varsler om en fullført betaling, kontrollerer appen betalingsstatusen hos Nets, oppdaterer betalingsinformasjonen og fører betalingssteget videre hvis statusen er `Paid`. Dette skjer på serveren og er ikke avhengig av at brukeren returnerer til appen etter betalingen.
+
+Det er betalingssteget som fullføres automatisk. Hvis neste steg i prosessen er en slutthendelse, blir også instansen fullført. Ellers går instansen videre til neste prosessteg.
+
+For at automatisk videreføring skal fungere:
+
+- Sett opp tilgangene for tjenesteeieren som beskrevet i [steg 3](#3-gi-tilgang-til-den-som-skal-betale-og-tjenesteeieren).
+- Bygg og publiser appen på nytt etter konfigurasjonsendringer.
+- Start en ny betaling etter publisering. Webhooken registreres når betalingen opprettes, så betalinger som ble opprettet før endringen, får ikke den nye callbacken.
+
+Webhooken registreres ikke ved lokal utvikling. Test derfor denne flyten i et publisert testmiljø.

--- a/content/altinn-studio/v9/develop-a-service/process/payment/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/process/payment/_index.nb.md
@@ -88,9 +88,9 @@ Altinn Studio legger automatisk til standardscopene for tjenesteeier i Maskinpor
 
 ## 7. Automatisk videreføring etter fullført betaling
 
-Den innebygde Nets Easy-integrasjonen registrerer en webhook når den oppretter en betaling. Når Nets varsler om en fullført betaling, kontrollerer appen betalingsstatusen hos Nets, oppdaterer betalingsinformasjonen og fører betalingssteget videre hvis statusen er `Paid`. Dette skjer på serveren og er ikke avhengig av at brukeren returnerer til appen etter betalingen.
+Den innebygde Nets Easy-integrasjonen registrerer en webhook når den oppretter en betaling. Når Nets varsler om en fullført betaling, kontrollerer appen betalingsstatusen hos Nets, oppdaterer betalingsinformasjonen og fører betalingsoppgaven videre hvis statusen er `Paid`. Dette skjer på serveren og er ikke avhengig av at brukeren returnerer til appen etter betalingen.
 
-Det er betalingssteget som fullføres automatisk. Hvis neste steg i prosessen er en slutthendelse, blir også instansen fullført. Ellers går instansen videre til neste prosessteg.
+Det er betalingsoppgaven som fullføres automatisk. Hvis neste steg i prosessen er en slutthendelse, blir også instansen fullført. Ellers går instansen videre til neste prosessteg.
 
 For at automatisk videreføring skal fungere:
 


### PR DESCRIPTION
## Description

Documents how the built-in Nets Easy webhook advances a payment task after a completed payment, even when the user does not return to the app.

- adds the required Maskinporten and service-owner policy configuration
- clarifies that the payment task, rather than necessarily the entire instance, is completed
- documents the v8.12.0 version requirement, deployment requirement, and existing-payment limitation
- covers both v8 and v9 in Norwegian and English without adding new pages

## Verification

- Hugo 0.162.0 build completed successfully
- git diff --check completed successfully

Related to Altinn/altinn-studio#20101.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated payment guides to explain authorisation requirements for both the payer and service owner, including required app permissions and standard Maskinporten scopes.
  - Added guidance on automatic process advancement after successful Nets Easy payments, including payment verification, task completion, and instance progression.
  - Documented deployment and configuration prerequisites, including republishing after permission changes and the limitation that webhook registration is unavailable during local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->