### PR TITLE
Språkvask: Veiledning for autorisasjonsregler

### DIFF
--- a/content/altinn-studio/v9/develop-a-service/reference/configuration/authorization/guidelines_authorization/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/configuration/authorization/guidelines_authorization/_index.nb.md
@@ -45,5 +45,3 @@ Som applikasjonseier må du alltid vurdere om intensjonene i rollebeskrivelsen s
 ## Altinn kan pålegge deg å endre autorisasjonsregler
 Selv om det er ditt ansvar som applikasjonseier å konstruere riktig autorisasjonsregel og velge riktige roller, gjennomfører Altinn stikkprøver av autorisasjonsreglene til tjenester i produksjon.
 Hvis vi oppdager det vi anser som feil bruk av Altinn Autorisasjon, vil vi om nødvendig ta tjenesten ut av produksjon eller pålegge deg å endre autorisasjonsreglene.
-
-{{<children />}}

--- a/content/altinn-studio/v9/develop-a-service/reference/configuration/authorization/guidelines_authorization/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/configuration/authorization/guidelines_authorization/_index.nb.md
@@ -43,5 +43,5 @@ Som applikasjonseier må du alltid vurdere om intensjonene i rollebeskrivelsen s
 {{% /notice%}}
 
 ## Altinn kan pålegge deg å endre autorisasjonsregler
-Selv om det er ditt ansvar som applikasjonseier å konstruere riktig autorisasjonsregel og velge riktige roller, gjennomfører Altinn stikkprøver av autorisasjonsreglene til tjenester i produksjon.
+Selv om det er ditt ansvar som applikasjonseier å konstruere riktig autorisasjonsregel og velge riktige roller, gjennomfører Altinn stikkprøver av autorisasjonsreglene for tjenester i produksjon.
 Hvis vi oppdager det vi anser som feil bruk av Altinn Autorisasjon, vil vi om nødvendig ta tjenesten ut av produksjon eller pålegge deg å endre autorisasjonsreglene.

--- a/content/altinn-studio/v9/develop-a-service/reference/configuration/authorization/guidelines_authorization/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/configuration/authorization/guidelines_authorization/_index.nb.md
@@ -2,7 +2,7 @@
 draft: true
 title: Veiledning for autorisasjonsregler
 linktitle: Veiledning
-description: Autorisasjonsregler må du definere med omhu. Denne veiledningen forteller hva du som applikasjonseier må vurdere før du setter autorisasjonsregler for en applikasjon
+description: Autorisasjonsregler må du definere med omhu. Denne veiledningen forteller hva du som applikasjonseier må vurdere før du setter autorisasjonsregler for en applikasjon.
 toc: true
 tags: [needsReview]
 ---
@@ -15,14 +15,14 @@ Du som eier av tjenesten er selv ansvarlig for å lage autorisasjonsregler og ve
 Selv om XACML-standarden gir deg stor frihet til å definere regler og velge rollene du ønsker, må du følge denne veiledningen for å sikre at
 tilgangen til applikasjonen er korrekt og fungerer etter hensikten.
 
-For å ta de riktige valgene når du lager autorisasjonsregler for appen din, trenger du en generell forståelse av hvordan Altinn Autorisasjon fungerer og hvordan den brukes til å kontrollere tilgang.
+For å ta de riktige valgene når du lager autorisasjonsregler for appen din, trenger du en generell forståelse av hvordan Altinn Autorisasjon fungerer og hvordan du bruker den til å kontrollere tilgang.
 På denne [siden](https://altinn.github.io/docs/utviklingsguider/styring-av-tilgang/for-tjenesteeier/) kan du lese mer om Altinn Autorisasjon.
 
 ## Du må velge roller med omhu!
 I konfigurasjonsfilen for autorisasjon bruker du roller for å definere hvem som har lov til å utføre hvilke handlinger.
-Altinn tilbyr et sett med roller du kan bruke som betingelse for å gi tilgang til et bestemt trinn i arbeidsprosessen og informasjonen som vises.
+Altinn tilbyr et sett med roller du kan bruke som betingelse for å gi tilgang til et bestemt trinn i arbeidsprosessen og informasjonen som vises der.
 
-Før du velger hvilken rolle du skal bruke, må du være sikker på at du har en god forståelse av hva disse rollene betyr og hva slags tjenester og informasjon denne rollen forventes å ha tilgang til.
+Før du velger hvilken rolle du skal bruke, må du være sikker på at du har en god forståelse av hva disse rollene betyr, og hvilke tjenester og hvilken informasjon du kan forvente at rollen har tilgang til.
 Det er viktig at autorisasjonsreglene og rollevalget samsvarer med intensjonene og forventningene administratoren for aktøren har. 
 For eksempel forventer administratoren antagelig at rollen «Skatt» gir tilgang til tjenester knyttet til for eksempel skatterapportering, men ikke at denne rollen gir tilgang til tjenester innen lønn og personalområdet. 
 På samme måte bør du være forsiktig med å bruke for eksempel rollen «Kontaktperson» fra Enhetsregisteret til å gi tilgang til tjenester, med mindre du har vurdert grunnlaget for tilgangen grundig. 
@@ -43,7 +43,7 @@ Som applikasjonseier må du alltid vurdere om intensjonene i rollebeskrivelsen s
 {{% /notice%}}
 
 ## Altinn kan pålegge deg å endre autorisasjonsregler
-Selv om det er ditt ansvar som applikasjonseier å konstruere riktig autorisasjonsregel og velge riktige roller, gjennomfører Altinn stikkprøver av autorisasjonsreglene for tjenester som settes i produksjon.
+Selv om det er ditt ansvar som applikasjonseier å konstruere riktig autorisasjonsregel og velge riktige roller, gjennomfører Altinn stikkprøver av autorisasjonsreglene til tjenester i produksjon.
 Hvis vi oppdager det vi anser som feil bruk av Altinn Autorisasjon, vil vi om nødvendig ta tjenesten ut av produksjon eller pålegge deg å endre autorisasjonsreglene.
 
 {{<children />}}


### PR DESCRIPTION
Closes Altinn/altinn-studio#20256

Fullfører språkvask av `guidelines_authorization/_index.nb.md` (flyttet fra `new-from-v8/` i #3052). Filen var allerede grundig vasket i PR #3023, men noen få s-passiv-konstruksjoner gjensto.

Endringer:
- Fjernet gjenværende s-passiv-konstruksjoner:
  - "hvordan den brukes" → "hvordan du bruker den"
  - "denne rollen forventes å ha tilgang til" → "du kan forvente at rollen har tilgang til"
  - "tjenester som settes i produksjon" → "tjenester i produksjon"
- Lagt til manglende punktum i frontmatter `description`
- Fjernet død `{{<children />}}`-shortcode (ingen undersider igjen etter at `roles_and_rights` ble fjernet i PR #3023)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined the Norwegian guidance on choosing authorisation roles carefully.
  * Clarified wording about role meanings, expected access to services and information, and use of Altinn Authorisation.
  * Updated the final section to explain that authorisation rules for services in production may be subject to spot checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->