### PR TITLE
Språkvask: Integrere app med Meldingstjenesten

### DIFF
--- a/content/altinn-studio/v9/develop-a-service/integration/correspondence/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/integration/correspondence/_index.nb.md
@@ -11,8 +11,8 @@ tags: [needsReview]
 Slik integrerer du [meldingstjenesten](/nb/correspondence/) med en Altinn-app. Med en slik integrasjon kan appen sende digitale meldinger og vedlegg sikkert til både organisasjoner og enkeltpersoner.
 
 ## Forutsetninger
-1. En [Altinn-ressurs](#altinn-ressurs)
-2. [Altinn.App.Api](https://www.nuget.org/packages/Altinn.App.Api) og [Altinn.App.Core](https://www.nuget.org/packages/Altinn.App.Core) _v8.12.2_ eller nyere
+- En [Altinn-ressurs](#altinn-ressurs)
+- [Altinn.App.Api](https://www.nuget.org/packages/Altinn.App.Api) og [Altinn.App.Core](https://www.nuget.org/packages/Altinn.App.Core) _v8.12.2_ eller nyere
 
 ### Altinn-ressurs
 Når du sender en korrespondanse må du knytte den til en Altinn-ressurs. Ressursen bestemmer tilgangen til meldingene. Altinn evaluerer om både avsendere og mottakere har tilgang.

--- a/content/altinn-studio/v9/develop-a-service/integration/correspondence/maskinporten.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/integration/correspondence/maskinporten.nb.md
@@ -20,7 +20,7 @@ For å bruke [meldingstjenesten](/nb/correspondence/) trenger du en [Maskinporte
 - `altinn:correspondence.write`
 {.correspondence-custom-list}
 
-For å sette opp dette legger du til scopene i Altinn Studio som beskrevet i [veiledningen for å legge til Maskinporten-scopes](/nb/altinn-studio/v9/develop-a-service/integration/maskinporten/add-scopes/). Når appen publiseres, oppretter Altinn Studio Maskinporten-klienten og monterer generert `MaskinportenSettings` i appen.
+For å sette opp dette legger du til scopene i Altinn Studio som beskrevet i [veiledningen for å legge til Maskinporten-scopes](/nb/altinn-studio/v9/develop-a-service/integration/maskinporten/add-scopes/). Når du publiserer appen, oppretter Altinn Studio Maskinporten-klienten og monterer generert `MaskinportenSettings` i appen.
 
 Meldingsklienten finner og bruker automatisk den innebygde Maskinporten-klienten med standard konfigurasjonssti `MaskinportenSettings`.
 
@@ -121,7 +121,7 @@ internal sealed class CorrespondenceClientDemo(
   {
     CorrespondenceAuthorisation authorisation = CorrespondenceAuthorisation.Maskinporten;
 
-    // Vedleggsdataene strømmes til meldingstjenesten.
+    // Klienten strømmer vedleggsdataene til meldingstjenesten.
     // Ikke lukk strømmen selv: klienten overtar ansvaret og lukker den når opplastingen er fullført.
     Stream attachmentData = File.OpenRead("path/to/attachment.txt");
 


### PR DESCRIPTION
Closes Altinn/altinn-studio#20259

Kvalitetssjekk av `integration/correspondence` (flyttet fra `new-from-v8/` i #3052). Filene var allerede vasket i PR #3018, men noen få punkter gjensto.

Endringer:
- Gjorde "Forutsetninger"-lista om fra nummerert liste til kulepunkter, i tråd med konvensjonen ellers i dokumentasjonen (nummererte lister kun for prosedyrer/steg i rekkefølge)
- Fjernet s-passiv:
  - "Når appen publiseres" → "Når du publiserer appen"
  - Kodekommentar: "Vedleggsdataene strømmes til meldingstjenesten" → "Klienten strømmer vedleggsdataene til meldingstjenesten"