### PR TITLE
docs(v9): use expressions for conditional fields

### DIFF
--- a/content/altinn-studio/v9/develop-a-service/reference/configuration/stateless/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/configuration/stateless/_index.nb.md
@@ -265,7 +265,11 @@ Videre i eksempelet vil betegnelsen *bruker* være synonymt med en virksomhet re
         "textResourceBindings": {
           "title": "ErrorMessage"
         },
-        "hidden": ["notEquals", ["dataModel", "userAuthorized"], false],
+        "hidden": [
+          "or",
+          ["equals", ["dataModel", "userAuthorized"], true],
+          ["equals", ["dataModel", "userAuthorized"], null]
+        ],
         "required": false,
         "readOnly": true
       }
@@ -274,10 +278,10 @@ Videre i eksempelet vil betegnelsen *bruker* være synonymt med en virksomhet re
 
 3. **Vis eller skjul felter med uttrykk**
 
-    Komponentenes `hidden`-egenskap styrer hvilke felter brukeren ser. Uttrykkene i layouten leser `userAuthorized` fra datamodellen:
+    Komponentenes `hidden`-egenskap styrer hvilke felter brukeren ser. Feltet `userAuthorized` formidler resultatet av kontrollen som er beskrevet i steg 5. Feltet og uttrykkene styrer bare visningen og gir ikke i seg selv tilgang til tjenesten.
 
     - Søkefeltet og resultatfeltet skjules når `userAuthorized` er `false`.
-    - Feilmeldingen skjules så lenge `userAuthorized` ikke er `false`.
+    - Feilmeldingen skjules når `userAuthorized` er `true` eller ikke har fått en verdi.
 
     Dermed er søke- og resultatfeltene synlige som standard. Hvis autorisasjonen mislykkes, skjules disse feltene, og feilmeldingen vises. Se [dokumentasjonen for uttrykk]({{< relref "/altinn-studio/v9/develop-a-service/expressions" >}}) for flere eksempler.
 

--- a/content/altinn-studio/v9/develop-a-service/reference/configuration/stateless/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/reference/configuration/stateless/_index.nb.md
@@ -97,8 +97,6 @@ Eksempel app-struktur for en app som er satt opp på denne måten:
         │   layout-sets.json
         │
         └───stateless
-            |   RuleConfiguration.json
-            │   RuleHandler.js
             │   Settings.json
             │
             └───layouts
@@ -244,6 +242,7 @@ Videre i eksempelet vil betegnelsen *bruker* være synonymt med en virksomhet re
         "dataModelBindings": {
           "simpleBinding": "searchString"
         },
+        "hidden": ["equals", ["dataModel", "userAuthorized"], false],
         "required": false,
         "readOnly": false
       },
@@ -256,6 +255,7 @@ Videre i eksempelet vil betegnelsen *bruker* være synonymt med en virksomhet re
         "dataModelBindings": {
           "simpleBinding": "result"
         },
+        "hidden": ["equals", ["dataModel", "userAuthorized"], false],
         "required": false,
         "readOnly": true
       },
@@ -265,52 +265,21 @@ Videre i eksempelet vil betegnelsen *bruker* være synonymt med en virksomhet re
         "textResourceBindings": {
           "title": "ErrorMessage"
         },
