### PR TITLE
docs(v9): remove obsolete Studio PDF preview

### DIFF
--- a/content/altinn-studio/v9/develop-a-service/process/payment/studio/configure-layouts.en.md
+++ b/content/altinn-studio/v9/develop-a-service/process/payment/studio/configure-layouts.en.md
@@ -47,5 +47,3 @@ This step is optional. The default is to use the same setup as the layout from t
 2. Click "Add new page".
 3. In the configuration panel for the page, open "PDF" and click on "Convert page to PDF".
 4. Add the "Payment" component, and any other of the available components to the PDF layout.
-5. To preview the final PDF, click the developer tool button at the botton right-hand side of the preview column ![Developer tools](/en/altinn-studio/v8/guides/development/payment/devtools.png)
-   - Click the "Preview PDF" button.

--- a/content/altinn-studio/v9/develop-a-service/process/payment/studio/configure-layouts.en.md
+++ b/content/altinn-studio/v9/develop-a-service/process/payment/studio/configure-layouts.en.md
@@ -47,3 +47,4 @@ This step is optional. The default is to use the same setup as the layout from t
 2. Click "Add new page".
 3. In the configuration panel for the page, open "PDF" and click on "Convert page to PDF".
 4. Add the "Payment" component, and any other of the available components to the PDF layout.
+5. To preview the PDF, open the developer tools at the bottom right of the preview ![Developer tools](../devtools.png), then click "Generer PDF".

--- a/content/altinn-studio/v9/develop-a-service/process/payment/studio/configure-layouts.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/process/payment/studio/configure-layouts.nb.md
@@ -41,5 +41,3 @@ Dette steget er valgfritt. Hvis du ikke gjennomfører dette steget, brukes oppse
 2. Klikk på **Legg til ny side**.
 3. I konfigurasjonspanelet for siden åpner du **PDF** og klikker på **Gjør om siden til PDF**.
 4. Legg til komponenten **Betaling**, og eventuelt andre tekster og komponenter du ønsker på PDF-siden.
-5. Forhåndsvis PDF-visning ved å klikke på **utviklerverktøy**-knappen nederst til høyre i forhåndsvisningen ![Utviklerverktøy](./devtools.png)
-   - Klikk på knappen **Forhåndsvis PDF**.

--- a/content/altinn-studio/v9/develop-a-service/process/payment/studio/configure-layouts.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/process/payment/studio/configure-layouts.nb.md
@@ -41,3 +41,4 @@ Dette steget er valgfritt. Hvis du ikke gjennomfører dette steget, brukes oppse
 2. Klikk på **Legg til ny side**.
 3. I konfigurasjonspanelet for siden åpner du **PDF** og klikker på **Gjør om siden til PDF**.
 4. Legg til komponenten **Betaling**, og eventuelt andre tekster og komponenter du ønsker på PDF-siden.
+5. Forhåndsvis PDF-en ved å åpne **utviklerverktøy** nederst til høyre i forhåndsvisningen ![Utviklerverktøy](../devtools.png), og klikk deretter på **Generer PDF**.


### PR DESCRIPTION
## Summary

- update the payment layout guide to use the remaining developer-tools PDF action
- replace the retired preview button label with Generer PDF
- keep the valid receipt-layout and PDF preview instructions

## Verification

- cross-checked the remaining label against PDFGeneratorPreviewSection in altinn-studio
- reviewed both complete changed articles using the requested writing-for-agents and Altinn documentation language guidance
- ran git diff --check

Hugo validation was not run because Hugo is not installed in the local environment.

## Original implementation PRs

- [Altinn/altinn-studio#19820: Remove the obsolete Studio PDF preview button](https://github.com/Altinn/altinn-studio/pull/19820)
