### PR TITLE
chore: rydd opp siste engelske v9-filer (issue #20271)

### DIFF
--- a/content/altinn-studio/v9/getting-started/_index.en.md
+++ b/content/altinn-studio/v9/getting-started/_index.en.md
@@ -1,6 +1,0 @@
----
-draft: true
-title: Getting Started with Altinn Studio
-description: What you need to get started in Altinn Studio
-weight: 5
----draft: true

--- a/content/altinn-studio/v9/this-is-AS/_index.en.md
+++ b/content/altinn-studio/v9/this-is-AS/_index.en.md
@@ -15,7 +15,7 @@ You can use Altinn Studio both with user interfaces for manual submission and wi
 ## What can I build with Altinn Studio?
 With Altinn Studio you can develop digital services for many different purposes. This can be anything from simple form services and information solutions to complex workflows with payment and signing. The platform supports both traditional forms and tailored applications with advanced integrations.
 
-See examples of use cases [here](/en/altinn-studio/v9/this-is-as/get-to-know-as/open-source).
+See examples of use cases [here](/en/altinn-studio/v9/this-is-as/get-to-know-as/usecases).
 
 ## Altinn Studio is the connector
 A form is rarely just data fields to be submitted. You need more to create a good service. This can be:

--- a/content/altinn-studio/v9/this-is-AS/get-to-know-AS/open-source.en.md
+++ b/content/altinn-studio/v9/this-is-AS/get-to-know-AS/open-source.en.md
@@ -5,7 +5,7 @@ description: How you can contribute to the development of Altinn Studio.
 weight: 2
 ---
 
-Altinn Studio is not perfect, but the tool takes you a long way towards building good digital services. We continuously add new functionality.
+Altinn Studio is never a finished product, and it will never cover 100% of your needs out of the box. However, the tool takes you a long way towards building good digital services, and we continuously add new functionality based on feedback. Where the tool falls short, it gives you the ability to build the missing pieces yourself.
 
 Instead of building something bespoke or buying something – why not contribute to the project where something is missing? This way you can give something back to society. The Altinn Studio teams handle quality assurance and further maintenance of the code.
 


### PR DESCRIPTION
Følger opp de 7 kandidatfilene fra #20271 (etter full gjennomlesning, ikke bare dato-/stikkprøve).

## Endringer
- **Slettet** `getting-started/_index.en.md` – korrupt frontmatter (`---draft: true` uten linjeskift) og ingen brødtekst i det hele tatt. Norsk har en fullverdig landingsside med en shortcode som ikke lot seg oversette som den var.
- **Fikset lenke** i `this-is-AS/_index.en.md`: `open-source` → `usecases` (matcher nb etter QA-fix i PR #3003).
- **Oppdatert innledning** i `this-is-AS/get-to-know-AS/open-source.en.md` for å matche omformuleringen som ble gjort i nb i samme QA-fix.

## Ikke endret (bevisst)
- `develop-a-service/data/restricted-data/_index.en.md` og `develop-a-service/look-and-feel/subform/backend-manual/_index.en.md` beholdes uendret. Begge er solide oversettelser, men har noen lenker som peker til `/v8/`-stier fordi den tilsvarende engelske `/v9/`-siden ikke finnes ennå. Siden hele v9-treet fortsatt er `draft: true` og ikke bygges til produksjon, er dette ikke en live-brutt lenke – lenkene bør oppdateres når de manglende engelske v9-sidene opprettes.
- `getting-started/development/custom-development/_index.en.md` og `manage-a-service/monitor-and-instrument/_index.en.md` er solide, oppdaterte oversettelser – ingen handling nødvendig.

Full analyse og korrigering av tidligere (upresis) konklusjon er lagt inn som kommentar på #20271.

Hugo-bygg verifisert rent (ingen REF_NOT_FOUND).

Closes #20271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “What can I build with Altinn Studio?” section to link to use cases.
  * Revised the open-source introduction to clarify product evolution, user feedback, and extensibility.
  * Removed the draft “Getting Started with Altinn Studio” page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Closes #20271