+        "hidden": ["notEquals", ["dataModel", "userAuthorized"], false],
         "required": false,
         "readOnly": true
       }
     ]
     ```
 
-3. **Legg inn dynamikkregler for å vise/skjule felter**
+3. **Vis eller skjul felter med uttrykk**
 
-    Vi bruker dynamikkregler til å vise/skjule felter avhengig av om en bruker er autorisert eller ikke.
+    Komponentenes `hidden`-egenskap styrer hvilke felter brukeren ser. Uttrykkene i layouten leser `userAuthorized` fra datamodellen:
 
-    Det er lagt inn en dynamikkregel i `RuleHandler.js` som sjekker om et felt i datamodellen har verdien `false`. [Les mer om hvordan du konfigurerer dynamikkregler](/nb/altinn-studio/v9/develop-a-service/look-and-feel/dynamics/).
+    - Søkefeltet og resultatfeltet skjules når `userAuthorized` er `false`.
+    - Feilmeldingen skjules så lenge `userAuthorized` ikke er `false`.
 
-    I `RuleConfiguration.json` ser du hvordan regelen brukes. Hvis input-verdien fra datamodellen `userAuthorized` er false, vises errorBoks-komponenten, mens det motsatte skjer med søke- og resultatfeltene - disse skjules.
-
-    Standard oppførsel er det motsatte, altså at søk og resultat er synlig, mens error-feltet er skjult.
-
-    ```json
-    {
-      "data": {
-        "ruleConnection": {},
-        "conditionalRendering": {
-          "e2dd8ff0-f8f1-11eb-b2bc-5b40a942c260": {
-            "selectedFunction": "isFalse",
-            "inputParams": {
-              "value": "userAuthorized"
-            },
-            "selectedAction": "Show",
-            "selectedFields": {
-              "e2dd68e0-f8f1-11eb-b2bc-5b40a942c260": "errorBoks"
-            }
-          },
-          "e2dd8ff0-f8f1-11eb-b2bc-5b40a942c261": {
-            "selectedFunction": "isFalse",
-            "inputParams": {
-              "value": "userAuthorized"
-            },
-            "selectedAction": "Hide",
-            "selectedFields": {
-              "e2dd68e0-f8f1-11eb-b2bc-5b40a942c261": "sokeBoks",
-              "e2dd68e0-f8f1-11eb-b2bc-5b40a942c262": "resultatBoks"
-            }
-          }
-        }
-      }
-    }
-    ```
+    Dermed er søke- og resultatfeltene synlige som standard. Hvis autorisasjonen mislykkes, skjules disse feltene, og feilmeldingen vises. Se [dokumentasjonen for uttrykk]({{< relref "/altinn-studio/v9/develop-a-service/expressions" >}}) for flere eksempler.
 
 4. **Legg til tekstressurser**
 

--- a/content/altinn-studio/v9/parkinglot/third-party-auth/third-party-auth.nb.md
+++ b/content/altinn-studio/v9/parkinglot/third-party-auth/third-party-auth.nb.md
@@ -59,6 +59,7 @@ Videre i eksempelet vil betegnelsen *bruker* være synonymt med en virksomhet re
         "dataModelBindings": {
           "simpleBinding": "searchString"
         },
+        "hidden": ["equals", ["dataModel", "userAuthorized"], false],
         "required": false,
         "readOnly": false
       },
@@ -71,6 +72,7 @@ Videre i eksempelet vil betegnelsen *bruker* være synonymt med en virksomhet re
         "dataModelBindings": {
           "simpleBinding": "result"
         },
+        "hidden": ["equals", ["dataModel", "userAuthorized"], false],
         "required": false,
         "readOnly": true
       },
@@ -80,52 +82,21 @@ Videre i eksempelet vil betegnelsen *bruker* være synonymt med en virksomhet re
         "textResourceBindings": {
           "title": "ErrorMessage"
         },
+        "hidden": ["notEquals", ["dataModel", "userAuthorized"], false],
         "required": false,
         "readOnly": true
       }
     ]
     ```
 
-3. **Legg inn dynamikkregler for å vise/skjule felter**
+3. **Vis eller skjul felter med uttrykk**
 
-    Vi bruker dynamikkregler til å vise/skjule felter avhengig av om en bruker er autorisert eller ikke.
+    Komponentenes `hidden`-egenskap styrer hvilke felter brukeren ser. Uttrykkene i layouten leser `userAuthorized` fra datamodellen:
 
