### PR TITLE
docs(v8): legg til regelsider for ALTINNAPP0900 og ALTINNAPP0901

### DIFF
--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0900/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0900/_index.en.md
@@ -1,0 +1,25 @@
+---
+title: "ALTINNAPP0900: to felt deler samme id"
+tags: [needstranslation]
+description: "To oppføringer i presentationFields eller dataFields har samme id for samme dataTypeId"
+weight: 90
+---
+
+Denne diagnostikken meldes når to oppføringer i `presentationFields` eller `dataFields` i
+`applicationmetadata.json` har samme `id` og samtidig peker på samme `dataTypeId`.
+Meldingen navngir hvilken av de to egenskapene det gjelder, id-en, datatypen og begge
+`path`-verdiene.
+
+Id-en er nøkkelen verdien lagres under på instansen: `presentationTexts` for
+presentasjonsfelt og `dataValues` for datafelt. Verdiene for én datatype regnes ut samlet,
+og samme nøkkel kan ikke lagres to ganger. Appen feiler derfor i stedet for å regne ut noen
+av dem, og både instansiering og lagring av den datatypen stopper.
+
+Kategori `Metadata`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
+
+Gi hver oppføring sin egen `id`.
+
+Å bruke samme `id` på *ulike* datatyper er fortsatt lov. Da gjelder verdien fra den
+datatypen som ble lagret sist, og noen apper bruker dette bevisst for å fylle samme
+presentasjonsfelt fra den modellen instansen har. Regelen melder bare oppføringer som deler
+både `id` og `dataTypeId`.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0900/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0900/_index.nb.md
@@ -1,0 +1,24 @@
+---
+title: "ALTINNAPP0900: to felt deler samme id"
+description: "To oppføringer i presentationFields eller dataFields har samme id for samme dataTypeId"
+weight: 90
+---
+
+Denne diagnostikken meldes når to oppføringer i `presentationFields` eller `dataFields` i
+`applicationmetadata.json` har samme `id` og samtidig peker på samme `dataTypeId`.
+Meldingen navngir hvilken av de to egenskapene det gjelder, id-en, datatypen og begge
+`path`-verdiene.
+
+Id-en er nøkkelen verdien lagres under på instansen: `presentationTexts` for
+presentasjonsfelt og `dataValues` for datafelt. Verdiene for én datatype regnes ut samlet,
+og samme nøkkel kan ikke lagres to ganger. Appen feiler derfor i stedet for å regne ut noen
+av dem, og både instansiering og lagring av den datatypen stopper.
+
+Kategori `Metadata`, alvorlighetsgrad **feil**. Regelen stopper altså bygget.
+
+Gi hver oppføring sin egen `id`.
+
+Å bruke samme `id` på *ulike* datatyper er fortsatt lov. Da gjelder verdien fra den
+datatypen som ble lagret sist, og noen apper bruker dette bevisst for å fylle samme
+presentasjonsfelt fra den modellen instansen har. Regelen melder bare oppføringer som deler
+både `id` og `dataTypeId`.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0901/_index.en.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0901/_index.en.md
@@ -1,0 +1,18 @@
+---
+title: "ALTINNAPP0901: feltet peker på en ukjent datatype"
+tags: [needstranslation]
+description: "En oppføring i presentationFields eller dataFields har en dataTypeId appen ikke har deklarert"
+weight: 91
+---
+
+Denne diagnostikken meldes når en oppføring i `presentationFields` eller `dataFields` i
+`applicationmetadata.json` har en `dataTypeId` som ikke finnes blant `dataTypes` i samme
+fil. Meldingen navngir egenskapen, id-en til oppføringen og datatypen den peker på.
+
+Appen regner bare ut feltet for datatypen oppføringen navngir. Peker den på en datatype som
+ikke finnes, blir verdien aldri regnet ut, og feltet står tomt på instansen uten at noe
+feiler. Den vanligste årsaken er en skrivefeil i `dataTypeId`.
+
+Kategori `Metadata`, alvorlighetsgrad **advarsel**.
+
+Rett `dataTypeId` til en datatype appen deklarerer, eller fjern oppføringen.

--- a/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0901/_index.nb.md
+++ b/content/altinn-studio/v8/reference/analysis/rules/ALTINNAPP0901/_index.nb.md
@@ -1,0 +1,17 @@
+---
+title: "ALTINNAPP0901: feltet peker på en ukjent datatype"
+description: "En oppføring i presentationFields eller dataFields har en dataTypeId appen ikke har deklarert"
+weight: 91
+---
+
+Denne diagnostikken meldes når en oppføring i `presentationFields` eller `dataFields` i
+`applicationmetadata.json` har en `dataTypeId` som ikke finnes blant `dataTypes` i samme
+fil. Meldingen navngir egenskapen, id-en til oppføringen og datatypen den peker på.
+
+Appen regner bare ut feltet for datatypen oppføringen navngir. Peker den på en datatype som
+ikke finnes, blir verdien aldri regnet ut, og feltet står tomt på instansen uten at noe
+feiler. Den vanligste årsaken er en skrivefeil i `dataTypeId`.
+
+Kategori `Metadata`, alvorlighetsgrad **advarsel**.
+
+Rett `dataTypeId` til en datatype appen deklarerer, eller fjern oppføringen.


### PR DESCRIPTION
Dokumenterer to nye regler i `ApplicationMetadataAnalyzer`, lagt til i
[Altinn/altinn-studio#20351](https://github.com/Altinn/altinn-studio/pull/20351). Begge sjekker
`presentationFields` og `dataFields` i `applicationmetadata.json` ved bygging av appen.

| Regel | Alvorlighetsgrad | Melder |
| --- | --- | --- |
| `ALTINNAPP0900` | Feil | To oppføringer i samme egenskap deler både `id` og `dataTypeId` |
| `ALTINNAPP0901` | Advarsel | En oppføring peker på en `dataTypeId` appen ikke deklarerer |

ALTINNAPP0900 fanger opp en konfigurasjon som tar appen ned: id-en er nøkkelen verdien lagres under
på instansen, verdiene for én datatype regnes ut samlet, og samme nøkkel kan ikke lagres to ganger.
Appen feilet derfor hver instansiering og hver lagring av den datatypen. Sidene forklarer også
hvorfor det fortsatt er lov å bruke samme `id` på *ulike* datatyper — noen apper fyller bevisst
samme presentasjonsfelt fra den modellen instansen har.

ALTINNAPP0901 melder en oppføring som aldri blir regnet ut, og som derfor etterlater feltet tomt
på instansen uten at noe feiler. Den vanligste årsaken er en skrivefeil i `dataTypeId`.

Sidene ligger under `reference/analysis/rules/` som de øvrige ALTINNAPP-sidene, med `weight` 90 og
91, og engelsk versjon merket `needstranslation`.

Byggekontroll: `hugo -D` bygger alle fire sidene. Den ene feilen i bygget er `auth-requirements.en.md`
som mangler på `master` fra før, og som bare rammer bygg med utkast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added English and Norwegian documentation for analysis rule ALTINNAPP0900, covering duplicate field identifiers, resulting build failures, and recommended corrections.
  * Added English and Norwegian documentation for analysis rule ALTINNAPP0901, covering references to undeclared data types, affected field values, likely causes, and remediation steps.
  * Documentation now clarifies rule categories, severity levels, and the distinction between permitted identifiers across different data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->