### PR TITLE
Fiks v8-lenker for allerede migrerte logikk-emner i v9

### DIFF
--- a/content/altinn-studio/v9/develop-a-service/look-and-feel/dynamics/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/look-and-feel/dynamics/_index.nb.md
@@ -9,7 +9,7 @@ aliases:
 
 Du kan sette opp dynamikk i skjema ved å bruke uttrykk med dynamikkverktøyet i Altinn Studio.
 
-Uttrykk er et begrep i Altinn-tjenester som lar deg dynamisk tildele verdier til ulike elementer. [Les mer om hva du kan bruke uttrykk til og hvordan syntaksen fungerer](/nb/altinn-studio/v8/reference/logic/expressions/).
+Uttrykk er et begrep i Altinn-tjenester som lar deg dynamisk tildele verdier til ulike elementer. [Les mer om hva du kan bruke uttrykk til og hvordan syntaksen fungerer]({{< relref "/altinn-studio/v9/develop-a-service/expressions" >}}).
 
 ## Terminologi
 

--- a/content/altinn-studio/v9/develop-a-service/look-and-feel/options/sources/dynamic/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/look-and-feel/options/sources/dynamic/_index.nb.md
@@ -188,7 +188,7 @@ Du kan legge til både statiske og dynamiske parametre ved å sette opp `queryPa
 
 I eksempelet over vil systemet alltid sende parameteret `loyvetype=garanti` med (dette er helt statisk og vil ikke endre seg). Systemet sender parameteret `orgnummer={nr}` med, hvor `{nr}` er verdien på feltet `soknad.transportorOrgnummer` i datamodellen. Systemet sender parameteret `myndig={bool}` med, hvor `{bool}` blir enten `true` eller `false` basert på om verdien på feltet `soknad.alder` er større enn eller lik 18.
 
-Flere eksempler på uttrykk finner du i [dokumentasjonen for dynamikk]({{< relref "../../../dynamics" >}}), og den fullstendige oversikten over tilgjengelige funksjoner finner du i [referanseoversikten over uttrykk](/nb/altinn-studio/v8/reference/logic/expressions/).
+Flere eksempler på uttrykk finner du i [dokumentasjonen for dynamikk]({{< relref "../../../dynamics" >}}), og den fullstendige oversikten over tilgjengelige funksjoner finner du i [referanseoversikten over uttrykk]({{< relref "/altinn-studio/v9/develop-a-service/expressions/reference" >}}).
 
 ### Basert på datamodellen
 

--- a/content/altinn-studio/v9/develop-a-service/process/flowcontrol/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/process/flowcontrol/_index.nb.md
@@ -62,7 +62,7 @@ For å oppnå dette må du legge til betingelsesuttrykk (conditionExpressions) t
 ```
 Hvis brukeren har sendt inn en Amount på 1000, evaluerer uttrykkene i sekvensflyten _Flow_g1_end_ til falsk. Systemet fjerner da flyten fra de mulige flytene å velge mellom. Den eneste tilgjengelige flyten er _Flow_g1_t2_, og derfor velger systemet den.
 
-For å se flere muligheter med uttrykk, se [Uttrykk](/nb/altinn-studio/v8/reference/logic/expressions/)
+For å se flere muligheter med uttrykk, se [Uttrykk]({{< relref "/altinn-studio/v9/develop-a-service/expressions" >}})
 
 ### Kontrollere flyten ut av en gateway basert på brukerhandling utført ved hjelp av uttrykk
 
@@ -110,7 +110,7 @@ For å gjøre dette bruker du uttrykksfunksjonen _gatewayAction_
 
 Uttrykksfunksjonen _gatewayAction_ returnerer handlingen som ble utført i oppgaven som prosessen nettopp forlot. I eksempelet ovenfor er forrige oppgave _Task_2_.
 
-Du kan kombinere funksjonen _gatewayAction_ med alle de andre funksjonene i [uttrykk](/nb/altinn-studio/v8/reference/logic/expressions/)
+Du kan kombinere funksjonen _gatewayAction_ med alle de andre funksjonene i [uttrykk]({{< relref "/altinn-studio/v9/develop-a-service/expressions" >}})
 
 ## Komplekse gateways som krever tilpasset kode
 

--- a/content/altinn-studio/v9/develop-a-service/reference/configuration/messagebox/create-copy/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/configuration/messagebox/create-copy/_index.nb.md
@@ -88,7 +88,7 @@ applicationmetadata.json
 
 ## Programmatiske endringer
 
