### PR TITLE
docs(v9): remove frontend version overrides

### DIFF
--- a/content/altinn-studio/v9/manage-a-service/maintainance/dependencies/_index.en.md
+++ b/content/altinn-studio/v9/manage-a-service/maintainance/dependencies/_index.en.md
@@ -6,8 +6,8 @@ description: How to update dependencies in an app.
 toc: true
 ---
 
-The app is dependent on multiple external dependencies.
-This includes larger libraries with common functionality for all apps and reference to the apps frontend.
+The app depends on several external resources.
+These include shared libraries used by all apps and the Helm chart used for deployment.
 
 These dependencies are defined in different places in the app, and each dependency is references by a specific _version_.
 When fixes and improvements are made to the dependencies a new _version_ will be published.
@@ -78,45 +78,6 @@ Example.:
 
 {{</content-version-container>}}
 {{</content-version-selector>}}
-
-## App frontend
-
-App frontend is loaded at runtime, through a link to the javascript-file for app frontend.
-This javascript-file uses [Semantic Versioning](https://semver.org/):
-
-> Given a version number MAJOR.MINOR.PATCH, increment the:
-> 
-> MAJOR version when you make incompatible API changes,<br/>
-> MINOR version when you add functionality in a backwards compatible manner, and<br/>
-> PATCH version when you make backwards compatible bug fixes.
-> 
-> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
-
-The app references by default to a _major_ version of app frontend, e.g. version 1.x.y
-With the default setup all _minor_ and _patch_ version will be automatically pulled in.
-If a new _major_ version is published you need to update your app to pull this new version, watch out for [breaking changes](/en/community/changelog/app-frontend/))
-
-If you want to lock the frontend to a specific version of app frontend (e.g. 1.2.3) you specify this directly in the URL that points to app frontend.
-
-### Upgrade to new version / specific version
-The reference to app frontend is located in `App/views/Home/Index.cshtml`.
-
-You need to update two references:
-
-- Reference to altinn-app-frontend.**js**-file which contains the code for app frontend.
-  
-```html
-<script src="https://altinncdn.no/toolkits/altinn-app-frontend/<VERSIONNUMBER>/altinn-app-frontend.js"></script>
-```
-- Reference to altinn-app-frontend.**css** which contains the styling for app frontend.
-
-```html
-<script src="https://altinncdn.no/toolkits/altinn-app-frontend/<VERSIONNUMBER>/altinn-app-frontend.css"></script>
-```
-
-Search for the filename (`altinn-app-frontend.js` or `altinn-app-frontend.css`) and replace the version number (e.g. 1) with the desired version number (e.g. 2).
-
-_Reminder:_ If you depend on a _major_ version (e.g. 2), every _minor_ and _patch_ version of this _major_ release will be applied automatically. If a specific version is defined (e.g. 2.0.0) the application will fetch this version until the reference is updated and no fixes or improvements will be fetched.
 
 ## Deployment
 

--- a/content/altinn-studio/v9/manage-a-service/maintainance/dependencies/_index.nb.md
+++ b/content/altinn-studio/v9/manage-a-service/maintainance/dependencies/_index.nb.md
@@ -7,7 +7,7 @@ toc: true
 ---
 
 Appen er avhengig av flere ressurser som ligger utenfor selve appen.
-Dette inkluderer støttebiblioteker med felles funksjonalitet for alle apper og referanse til appen sin frontend.
+Dette inkluderer støttebiblioteker med felles funksjonalitet for alle apper og Helm-diagrammet som brukes ved utrulling.
 
 Disse avhengighetene er definert noen forskjellige steder i appen, og hver avhengighet refereres til med en spesifikk _versjon_.
 Når ressursene oppdateres, publiseres de på nytt som en ny _versjon_. En ny versjon kommer ofte med ny funksjonalitet eller forbedringer.
@@ -80,45 +80,6 @@ F.eks.:
 {{</content-version-container>}}
 {{</content-version-selector>}}
 
