### PR TITLE
docs: egendefinerte oppgave-hooker for v9

### DIFF
--- a/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
@@ -130,6 +130,67 @@ I tillegg kjører plattformen systemoppgaver på en ny måte i v9. I v8 kjørte 
 
 Se [Lage en egendefinert systemoppgave]({{< relref "/altinn-studio/v9/develop-a-service/process/service-tasks/custom" >}}) for hele oppsettet, og [Systemoppgaver med flere steg]({{< relref "/altinn-studio/v9/develop-a-service/process/service-tasks/flere-steg" >}}) hvis oppgaven sender noe og venter på svar.
 
+## Breaking changes
+
+### Egendefinerte oppgave-hooker er flyttet og har fått ny funksjonsmåte
+
+Har appen din en klasse som implementerer `IProcessTaskStart`, `IProcessTaskEnd` eller `IProcessTaskAbandon` — kode som kjører når en oppgave starter, avsluttes eller forlates — må den migreres for hånd. I motsetning til systemoppgavene over gjør ikke oppgraderingen noe av jobben her: grensesnittene er fjernet uten en overgangsperiode med kompileringsadvarsler, så koden slutter rett og slett å kompilere til du har gjort om den.
+
+Bruk de nye grensesnittene i `Altinn.App.Core.Features.Process` i stedet:
+
+| Gammelt grensesnitt | Nytt grensesnitt |
+| -------------------- | ----------------------- |
+| `IProcessTaskStart` | `IOnTaskStartingHandler` |
+| `IProcessTaskEnd` | `IOnTaskEndingHandler` |
+| `IProcessTaskAbandon` | `IOnTaskAbandonHandler` |
+
+Utover navnet er det tre praktiske forskjeller å kode mot:
+
+- **Hooken avgjør selv hvilken oppgave den gjelder for.** Før kjørte hver registrerte handler for *alle* oppgaver i prosessen, og koden måtte selv sjekke `taskId`. Nå implementerer hooken `ShouldRunForTask(string taskId)`, og bare handleren(e) som svarer `true` for gjeldende oppgave kjører.
+- **Hooken kjører som et steg i arbeidsflytmotoren**, akkurat som systemoppgavene over, og kan derfor bli forsøkt på nytt automatisk ved feil — implementasjonen må altså være idempotent. I stedet for å kaste unntak ved feil returnerer du et `HookResult` (et eget resultat for hooker, ikke å forveksle med `ServiceTaskResult` som brukes av systemoppgaver): `HookResult.Success()`, `HookResult.FailedRetryable("melding")` for en forbigående feil, eller `HookResult.FailedPermanent("melding")` for en feil som trenger en rettelse.
+- **Instansdata leses og endres via `IInstanceDataMutator`** i stedet for et rått `Instance`-objekt. Kontekstobjektet hooken mottar (`OnTaskStartingContext` og tilsvarende for de to andre) gir deg både instansen og en mutator — endringer du gjør gjennom den, lagres automatisk når hooken fullfører uten feil.
+
+I tillegg mister start-hooken `prefill`-parameteren. Brukte du prefill-data i `IProcessTaskStart.Start`, flytt den logikken til `IInstantiationProcessor.DataCreation`, som fortsatt mottar prefill og er upåvirket av denne endringen.
+
+```csharp
+// Før (v8)
+public class MyTaskStartHandler : IProcessTaskStart
+{
+    public Task Start(string taskId, Instance instance, Dictionary<string, string>? prefill)
+    {
+        if (taskId != "Task_1")
+        {
+            return Task.CompletedTask;
+        }
+
+        // Egendefinert logikk her
+
+        return Task.CompletedTask;
+    }
+}
+
+// Etter (v9)
+public class MyTaskStartHandler : IOnTaskStartingHandler
+{
+    public bool ShouldRunForTask(string taskId) => taskId == "Task_1";
+
+    public async Task<HookResult> Execute(OnTaskStartingContext context)
+    {
+        // Egendefinert logikk her, f.eks. context.InstanceDataMutator
+
+        return HookResult.Success();
+    }
+}
+```
+
+`IOnTaskEndingHandler` og `IOnTaskAbandonHandler` følger samme mønster, med `Execute(OnTaskEndingContext)` og `Execute(OnTaskAbandonContext)`. Registrering i `Program.cs` er uendret bortsett fra grensesnittnavnet: `services.AddTransient<IOnTaskStartingHandler, MyTaskStartHandler>();`
+
+De nye hookene lar deg i tillegg valgfritt overstyre arbeidsflytmotorens standard tidsavbrudd og gjenforsøksstrategi for steget, via egenskapen `StepOptions`. Det er en ny mulighet uten noe tilsvarende i v8, så ikke noe du trenger å sette for å migrere.
+
+{{% notice warning %}}
+Bare én matchende handler er tillatt per oppgave. Svarer to registrerte handlere av samme type (for eksempel to `IOnTaskStartingHandler`) `true` for samme oppgave, feiler prosessovergangen permanent. Hadde du før flere handler-klasser rettet mot ulike oppgaver, pass på at `ShouldRunForTask`-implementasjonene deres ikke overlapper — virket to av dine gamle handlere på samme oppgave, slå dem sammen til én.
+{{% /notice %}}
+
 ### Mindre endringer
 
 Oppgraderingen ordner disse endringene uten at du trenger å gjøre noe, men det er greit å kjenne til dem:

--- a/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
+++ b/content/altinn-studio/v9/new-in-v9/upgrade/_index.nb.md
@@ -132,9 +132,9 @@ Se [Lage en egendefinert systemoppgave]({{< relref "/altinn-studio/v9/develop-a-
 
 ## Breaking changes
 
-### Egendefinerte oppgave-hooker er flyttet og har fått ny funksjonsmåte
+### Vi har flyttet egendefinerte oppgave-hooker og de har fått ny funksjonsmåte
 
-Har appen din en klasse som implementerer `IProcessTaskStart`, `IProcessTaskEnd` eller `IProcessTaskAbandon` — kode som kjører når en oppgave starter, avsluttes eller forlates — må den migreres for hånd. I motsetning til systemoppgavene over gjør ikke oppgraderingen noe av jobben her: grensesnittene er fjernet uten en overgangsperiode med kompileringsadvarsler, så koden slutter rett og slett å kompilere til du har gjort om den.
+Hvis appen din har en klasse som implementerer `IProcessTaskStart`, `IProcessTaskEnd` eller `IProcessTaskAbandon`, det vil si kode som kjører når en oppgave starter, avsluttes eller forlates, må du migrere den manuelt. Systemoppgavene over er med i oppgraderingen, men for disse tre oppgavene har vi fjernet grensesnittene uten en overgangsperiode med kompileringsadvarsler. Koden slutter rett og slett å kompilere til du har gjort om på den.
 
 Bruk de nye grensesnittene i `Altinn.App.Core.Features.Process` i stedet:
 
@@ -144,14 +144,13 @@ Bruk de nye grensesnittene i `Altinn.App.Core.Features.Process` i stedet:
 | `IProcessTaskEnd` | `IOnTaskEndingHandler` |
 | `IProcessTaskAbandon` | `IOnTaskAbandonHandler` |
 
-Utover navnet er det tre praktiske forskjeller å kode mot:
+Utover navnet er det tre praktiske forskjeller du må kode mot:
 
-- **Hooken avgjør selv hvilken oppgave den gjelder for.** Før kjørte hver registrerte handler for *alle* oppgaver i prosessen, og koden måtte selv sjekke `taskId`. Nå implementerer hooken `ShouldRunForTask(string taskId)`, og bare handleren(e) som svarer `true` for gjeldende oppgave kjører.
-- **Hooken kjører som et steg i arbeidsflytmotoren**, akkurat som systemoppgavene over, og kan derfor bli forsøkt på nytt automatisk ved feil — implementasjonen må altså være idempotent. I stedet for å kaste unntak ved feil returnerer du et `HookResult` (et eget resultat for hooker, ikke å forveksle med `ServiceTaskResult` som brukes av systemoppgaver): `HookResult.Success()`, `HookResult.FailedRetryable("melding")` for en forbigående feil, eller `HookResult.FailedPermanent("melding")` for en feil som trenger en rettelse.
+- **Hooken avgjør selv hvilken oppgave den gjelder for.** Før kjørte hver registrerte handler for *alle* oppgaver i prosessen, og koden måtte selv sjekke `taskId`. Nå implementerer hooken `ShouldRunForTask(string taskId)`, og kjører bare handleren(e) som svarer `true` for gjeldende oppgave.
+- **Hooken kjører som et steg i arbeidsflytmotoren**, akkurat som systemoppgavene over. Hvis det oppstår feil, kan det kan hende at den blir forsøkt kjørt på nytt automatisk — implementasjonen må altså være idempotent. I stedet for å kaste unntak ved feil returnerer du et `HookResult` (et eget resultat for hooker, ikke å forveksle med `ServiceTaskResult` som brukes av systemoppgaver): `HookResult.Success()`, `HookResult.FailedRetryable("melding")` for en forbigående feil, eller `HookResult.FailedPermanent("melding")` for en feil som trenger en rettelse.
 - **Instansdata leses og endres via `IInstanceDataMutator`** i stedet for et rått `Instance`-objekt. Kontekstobjektet hooken mottar (`OnTaskStartingContext` og tilsvarende for de to andre) gir deg både instansen og en mutator — endringer du gjør gjennom den, lagres automatisk når hooken fullfører uten feil.
 
-I tillegg mister start-hooken `prefill`-parameteren. Brukte du prefill-data i `IProcessTaskStart.Start`, flytt den logikken til `IInstantiationProcessor.DataCreation`, som fortsatt mottar prefill og er upåvirket av denne endringen.
-
+I tillegg mister start-hooken `prefill`-parameteren. Hvis du tidligere har brukt prefill-data i `IProcessTaskStart.Start`, må du flytte den logikken til `IInstantiationProcessor.DataCreation`, som fortsatt mottar prefill og er upåvirket av denne endringen.
 ```csharp
 // Før (v8)
 public class MyTaskStartHandler : IProcessTaskStart
@@ -185,7 +184,7 @@ public class MyTaskStartHandler : IOnTaskStartingHandler
 
 `IOnTaskEndingHandler` og `IOnTaskAbandonHandler` følger samme mønster, med `Execute(OnTaskEndingContext)` og `Execute(OnTaskAbandonContext)`. Registrering i `Program.cs` er uendret bortsett fra grensesnittnavnet: `services.AddTransient<IOnTaskStartingHandler, MyTaskStartHandler>();`
 
-De nye hookene lar deg i tillegg valgfritt overstyre arbeidsflytmotorens standard tidsavbrudd og gjenforsøksstrategi for steget, via egenskapen `StepOptions`. Det er en ny mulighet uten noe tilsvarende i v8, så ikke noe du trenger å sette for å migrere.
+De nye hookene gjør også at du kan velge å overstyre arbeidsflytmotorens standard tidsavbrudd og strategi for å prøve igjen for steget, med egenskapen `StepOptions`. Det er en ny mulighet, uten noe tilsvarende i versjon 8, så det er ikke noe du trenger å sette for å migrere.
 
 {{% notice warning %}}
 Bare én matchende handler er tillatt per oppgave. Svarer to registrerte handlere av samme type (for eksempel to `IOnTaskStartingHandler`) `true` for samme oppgave, feiler prosessovergangen permanent. Hadde du før flere handler-klasser rettet mot ulike oppgaver, pass på at `ShouldRunForTask`-implementasjonene deres ikke overlapper — virket to av dine gamle handlere på samme oppgave, slå dem sammen til én.


### PR DESCRIPTION
Oppgraderingsguiden manglet et avsnitt om `IProcessTaskStart`, `IProcessTaskEnd` og `IProcessTaskAbandon`. 

## Endret side

- `new-in-v9/upgrade/`: nytt avsnitt `breaking changes` om at oppgave-hookene er flyttet til `IOnTaskStartingHandler`, `IOnTaskEndingHandler` og `IOnTaskAbandonHandler`, med tabell over de nye grensesnittnavnene, en gjennomgang av de tre praktiske forskjellene (`ShouldRunForTask`, `HookResult`, `IInstanceDataMutator`) og et før/etter-kodeeksempel.

## Merknader

- Advarsel lagt inn om at bare én matchende handler er tillatt per oppgave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for process task hooks in Altinn Studio v9.
  * Documented the transition to the new starting, ending, and abandonment handler interfaces.
  * Explained updated task selection and execution patterns, including context-based processing, results, instance data updates, and configurable step options.
  * Clarified that implementations must be idempotent to support workflow retries.
  * Documented the relocation of start-hook prefill handling and the effect of overlapping handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->