### PR TITLE
Migrer og språkvask Varsling-integrasjon (e-post/SMS) fra v8 til v9

### DIFF
--- a/content/altinn-studio/v9/develop-a-service/integration/notifications/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/integration/notifications/_index.nb.md
@@ -1,0 +1,13 @@
+---
+title: Integrere Altinn-app med Varsling
+linktitle: Varsling
+description: Slik publiserer du varsler til brukere fra en Altinn-app.
+draft: true
+weight: 110
+toc: true
+tags: [needsReview]
+---
+
+En app kan publisere varsler til brukere ved hjelp av [Altinn Varslinger-API-et](/nb/notifications). `Altinn.App.Core` har ferdigbygde grensesnitt for å støtte dette.
+
+{{<children />}}

--- a/content/altinn-studio/v9/develop-a-service/integration/notifications/email.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/integration/notifications/email.nb.md
@@ -1,0 +1,78 @@
+---
+title: E-post
+description: Slik oppretter du egendefinerte e-postvarslinger for apper.
+draft: true
+weight: 10
+tags: [needsReview]
+---
+
+## Aktivere e-postvarsling i appen din
+
+Appen inkluderer automatisk e-postklienten. For å bruke den, sett inn grensesnittet `IEmailNotificationClient` i konstruktøren.
+Grensesnittet definerer en metode du bruker til å bestille en e-postvarsling fra API-et til [Altinn Notifications](https://github.com/Altinn/altinn-notifications).
+
+### Kodeeksempel
+
+Under ser du et eksempel der du prøver å sende en e-postvarsling når brukeren har begynt å fylle ut skjemaet, ved hjelp av grensesnittet `IProcessTaskStart`.
+
+```csharp file=EmailOnStart.cs
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.App.Core.Features;
+using Altinn.App.Core.Internal.Notifications.Email;
+using Altinn.App.Core.Models.Notifications.Email;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.App.Core;
+
+public class EmailOnStart(ILogger<EmailOnStart> logger, IEmailNotificationClient emailNotificationClient)
+    : IProcessTaskStart
+{
+    public async Task Start(string taskId, Instance instance, Dictionary<string, string> prefill)
+    {
+        // "Task_1" er navnet på skjema-steget i bpmn-prosessen
+        if (taskId != "Task_1")
+            return;
+
+        try
+        {
+            var order = new EmailNotification
+            {
+                Subject = "Skjema startet",
+                Body = "Du har startet innfylling av skjema",
+                SendersReference = "<min-skjema-ref>",
+                Recipients = [new("navn.navnesen@epost.no")],
+            };
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var orderResult = await emailNotificationClient.Order(order, cts.Token);
+            logger.LogInformation(
+                "Task started, email sent to {EmailAddress} - OrderId={OrderId}",
+                order.Recipients[0].EmailAddress,
+                orderResult.OrderId
+            );
+        }
+        catch (EmailNotificationException e)
+        {
+            logger.LogError(e, "Error sending email on task start");
+        }
+    }
+}
+```
+
+Deretter må du registrere klassen `EmailOnStart` som `IProcessTaskStart` i `Program.cs`.
+
+```csharp file=Program.cs
+using Altinn.App.Core;
+using Altinn.App.Core.Features;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+void RegisterCustomAppServices(IServiceCollection services, IConfiguration config, IWebHostEnvironment env)
+{
+    services.AddSingleton<IProcessTaskStart, EmailOnStart>();
+}
+```

--- a/content/altinn-studio/v9/develop-a-service/integration/notifications/sms.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/integration/notifications/sms.nb.md
@@ -1,0 +1,78 @@
+---
+title: SMS
+description: Slik oppretter du egendefinerte SMS-varslinger for apper.
+draft: true
+weight: 20
+tags: [needsReview]
+---
+
+## Aktivere SMS-varsling i appen din
+
+Appen inkluderer automatisk SMS-klienten. For å bruke den, sett inn grensesnittet `ISmsNotificationClient` i konstruktøren.
+Grensesnittet definerer en metode du bruker til å bestille en SMS-varsling fra API-et til [Altinn Notifications](https://github.com/Altinn/altinn-notifications).
+
+### Kodeeksempel
+
+Under ser du et eksempel der du prøver å sende en SMS-varsling når brukeren har begynt å fylle ut skjemaet, ved hjelp av grensesnittet `IProcessTaskStart`.
+
+```csharp file=SmsOnStart.cs
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Altinn.App.Core.Features;
+using Altinn.App.Core.Internal.Notifications.Sms;
+using Altinn.App.Core.Models.Notifications.Sms;
+using Altinn.Platform.Storage.Interface.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Altinn.App.Core;
+
+public class SmsOnStart(ILogger<SmsOnStart> logger, ISmsNotificationClient smsNotificationClient)
+    : IProcessTaskStart
+{
+    public async Task Start(string taskId, Instance instance, Dictionary<string, string> prefill)
+    {
+        // "Task_1" er navnet på skjema-steget i bpmn-prosessen
+        if (taskId != "Task_1")
+            return;
+
+        try
+        {
+            var order = new SmsNotification
+            {
+                SenderNumber = "<sender>",
+                Body = "Du har startet innfylling av skjema",
+                SendersReference = "<min-skjema-ref>",
+                Recipients = [new("0047XXXXXXXX")],
+            };
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var orderResult = await smsNotificationClient.Order(order, default);
+            logger.LogInformation(
+                "Task started, SMS sent to {MobileNumber} - OrderId={OrderId}",
+                order.Recipients[0].MobileNumber,
+                orderResult.OrderId
+            );
+        }
+        catch (SmsNotificationException e)
+        {
+            logger.LogError(e, "Error sending SMS on task start");
+        }
+    }
+}
+```
+
+Deretter må du registrere klassen `SmsOnStart` som `IProcessTaskStart` i `Program.cs`.
+
+```csharp file=Program.cs
+using Altinn.App.Core;
+using Altinn.App.Core.Features;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+void RegisterCustomAppServices(IServiceCollection services, IConfiguration config, IWebHostEnvironment env)
+{
+    services.AddSingleton<IProcessTaskStart, SmsOnStart>();
+}
+```


### PR DESCRIPTION
## Bakgrunn
En del av kartleggingen på [Altinn/altinn-studio#20316](https://github.com/Altinn/altinn-studio/issues/20316) avdekket at "publisere varsler" (v8 `reference/logic/notifications/*`) er et reelt hull i v9 - ingen tilsvarende dokumentasjon fantes.

## Endringer
Migrerer de tre v8-artiklene til v9, plassert under `develop-a-service/integration/notifications/` - parallelt med `integration/correspondence/`, siden Varsling (Altinn Notifications) er et eget Altinn-produkt med egen plattform-API, samme mønster som Meldingstjenesten:

- `_index.nb.md` - oversikt
- `email.nb.md` - e-postvarsling
- `sms.nb.md` - SMS-varsling

Språkvasket samtidig med flyttingen:
- Fjernet s-passiv ("legges automatisk til" → "Appen inkluderer automatisk...")
- "vi" → "du"
- Fjernet substantiveringer ("generering av e-postvarslinger" → "e-postvarsling", "utfylling av skjema" → "fylle ut skjemaet")
- Anglisismer: "interface" → "grensesnitt", "injiser" → "sett inn ... i konstruktøren"
- `description`: "Hvordan opprette..." → "Slik oppretter du..."
- Overskrift endret fra imperativ til infinitiv siden den innleder en forklaring, ikke en nummerert prosedyre

## Verifisering
Rent Hugo-bygg, ingen `REF_NOT_FOUND`. Kun nye v9-filer, ingen v8-filer endret.

Ref: Altinn/altinn-studio#20316