-
-## App frontend
-
-App frontend lastes inn av appen runtime, via en lenke til javascript-filen som er app frontend.
-Denne javascript-filen versjoneres ihht. [Semantic Versioning](https://semver.org/):
-
-> Given a version number MAJOR.MINOR.PATCH, increment the:
-> 
-> MAJOR version when you make incompatible API changes,<br/>
-> MINOR version when you add functionality in a backwards compatible manner, and<br/>
-> PATCH version when you make backwards compatible bug fixes.
-> 
-> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
-
-App'en refererer som standard til en _major_ versjon av app frontend, f.eks. versjon 1.x.y.
-Med mindre det kommer en ny _major_ versjon vil alle oppdateringer med ny _minor_ eller _patch_ versjoner komme med automatisk.
-Om det kommer en ny _major_ versjon må man eksplisitt oppdatere appen til å referere til denne.
-
-Dersom man ønsker å referere til en spesifikk versjon av app frontend (f.eks. 1.2.3) så kan dette spesifiseres direkte i url'en som peker på app frontend.
-
-### Oppgradere til nyeste versjon / spesifisere versjon
-Referansen til app frontend ligger i `App/views/Home/Index.cshtml`.
-
-Det er 2 referanser som må oppdateres:
-
-- Referansen til altinn-app-frontend.**js**-filen som er app frontend koden.
-  
-```html
-<script src="https://altinncdn.no/toolkits/altinn-app-frontend/<VERSJONSNUMMER>/altinn-app-frontend.js"></script>
-```
-- Referansen til altinn-app-frontend.**css** som inneholder styling for app frontend.
-
-```html
-<script src="https://altinncdn.no/toolkits/altinn-app-frontend/<VERSJONSNUMMER>/altinn-app-frontend.css"></script>
-```
-
-Søk etter filnavnet (`altinn-app-frontend.js` eller `altinn-app-frontend.css`) og erstatt versjonsnummeret (f.eks. 1) med ønsket versjonsnummer (f.eks. 2).
-
-_Husk:_ Dersom man setter kun _major versjon_ (f.eks. 2), så vil alle oppdateringer innenfor denne major versjoner (bugfix, ny funksjonalitet som ikke er breaking) komme med automatisk. Dersom man setter en _spesifikk versjon_ (f.eks. 2.0.0) så vil appen hente akkurat denne versjonen, helt til referansen evt. oppdateres til å bruke en annen versjon.
 
 ## Deployment
 

--- a/content/altinn-studio/v9/test-a-service/testing/local/debug/_index.nb.md
+++ b/content/altinn-studio/v9/test-a-service/testing/local/debug/_index.nb.md
@@ -54,13 +54,3 @@ Dette forutsetter at du allerede har startet appen.
    ![debug](debug4.png "Se på lokale verdier")
 
 [Les mer om feilsøking i Visual Studio Code i dokumentasjonen](https://code.visualstudio.com/docs/editor/debugging).
-
-## Endre frontend-versjon
-
-Hvis du har et lokalt utviklingsmiljø for [frontend-appen](https://github.com/Altinn/app-frontend-react/), eller hvis du ønsker å teste med en spesifikk versjon av frontend, kan dette gjøres ved å endre den kjørende frontend-versjonen fra lenken på forsiden av local.altinn.cloud:
-
-![use-diff-frontend-version](use-diff-frontend-version.png "Funksjonalitet for å endre frontend-versjon")
-
-{{% panel info %}}
-**MERK:** Dette virker bare hvis du har beholdt standardstien for lasting av frontend-appens JavaScript-fil i `Index.cshtml`-filen i appen du jobber med. Hvis du har endret til å bruke en annen sti, vil dette overstyre eventuelle endringer du gjør via local.altinn.cloud.
-{{% /panel %}}


### PR DESCRIPTION
## Summary

- remove instructions for changing the app frontend version through local.altinn.cloud
- remove instructions for pinning or upgrading app frontend through Index.cshtml
- describe only dependencies that app developers manage independently

Frontend and backend versions are coupled in v9. The local frontend selector is a platform-development tool and is not meaningful configuration for app developers.

## Verification

- reviewed the complete changed articles using the requested writing-for-agents and Altinn documentation language guidance
- searched the v9 documentation for the removed filename and version-override instructions
- ran git diff --check

Hugo validation was not run because Hugo is not installed in the local environment.

## Original implementation PRs

- [Altinn/altinn-studio#17488: Generate HTML from assets.json with custom CSS and JavaScript support](https://github.com/Altinn/altinn-studio/pull/17488)