-Under kopiering av skjema utfører logikken metodekall mot **IInstantiationProcessor.DataCreation**. Dette gjør det mulig å gjøre programmatiske endringer i data som kopieres. [Les mer om egendefinert forhåndsutfylling](/nb/altinn-studio/v8/guides/development/prefill/custom/).
+Under kopiering av skjema utfører logikken metodekall mot **IInstantiationProcessor.DataCreation**. Dette gjør det mulig å gjøre programmatiske endringer i data som kopieres. [Les mer om egendefinert forhåndsutfylling]({{< relref "/altinn-studio/v9/develop-a-service/data/prefill/how-to/custom" >}}).
 
 ## Validering
 

--- a/content/altinn-studio/v9/develop-a-service/reference/process/flowcontrol/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/process/flowcontrol/_index.nb.md
@@ -63,7 +63,7 @@ For å oppnå dette må du legge til betingelsesuttrykk (conditionExpressions) t
 ```
 Hvis brukeren har sendt inn en Amount på 1000, evaluerer uttrykkene i sekvensflyten _Flow_g1_end_ til falsk. Systemet fjerner da flyten fra de mulige flytene å velge mellom. Den eneste tilgjengelige flyten er _Flow_g1_t2_, og derfor velger systemet den.
 
-For å se flere muligheter med uttrykk, se [Uttrykk](/nb/altinn-studio/v8/reference/logic/expressions/)
+For å se flere muligheter med uttrykk, se [Uttrykk]({{< relref "/altinn-studio/v9/develop-a-service/expressions" >}})
 
 ### Kontrollere flyten ut av en gateway basert på brukerhandling utført ved hjelp av uttrykk
 
@@ -111,7 +111,7 @@ For å gjøre dette bruker du uttrykksfunksjonen _gatewayAction_
 
 Uttrykksfunksjonen _gatewayAction_ returnerer handlingen som ble utført i oppgaven som prosessen nettopp forlot. I eksempelet ovenfor er forrige oppgave _Task_2_.
 
-Du kan kombinere funksjonen _gatewayAction_ med alle de andre funksjonene i [uttrykk](/nb/altinn-studio/v8/reference/logic/expressions/)
+Du kan kombinere funksjonen _gatewayAction_ med alle de andre funksjonene i [uttrykk]({{< relref "/altinn-studio/v9/develop-a-service/expressions" >}})
 
 ## Komplekse gateways som krever tilpasset kode
 


### PR DESCRIPTION
## Bakgrunn
Tidligere rapport konkluderte med at hele `reference/logic/*`-seksjonen fra v8 manglet i v9. En gjennomgang (se [Altinn/altinn-studio#20316](https://github.com/Altinn/altinn-studio/issues/20316)) viser at det meste faktisk allerede er migrert og språkvasket, bare flyttet til nye plasseringer under v9s nye struktur:

| v8-emne | v9-plassering |
|---|---|
| `expressions/` | `develop-a-service/expressions/` |
| `dataprocessing/calculation/` | `develop-a-service/data/dataprocessing/calculation/` |
| `validation/{expression-validation,files}` | `develop-a-service/data/validation/` |
| `instantiation/` | Splittet: `develop-a-service/reference/api/auth/` + `develop-a-service/data/prefill/how-to/custom/` |

## Endringer i denne PR-en
Oppdaterer 7 gjenværende v8-lenker i 5 `.nb.md`-filer som pekte til v8-versjonene av disse (nå bekreftet migrerte) sidene, til å bruke intern v9-lenke (`{{< relref >}}`) i stedet:

- `develop-a-service/look-and-feel/dynamics/_index.nb.md`
- `develop-a-service/look-and-feel/options/sources/dynamic/_index.nb.md`
- `develop-a-service/process/flowcontrol/_index.nb.md`
- `develop-a-service/reference/process/flowcontrol/_index.nb.md`
- `develop-a-service/reference/configuration/messagebox/create-copy/_index.nb.md`

Engelske søsterfiler (`.en.md`) er bevisst ikke rørt, siden målsidene (`expressions/`, `prefill/how-to/config/`) kun finnes på norsk i v9 ennå.

## Verifisering
- Rent Hugo-bygg for disse filene (ingen `REF_NOT_FOUND`).
- Kun `.nb.md`-filer i `develop-a-service/` rørt, ingen v8-filer endret.

Closes Altinn/altinn-studio#20316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Norwegian documentation links to point to the current version 9 expression and custom prefill references.
  - Replaced outdated version 8 URLs with version-aware links, improving navigation and reducing the risk of broken references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->