### PR TITLE
docs(v8): fjern leverandørnavn fra Fiks Arkiv-veiledningen

### DIFF
--- a/content/altinn-studio/v8/guides/development/fiks-arkiv/_index.en.md
+++ b/content/altinn-studio/v8/guides/development/fiks-arkiv/_index.en.md
@@ -21,7 +21,7 @@ Before setting up the Fiks Arkiv integration in your app you will need to have t
 
 - **Fiks Protokoll** enabled in Fiks forvaltning portal for your organisation
 - **Samarbeidsportalen** access to administer Maskinporten clients for your organisation. Altinn Studio uses this authorisation when you log in with Ansattporten and add Maskinporten scopes to the app.
-- An **archive system** that integrates with Fiks Arkiv (e.g., Public 360)
+- An **archive system** that integrates with Fiks Arkiv
 
 ## Integration architecture and flow
 
@@ -654,8 +654,8 @@ As Digdir does not offer the archive system or Fiks Arkiv, we do not have extens
 the application developer reference KS Digital's documentation along side the documentation of 
 the archive system provider. 
 
-However, as more application owners make use of the integration we have seen a few common pit falls.
-These along with solutions are listed below, to be used at your convenience. 
+The Fiks Arkiv account that receives the messages is however set up the same way regardless of archive system.
+The steps are described below.
 
 ### Create a Fiks Arkiv account
 {.floating-bullet-numbers-sibling-ol}
@@ -677,15 +677,6 @@ These along with solutions are listed below, to be used at your convenience.
 4. Under the account, navigate to the _Søk etter systemer_ tab and look up the system created to send messages.
 Grant this system permission to send messages to the recipient account by clicking _Gi tilgang_.
     <img src="fiks-system-whitelist.png" alt="Screenshot illustrating how to give access to a system from a Fiks account" width="80%">
-
-### Known issues in configuration of Public 360
-
-#### The encryption key is not documented
-
-The maskinporten token uploaded in P360 is used as the private part of the encryption key
-the Fiks Arkiv account that receives messages should upload the public part of this certificate
-as the encryption key. 
-
 
 ## External documentation 
 

--- a/content/altinn-studio/v8/guides/development/fiks-arkiv/_index.nb.md
+++ b/content/altinn-studio/v8/guides/development/fiks-arkiv/_index.nb.md
@@ -22,7 +22,7 @@ Før du setter opp Fiks Arkiv-integrasjonen i appen din, må du ha følgende på
 
 - **Fiks Protokoll** aktivert i Fiks forvaltningsportalen for din organisasjon
 - Tilgang i **Samarbeidsportalen** til å administrere Maskinporten-klienter for organisasjonen din. Altinn Studio bruker denne autoriseringen når du logger inn med Ansattporten og legger Maskinporten-scopes til appen.
-- Et **arkivsystem** som integrerer med Fiks Arkiv (f.eks. Public 360)
+- Et **arkivsystem** som integrerer med Fiks Arkiv
 
 ## Integrasjonsarkitektur og flyt
 
@@ -654,8 +654,8 @@ Ettersom Digdir ikke tilbyr arkivsystemet eller Fiks Arkiv, har vi ikke omfatten
 applikasjonsutvikleren refererer til KS Digitals dokumentasjon sammen med dokumentasjonen fra 
 arkivsystemleverandøren. 
 
-Imidlertid, ettersom flere applikasjonseiere tar i bruk integrasjonen har vi sett noen vanlige fallgruver.
-Disse sammen med løsninger er listet opp nedenfor, til din disposisjon. 
+Selve Fiks Arkiv-kontoen som skal ta imot meldingene opprettes likevel på samme måte uavhengig av arkivsystem.
+Stegene er beskrevet nedenfor.
 
 ### Opprett en Fiks Arkiv-konto
 {.floating-bullet-numbers-sibling-ol}
@@ -677,15 +677,6 @@ Disse sammen med løsninger er listet opp nedenfor, til din disposisjon.
 4. Under kontoen, naviger til fanen _Søk etter systemer_ og slå opp systemet som ble opprettet for å sende meldinger.
 Gi dette systemet tillatelse til å sende meldinger til mottakerkontoen ved å klikke _Gi tilgang_.
     <img src="fiks-system-whitelist.png" alt="Skjermbilde som illustrerer hvordan gi tilgang til et system fra en Fiks-konto" width="80%">
-
-### Kjente problemer i konfigurasjon av Public 360
-
-#### Krypteringsnøkkelen er ikke dokumentert
-
-Maskinporten-tokenet som lastes opp i P360 brukes som den private delen av krypteringsnøkkelen
-Fiks Arkiv-kontoen som mottar meldinger skal laste opp den offentlige delen av dette sertifikatet
-som krypteringsnøkkelen. 
-
 
 ## Ekstern dokumentasjon 
 


### PR DESCRIPTION
Fjerner navn på arkivsystemleverandører fra v8-veiledningen for Fiks Arkiv (nb og en).

- Eksempelet i forutsetningene nevner ikke lenger en bestemt leverandør.
- Delen «Kjente problemer i konfigurasjon av …» er fjernet. Den gjaldt ett produkt og gir ikke mening uten navnet. Kravene til krypteringsnøkkelparet dekkes allerede av steg 3, som viser til dokumentasjonen for arkivsystemet.
- Innledningen til mottaksdelen er justert, siden den ikke lenger lover en liste over fallgruver.

Den nye v9-siden (#3071) følger samme regel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Fiks Arkiv guide to use archive-system-neutral guidance.
  - Clarified that Fiks Arkiv account setup follows the same process regardless of the archive system.
  - Streamlined prerequisite and receiving-message instructions in English and Norwegian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->