### PR TITLE
docs(v9): explain custom CSS and JavaScript

### DIFF
--- a/content/altinn-studio/v9/develop-a-service/look-and-feel/custom-css-js/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/look-and-feel/custom-css-js/_index.nb.md
@@ -1,0 +1,77 @@
+---
+title: Egendefinert CSS og JavaScript
+linktitle: Egendefinert CSS og JavaScript
+description: Slik legger du til egne stilark og skript i en app.
+weight: 90
+draft: true
+---
+
+Du kan legge til egne CSS- og JavaScript-filer uten å endre siden som laster appen. Appen finner filene ved oppstart og legger dem inn etter appens egne ressurser.
+
+{{% notice warning %}}
+Egendefinert kode vedlikeholdes av tjenesteeier. Ikke baser koden på interne HTML-elementer, CSS-klasser eller JavaScript-funksjoner i app-frontenden. Disse kan endres uten å være en del av den offentlige kontrakten.
+{{% /notice %}}
+
+## Legg til lokale filer
+
+Opprett én eller begge av disse mappene i appen:
+
+```text
+App/
+└── wwwroot/
+    ├── custom-css/
+    │   └── custom.css
+    └── custom-js/
+        └── custom.js
+```
+
+- Legg stilark i `App/wwwroot/custom-css`.
+- Legg skript i `App/wwwroot/custom-js`.
+
+Alle filene i mappene lastes automatisk. Du trenger ikke å registrere dem i en konfigurasjonsfil. Start appen på nytt etter at du har lagt til, fjernet eller gitt nytt navn til en fil, slik at appen leser fillisten på nytt.
+
+Stilarkene lastes etter appens standardstilark. Skriptene lastes etter app-frontenden. Hvis du legger til flere filer, bør hver fil ha ett tydelig ansvar og ikke være avhengig av en bestemt innlastingsrekkefølge.
+
+## Last inn ressurser fra eksterne adresser
+
+Du kan registrere eksterne stilark og skript i `App/config/assets.json`. Bruk bare ressurser fra leverandører du stoler på.
+
+{{< code-title >}}
+App/config/assets.json
+{{< /code-title >}}
+
+```json
+{
+  "stylesheets": [
+    {
+      "url": "https://example.com/styles.css",
+      "media": "screen",
+      "integrity": "sha384-...",
+      "crossorigin": true
+    }
+  ],
+  "scripts": [
+    {
+      "url": "https://example.com/script.js",
+      "type": "module",
+      "integrity": "sha384-...",
+      "crossorigin": true
+    }
+  ]
+}
+```
+
+Begge listene er valgfrie. Et stilark støtter egenskapene `url`, `media`, `integrity` og `crossorigin`. Et skript støtter `url`, `type`, `async`, `defer`, `nomodule`, `integrity` og `crossorigin`. Den eneste støttede verdien for `type` er `module`.
+
+Bruk [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (`integrity`) når leverandøren tilbyr en kontrollsum. Da kontrollerer nettleseren at ressursen ikke er endret. Sett også `crossorigin` til `true` når leverandøren krever det for integritetskontrollen.
+
+Start appen på nytt etter at du har endret `assets.json`.
+
+## Test tilpasningene
+
+Test tilpasningene lokalt og i alle miljøer der appen skal kjøre. Kontroller særlig at:
+
+- skjemaet fortsatt kan brukes med tastatur og skjermleser
+- tekst, knapper og feilmeldinger er synlige ved ulike skjermstørrelser
+- skriptfeil ikke hindrer brukeren i å fylle ut eller sende inn skjemaet
+- eksterne ressurser er tilgjengelige og tillatt av sikkerhetsinnstillingene i miljøet

--- a/content/altinn-studio/v9/develop-a-service/look-and-feel/custom-css-js/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/look-and-feel/custom-css-js/_index.nb.md
@@ -6,10 +6,10 @@ weight: 90
 draft: true
 ---
 
-Du kan legge til egne CSS- og JavaScript-filer uten å endre siden som laster appen. Appen finner filene ved oppstart og legger dem inn etter appens egne ressurser.
+Du kan legge til egne CSS- og JavaScript-filer i appen. Appen finner filene ved oppstart og legger dem inn etter appens egne ressurser.
 
 {{% notice warning %}}
-Egendefinert kode vedlikeholdes av tjenesteeier. Ikke baser koden på interne HTML-elementer, CSS-klasser eller JavaScript-funksjoner i app-frontenden. Disse kan endres uten å være en del av den offentlige kontrakten.
+Unngå å basere tilpasningene på HTML-elementer, CSS-klasser eller JavaScript-funksjoner i app-frontenden. Disse kan endres mellom versjoner.
 {{% /notice %}}
 
 ## Legg til lokale filer
@@ -61,7 +61,7 @@ App/config/assets.json
 }
 ```
 
-Begge listene er valgfrie. Et stilark støtter egenskapene `url`, `media`, `integrity` og `crossorigin`. Et skript støtter `url`, `type`, `async`, `defer`, `nomodule`, `integrity` og `crossorigin`. Den eneste støttede verdien for `type` er `module`.
+Begge listene er valgfrie. For hvert stilark eller skript er bare `url` påkrevd. Et stilark kan i tillegg ha egenskapene `media`, `integrity` og `crossorigin`. Et skript kan ha `type`, `async`, `defer`, `nomodule`, `integrity` og `crossorigin`. Den eneste støttede verdien for `type` er `module`.
 
 Bruk [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (`integrity`) når leverandøren tilbyr en kontrollsum. Da kontrollerer nettleseren at ressursen ikke er endret. Sett også `crossorigin` til `true` når leverandøren krever det for integritetskontrollen.
 


### PR DESCRIPTION
## Summary

- add a v9 guide for local CSS and JavaScript files
- document external browser assets configured through App/config/assets.json
- explain loading order, restart requirements, integrity metadata, and testing responsibilities

## Verification

- cross-checked paths, supported properties, loading order, and caching behavior against IndexPageGenerator and BrowserAssetsConfiguration in altinn-studio
- reviewed the complete article using the requested writing-for-agents and Altinn documentation language guidance
- ran git diff --check

Hugo validation was not run because Hugo is not installed in the local environment.

## Original implementation PRs

- [Altinn/altinn-studio#17488: Generate HTML from assets.json with custom CSS and JavaScript support](https://github.com/Altinn/altinn-studio/pull/17488)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Norwegian guide for using custom CSS and JavaScript, including v8-to-v9 migration, asset management, security considerations, restart requirements, and testing guidance.
  * Documented the new locations for custom CSS and JavaScript when upgrading applications from v8 to v9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->