### PR TITLE
docs(v9): explain error summary timing

### DIFF
--- a/content/altinn-studio/v9/develop-a-service/data/validation/_index.nb.md
+++ b/content/altinn-studio/v9/develop-a-service/data/validation/_index.nb.md
@@ -11,6 +11,14 @@ Du kan kjøre valideringer enten på klientsiden (i nettleseren) eller på serve
 
 Du kan også sette opp validering til å kjøre ved sidebytte.
 
+## Når vises feiloppsummeringen?
+
+Feilmeldinger kan vises ved hvert felt mens brukeren fyller ut skjemaet. Feiloppsummeringen vises derimot ikke bare fordi et felt har en synlig feil.
+
+Oppsummeringen vises først når brukeren prøver å gå til en annen side eller sende inn skjemaet, og valideringsfeil stopper handlingen. Hvilke valideringer som kjører ved sidebytte, styres blant annet av `validateOnNext` og `validateOnPrevious` på komponenten [`NavigationButtons`]({{< relref "../../look-and-feel/components/NavigationButtons" >}}).
+
+Når brukeren retter feilene, fjernes de fortløpende fra oppsummeringen. Oppsummeringen forsvinner når ingen feil gjenstår. Hvis en feil oppstår på nytt senere, vises den fortsatt ved feltet i henhold til komponentens `showValidations`, men feiloppsummeringen vises ikke på nytt før brukeren gjør et nytt forsøk på å bytte side eller sende inn.
+
 ## Klientside-validering
 
 Klientside-validering kjører i nettleseren FØR data sendes til serveren for lagring. Dette gjør det mulig å gi raske tilbakemeldinger til brukeren underveis i utfyllingen.

--- a/content/altinn-studio/v9/plan-a-service/tone-of-voice/error-messages.nb.md
+++ b/content/altinn-studio/v9/plan-a-service/tone-of-voice/error-messages.nb.md
@@ -73,7 +73,7 @@ Gi gjerne brukeren to valgmuligheter:
 
 ## Oppsummerende feilmeldinger
 
-Hvis et skjema har flere feil, vis en oppsummering med lenker til hvert felt som har feil. Dette gjør det lettere for brukeren å se hva som må rettes.
+Når én eller flere feil hindrer brukeren i å gå videre eller sende inn skjemaet, vises en oppsummering med lenker til feltene som har feil. Dette gjør det lettere for brukeren å se hva som må rettes.
 
 ### Plassering av oppsummeringen
 


### PR DESCRIPTION
## Summary

- explain that inline validation does not display the global error summary by itself
- document that the summary appears after a blocked page change or submission
- describe how corrected errors are removed and when the summary can reappear
- align the error-message writing guidance with the runtime behavior

## Verification

- cross-checked the documented behavior against ErrorReport, Form, and validation-hook tests in altinn-studio
- reviewed both complete changed articles using the requested writing-for-agents and Altinn documentation language guidance
- ran git diff --check

Hugo validation was not run because Hugo is not installed in the local environment.

## Original implementation PRs

- [Altinn/altinn-studio#19940: Change when the global error summary is shown](https://github.com/Altinn/altinn-studio/pull/19940)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining when validation error summaries appear during form completion, navigation, and submission.
  * Clarified that corrected errors are removed from the summary and recurring errors remain visible at the relevant field.
  * Updated error-message guidance to explain that linked summaries appear when errors prevent users from continuing or submitting a form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->