### PR TITLE
Språkvask: Kalkulering av datafelt

### DIFF
--- a/content/altinn-studio/v9/develop-a-service/data/dataprocessing/calculation/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/data/dataprocessing/calculation/_index.nb.md
@@ -1,6 +1,6 @@
 ---
 draft: true
-title: Kalkulering av datafelt
+title: Kalkulering med uttrykk
 description: Slik konfigurerer du kalkulering med dynamiske uttrykk
 toc: true
 tags: [needsReview]
@@ -9,7 +9,7 @@ tags: [needsReview]
 
 Med uttrykk kan du beregne verdien av datamodellfelt automatisk. Uttrykksmotoren leser reglene fra en JSON Schema-spesifikasjon.
 
-## Hvordan konfigurere kalkulering med uttrykk
+## Konfigurere kalkulering med uttrykk
 
 {{<content-version-selector classes="border-box">}}
 

--- a/content/altinn-studio/v9/develop-a-service/data/dataprocessing/calculation/backend-manual/content.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/data/dataprocessing/calculation/backend-manual/content.nb.md
@@ -4,7 +4,7 @@ headless: true
 hidden: true
 tags: [needsReview]
 ---
-Kalkulering med uttrykk defineres i en egen fil ved siden av datamodellen din, og bruker navnekonvensjonen `navn.calculation.json`.
+Definer kalkulering med uttrykk i en egen fil ved siden av datamodellen din. Filen bruker navnekonvensjonen `navn.calculation.json`.
 Hvis datamodellen din heter `skjema`, har du allerede filene `skjema.cs` og `skjema.schema.json`. Den nye filen skal ligge i samme mappe og hete `skjema.calculation.json`.
 Du kan kopiere innholdet nedenfor som et utgangspunkt:
 
@@ -39,7 +39,7 @@ example.calculation.json
 }
 ```
 
-Reglene for feltene i datamodellen settes i `calculations`-objektet, der datamodellstien er nøkkelen, og verdien er en regel.
+Sett reglene for feltene i datamodellen i `calculations`-objektet, der datamodellstien er nøkkelen, og verdien er en regel.
 
 I motsetning til validering med uttrykk, støtter ikke kalkuleringer med uttrykk lister.
 


### PR DESCRIPTION
Closes Altinn/altinn-studio#20257

Kvalitetssjekk av `dataprocessing/calculation` (flyttet fra `new-from-v8/` i #3052). Filen var allerede vasket i PR #3021, men noen få punkter gjensto ved sammenligning med den parallelle, allerede godkjente søsterfunksjonen "Validering med uttrykk" (`expression-validation`).

Endringer:
- Tittel `Kalkulering av datafelt` → `Kalkulering med uttrykk` (fjerner substantivering med "av", samsvarer med søsterfunksjonen)
- Overskrift `Hvordan konfigurere kalkulering med uttrykk` → `Konfigurere kalkulering med uttrykk` (infinitiv, samme mønster som søsterfilen)
- Fjernet s-passiv i `backend-manual/content.nb.md`:
  - "Kalkulering med uttrykk defineres i en egen fil" → "Definer kalkulering med uttrykk i en egen fil"
  - "Reglene ... settes i `calculations`-objektet" → "Sett reglene ... i `calculations`-objektet"