-    Det er lagt inn en dynamikkregel i `RuleHandler.js` som sjekker om et felt i datamodellen har verdien `false`. Konfigurasjon av regler er beskrevet nærmere [her](/nb/altinn-studio/v8/reference/logic/dynamic/#legg-tilrediger-funksjoner-for-beregninger-eller-visskjul).
+    - Søkefeltet og resultatfeltet skjules når `userAuthorized` er `false`.
+    - Feilmeldingen skjules så lenge `userAuthorized` ikke er `false`.
 
-    I `RuleConfiguration.json` ser du hvordan regelen brukes. Hvis inputverdien fra datamodellen `userAuthorized` er false, vises errorBoks-komponenten, mens det motsatte skjer med søke- og resultatfeltene - disse skjules.
-
-    Standard oppførsel er det motsatte, altså at søk og resultat er synlig, mens error-feltet er skjult.
-
-    ```json
-    {
-      "data": {
-        "ruleConnection": {},
-        "conditionalRendering": {
-          "e2dd8ff0-f8f1-11eb-b2bc-5b40a942c260": {
-            "selectedFunction": "isFalse",
-            "inputParams": {
-              "value": "userAuthorized"
-            },
-            "selectedAction": "Show",
-            "selectedFields": {
-              "e2dd68e0-f8f1-11eb-b2bc-5b40a942c260": "errorBoks"
-            }
-          },
-          "e2dd8ff0-f8f1-11eb-b2bc-5b40a942c261": {
-            "selectedFunction": "isFalse",
-            "inputParams": {
-              "value": "userAuthorized"
-            },
-            "selectedAction": "Hide",
-            "selectedFields": {
-              "e2dd68e0-f8f1-11eb-b2bc-5b40a942c261": "sokeBoks",
-              "e2dd68e0-f8f1-11eb-b2bc-5b40a942c262": "resultatBoks"
-            }
-          }
-        }
-      }
-    }
-    ```
+    Dermed er søke- og resultatfeltene synlige som standard. Hvis autorisasjonen mislykkes, skjules disse feltene, og feilmeldingen vises. Se [dokumentasjonen for uttrykk]({{< relref "/altinn-studio/v9/develop-a-service/expressions" >}}) for flere eksempler.
 
 4. **Legg til tekstressurser**
 

--- a/content/altinn-studio/v9/parkinglot/third-party-auth/third-party-auth.nb.md
+++ b/content/altinn-studio/v9/parkinglot/third-party-auth/third-party-auth.nb.md
@@ -82,7 +82,11 @@ Videre i eksempelet vil betegnelsen *bruker* være synonymt med en virksomhet re
         "textResourceBindings": {
           "title": "ErrorMessage"
         },
-        "hidden": ["notEquals", ["dataModel", "userAuthorized"], false],
+        "hidden": [
+          "or",
+          ["equals", ["dataModel", "userAuthorized"], true],
+          ["equals", ["dataModel", "userAuthorized"], null]
+        ],
         "required": false,
         "readOnly": true
       }
@@ -91,10 +95,10 @@ Videre i eksempelet vil betegnelsen *bruker* være synonymt med en virksomhet re
 
 3. **Vis eller skjul felter med uttrykk**
 
-    Komponentenes `hidden`-egenskap styrer hvilke felter brukeren ser. Uttrykkene i layouten leser `userAuthorized` fra datamodellen:
+    Komponentenes `hidden`-egenskap styrer hvilke felter brukeren ser. Feltet `userAuthorized` formidler resultatet av kontrollen som er beskrevet i steg 5. Feltet og uttrykkene styrer bare visningen og gir ikke i seg selv tilgang til tjenesten.
 
     - Søkefeltet og resultatfeltet skjules når `userAuthorized` er `false`.
-    - Feilmeldingen skjules så lenge `userAuthorized` ikke er `false`.
+    - Feilmeldingen skjules når `userAuthorized` er `true` eller ikke har fått en verdi.
 
     Dermed er søke- og resultatfeltene synlige som standard. Hvis autorisasjonen mislykkes, skjules disse feltene, og feilmeldingen vises. Se [dokumentasjonen for uttrykk]({{< relref "/altinn-studio/v9/develop-a-service/expressions" >}}) for flere eksempler.
 


### PR DESCRIPTION
## Summary

- replace retired RuleHandler.js and RuleConfiguration.json examples with hidden expressions
- place each expression directly on the affected layout component
- update both the stateless configuration guide and its third-party authorization source article

## Verification

- reviewed the complete changed articles using the requested writing-for-agents and Altinn documentation language guidance
- ran git diff --check
- confirmed that the retired rule configuration is no longer referenced in either article

Hugo validation was not run because Hugo is not installed in the local environment.

## Original implementation PRs

- [Altinn/altinn-studio#17160: Remove rule configuration from apps, backend, and frontend](https://github.com/Altinn/altinn-studio/pull/17160)
