### PR TITLE
docs(v9): link workflow engine control panel

### DIFF
--- a/content/altinn-studio/v9/getting-started/development/localtest/local-dev/_index.en.md
+++ b/content/altinn-studio/v9/getting-started/development/localtest/local-dev/_index.en.md
@@ -114,6 +114,14 @@ In Altinn Studio, you must synchronise changes in the same way as with local cha
 {{% insert "content/altinn-studio/shared/studioctl/local-test-workflow.en.md" "/en/altinn-studio/v9/develop-a-service/reference/data/data-modeling/" "/en/altinn-studio/v9/test-a-service/testing/local/testusers/" %}}
 {{% insert "content/altinn-studio/shared/studioctl/useful-commands.en.md" %}}
 
+### Inspect processing in the workflow engine
+
+The workflow engine runs process steps asynchronously in v9. During local testing, use its control panel to see whether a workflow is waiting, running, completed, or failed.
+
+Open the localtest front page and select **Workflow engine** in the navigation. You can also open the control panel directly at [workflow-engine.local.altinn.cloud:8000](http://workflow-engine.local.altinn.cloud:8000/).
+
+The **Live** tab shows scheduled, active, and recently finished workflows. Use the **Query** tab to search older workflows or filter by status and time. The control panel is available while localtest is running.
+
 ### Preview changes in real-time
 
 - If you change JSON files, simply reload the page.

--- a/content/altinn-studio/v9/getting-started/development/localtest/local-dev/_index.nb.md
+++ b/content/altinn-studio/v9/getting-started/development/localtest/local-dev/_index.nb.md
@@ -122,6 +122,14 @@ I Altinn Studio må du synkronisere endringer på samme vis som ved lokale endri
 {{% insert "content/altinn-studio/shared/studioctl/local-test-workflow.nb.md" "/nb/altinn-studio/v9/develop-a-service/reference/data/data-modeling/" "/nb/altinn-studio/v9/test-a-service/testing/local/testusers/" %}}
 {{% insert "content/altinn-studio/shared/studioctl/useful-commands.nb.md" %}}
 
+### Følg prosessen i prosessmotoren
+
+Prosessmotoren utfører prosessteg asynkront i v9. Når du tester appen lokalt, kan du bruke kontrollpanelet til å se om en arbeidsflyt venter, kjører, er fullført eller har feilet.
+
+Åpne forsiden til localtest og velg **Workflow engine** i navigasjonen. Du kan også åpne kontrollpanelet direkte på [workflow-engine.local.altinn.cloud:8000](http://workflow-engine.local.altinn.cloud:8000/).
+
+Fanen **Live** viser planlagte, aktive og nylig avsluttede arbeidsflyter. Bruk fanen **Query** hvis du vil søke i eldre arbeidsflyter eller avgrense listen etter status og tidspunkt. Kontrollpanelet er tilgjengelig så lenge den lokale testplattformen kjører.
+
 ### Se endringer fortløpende
 
 - Hvis du endrer JSON-filer, holder det å laste inn siden på nytt.


### PR DESCRIPTION
## Summary

- link the local workflow-engine control panel from the v9 local-development guide
- explain what the Live and Query tabs are useful for during app testing
- add matching Norwegian and English guidance

## Verification

- cross-checked the control-panel URL and localtest navigation label against the altinn-studio implementation
- cross-checked the dashboard descriptions against its functional specification
- reviewed both complete changed articles using the requested writing-for-agents and Altinn documentation language guidance
- ran git diff --check

Hugo validation was not run because Hugo is not installed in the local environment.

## Original implementation PRs

- [Altinn/altinn-studio#20243: Add a local workflow-engine control panel](https://github.com/Altinn/altinn-studio/pull/20243)
