### PR TITLE
chore: update studio assistant model source

### DIFF
--- a/content/altinn-studio/v8/guides/development/assistant/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/assistant/_index.en.md
@@ -47,9 +47,9 @@ Threads let you start new conversations without context from old messages. We re
 
 Do not send personal or sensitive information to the assistant. We store messages for 90 days and use the data to debug and improve the assistant. We also use it for billing, but not to train AI models.
 
-## Data and AI models
+## AI models
 
-The assistant uses language models through Microsoft Azure. During the beta, the data may be processed outside the EU. We will move to processing strictly within the EU during the beta period.
+The assistant uses OpenAI models that run on Microsoft's infrastructure in the EEA.
 
 ## Cost
 

--- a/content/altinn-studio/v8/guides/development/assistant/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/assistant/_index.nb.md
@@ -47,9 +47,9 @@ Tråder lar deg opprette nye samtaler uten kontekst fra gamle meldinger. Vi anbe
 
 Ikke send personopplysninger eller sensitiv informasjon til assistenten. Vi lagrer meldinger i 90 dager, og bruker dataene til å feilsøke og forbedre assistenten. Vi bruker dem også til fakturering, men ikke til å trene KI-modeller.
 
-## Data og KI-modeller
+## KI-modeller
 
-Assistenten bruker språkmodeller gjennom Microsoft Azure. I betaen kan dataene bli behandlet utenfor EU. Vi går over til behandling utelukkende i EU i løpet av betaperioden.
+Assistenten bruker OpenAI-modeller som kjører på Microsoft sin infrastruktur i EØS.
 
 ## Kostnad
 


### PR DESCRIPTION
The Studio assistant has been updated to only use language models from OpenAI, running on Microsoft's infrastructure in the EEA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the assistant documentation in English and Norwegian.
  - Renamed the section from “Data and AI models” to “AI models”.
  - Clarified that the assistant uses OpenAI models hosted on Microsoft infrastructure within the European Economic Area (EEA).
  - Revised previous information regarding Azure, beta processing, and data processing locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->